### PR TITLE
fix: ecosystem audit — correct docs, NATS schema, justfile recipes

### DIFF
--- a/docs/adr/005-nats-subject-schema.md
+++ b/docs/adr/005-nats-subject-schema.md
@@ -1,0 +1,73 @@
+# ADR 005: NATS Subject Schema
+
+**Status:** Accepted
+
+**Supersedes:** Subject examples in ADR 002
+
+---
+
+## Context
+
+ADR 002 introduced NATS JetStream as the event bridge between ai-maestro webhooks and the rest of the HomericIntelligence ecosystem. The examples in ADR 002 used placeholder subjects (`maestro.agent.started`, `maestro.task.completed`) that were never implemented. The actual subject schema, designed and implemented in ProjectHermes, uses a hierarchical `hi.*` prefix with structured segments for routing and filtering.
+
+This ADR documents the implemented subject schema as the authoritative reference.
+
+## Decision
+
+All NATS subjects in the HomericIntelligence ecosystem follow this schema:
+
+### Agent Events
+
+```
+hi.agents.{host}.{name}.{verb}
+```
+
+- **host**: The ai-maestro hostId (e.g., `hermes`, `localhost`), slugified
+- **name**: The agent name, slugified
+- **verb**: One of `created`, `updated`, `deleted`
+
+Examples:
+- `hi.agents.hermes.code-reviewer.created`
+- `hi.agents.localhost.my-agent.updated`
+
+### Task Events
+
+```
+hi.tasks.{team_id}.{task_id}.{verb}
+```
+
+- **team_id**: The ai-maestro team ID
+- **task_id**: The ai-maestro task ID
+- **verb**: One of `updated`, `completed`, `failed`
+
+Examples:
+- `hi.tasks.team-42.task-7.updated`
+- `hi.tasks.team-42.task-7.completed`
+
+### JetStream Streams
+
+| Stream Name | Subjects | Retention |
+|---|---|---|
+| `homeric-agents` | `hi.agents.>` | Limits-based (default) |
+| `homeric-tasks` | `hi.tasks.>` | Limits-based (default) |
+
+Streams are created by ProjectHermes on startup if they do not already exist.
+
+### Durable Consumers
+
+| Consumer | Stream | Filter Subject | Service |
+|---|---|---|---|
+| `keystone-dag` | `homeric-tasks` | `hi.tasks.>` | ProjectKeystone |
+
+Additional durable consumers should be registered here as services are added.
+
+### Slugification
+
+All dynamic segments (host, name) are slugified by ProjectHermes: spaces become hyphens, dots become hyphens, all lowercase. This ensures subjects are valid NATS tokens.
+
+## Consequences
+
+- All subscribers must use the `hi.*` prefix, not the `maestro.*` prefix shown in ADR 002 examples.
+- Subscribers wanting all events for a category should use `>` wildcard: `hi.agents.>`, `hi.tasks.>`.
+- Subscribers wanting events for a specific entity can filter: `hi.tasks.team-42.>`.
+- New event verbs can be added without changing stream configuration.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -42,11 +42,11 @@ Additional repos cover supporting concerns:
 
 | Repo | Concern |
 |---|---|
-| ProjectKeystone | Secrets and credential management; injects secrets into ai-maestro agent configs |
+| ProjectKeystone | Automated task DAG execution; watches NATS task events, advances dependency graphs via ai-maestro REST API |
 | ProjectProteus | CI/CD pipelines; builds AchaeanFleet images, runs Myrmidons apply on merge |
 | ProjectOdyssey | Research sandbox; experimental agents not yet promoted to production |
 | ProjectScylla | Chaos/resilience testing; calls ai-maestro API to inject failures |
-| ProjectHephaestus | Shared libraries and SDK; imported by other repos, not deployed standalone |
+| ProjectHephaestus | Shared utilities (changelog, system-info, markdown tools); not yet imported as a dependency by other repos |
 
 ---
 
@@ -62,7 +62,8 @@ Additional repos cover supporting concerns:
               ┌──────────────────────┼──────────────▼──────────────────────────┐
               │                      │         ProjectHermes                   │
               │                      │  webhook receiver → NATS JetStream      │
-              │                      │  subjects: maestro.agent.* maestro.task.*│
+              │                      │  subjects: hi.agents.{host}.{name}.{verb}│
+              │                      │           hi.tasks.{team}.{task}.{verb} │
               │                      └────────────┬────────────────────────────┘
               │                                   │ NATS pub/sub
               │            ┌──────────────────────┼──────────────────────┐
@@ -86,13 +87,13 @@ Additional repos cover supporting concerns:
               │
               ▼
         ProjectKeystone
-        (secrets injection
-         into agent configs)
+        (DAG advancement
+         via REST + NATS)
 
   ProjectMnemosyne ──────► AchaeanFleet (image templates)
   (agent marketplace)  └──► Myrmidons (YAML manifest templates)
 
-  ProjectHephaestus ─────► all repos (shared SDK / libraries)
+  ProjectHephaestus ─────► available for future shared code (e.g., maestro-client)
   ProjectOdyssey    ─────► research sandbox (promotes → AchaeanFleet)
 ```
 
@@ -108,9 +109,9 @@ Additional repos cover supporting concerns:
 | ProjectArgus | infrastructure | Observability and alerting | Scrapes metrics endpoints | Grafana + Prometheus stack |
 | Myrmidons | provisioning | Declarative desired-state (GitOps) | REST CRUD on `/agents`, `/tasks` | `just apply` reconciles YAML → live state |
 | ProjectTelemachy | provisioning | Multi-step workflow orchestration | Chains `/tasks` calls | Workflow definitions as YAML |
-| ProjectKeystone | provisioning | Secrets and credential management | Injects into agent config at apply time | Vault or SOPS backend |
+| ProjectKeystone | provisioning | Automated task DAG execution | Watches NATS task events; advances via REST `/tasks` | JetStream durable consumer |
 | ProjectProteus | ci-cd | Automated build and deploy pipelines | Triggers Myrmidons apply on merge | Builds AchaeanFleet images |
 | ProjectMnemosyne | shared | Agent template marketplace / registry | Consumed by AchaeanFleet + Myrmidons | `marketplace.json` catalog |
-| ProjectHephaestus | shared | Shared SDK and utility libraries | n/a (library only) | Imported by all other repos |
+| ProjectHephaestus | shared | Shared utilities and tooling | n/a (library only) | Not yet imported by other repos |
 | ProjectOdyssey | research | Experimental agent research sandbox | Full REST API access | Promotes to AchaeanFleet when stable |
 | ProjectScylla | research | Chaos and resilience testing | Calls `/agents` to inject failures | Uses NATS events from ProjectHermes |

--- a/docs/nats-subjects.md
+++ b/docs/nats-subjects.md
@@ -1,0 +1,49 @@
+# NATS Subject Schema
+
+Central reference for the HomericIntelligence NATS event bus. See [ADR 005](adr/005-nats-subject-schema.md) for decision context.
+
+## Subject Patterns
+
+| Pattern | Published By | Consumed By | Description |
+|---|---|---|---|
+| `hi.agents.{host}.{name}.created` | Hermes | Argus, Telemachy | Agent registered |
+| `hi.agents.{host}.{name}.updated` | Hermes | Argus | Agent state changed |
+| `hi.agents.{host}.{name}.deleted` | Hermes | Argus, Telemachy | Agent removed |
+| `hi.tasks.{team_id}.{task_id}.updated` | Hermes | Keystone, Argus | Task status changed |
+| `hi.tasks.{team_id}.{task_id}.completed` | Hermes | Keystone, Argus | Task completed |
+| `hi.tasks.{team_id}.{task_id}.failed` | Hermes | Keystone, Argus | Task failed |
+
+## JetStream Streams
+
+| Stream | Subjects | Created By |
+|---|---|---|
+| `homeric-agents` | `hi.agents.>` | Hermes (on startup) |
+| `homeric-tasks` | `hi.tasks.>` | Hermes (on startup) |
+
+## Durable Consumers
+
+| Consumer Name | Stream | Service | Purpose |
+|---|---|---|---|
+| `keystone-dag` | `homeric-tasks` | ProjectKeystone | DAG advancement on task completion |
+
+## Subscription Examples
+
+```python
+# Subscribe to all task events (wildcard)
+await js.subscribe("hi.tasks.>", durable="my-consumer", cb=handler)
+
+# Subscribe to events for a specific team
+await js.subscribe("hi.tasks.team-42.>", cb=handler)
+
+# Subscribe to only completions across all teams
+await js.subscribe("hi.tasks.*.*.completed", cb=handler)
+```
+
+## Task Status Lifecycle
+
+```
+pending -> in_progress -> review -> completed
+                                 -> failed
+```
+
+Keystone advances DAGs when it sees `completed` (either as the subject verb or in the payload status field).

--- a/justfile
+++ b/justfile
@@ -56,9 +56,29 @@ argus-start:
     cd infrastructure/ProjectArgus && just start
 
 # ===========================================================================
+# Provisioning Services
+# ===========================================================================
+
+# Start ProjectKeystone DAG executor daemon
+keystone-start:
+    cd provisioning/ProjectKeystone && just start
+
+# Print ProjectKeystone DAG status across all teams
+keystone-status:
+    cd provisioning/ProjectKeystone && just status
+
+# ===========================================================================
 # Workflows
 # ===========================================================================
 
 # Run a named workflow via ProjectTelemachy
 telemachy-run WORKFLOW:
     cd provisioning/ProjectTelemachy && just run WORKFLOW={{ WORKFLOW }}
+
+# ===========================================================================
+# Research
+# ===========================================================================
+
+# Run ProjectScylla tests
+scylla-test:
+    cd research/ProjectScylla && just test


### PR DESCRIPTION
## Summary
- **C4**: Rewrite Keystone description from "secrets management" to "DAG execution" in architecture.md (3 locations: concern table, integration diagram, component table)
- **I5**: Fix NATS subject examples from `maestro.*` to `hi.*` prefix in integration diagram
- **I7**: Update Hephaestus from "imported by all repos" to "not yet imported"
- **I5**: Create ADR 005 documenting actual NATS subject schema (supersedes ADR 002 examples)
- **M4**: Create `docs/nats-subjects.md` as central reference for subjects, streams, and consumers
- **M5**: Add `keystone-start`, `keystone-status`, and `scylla-test` recipes to justfile

## Test plan
- [ ] Review architecture.md against actual repo code for accuracy
- [ ] Verify ADR 005 subject schema matches ProjectHermes publisher.py
- [ ] Verify justfile recipes point to correct submodule paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)