### PR TITLE
docs(architecture): Fix ProjectScylla description

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -45,7 +45,7 @@ Additional repos cover supporting concerns:
 | ProjectKeystone | Automated task DAG execution; watches NATS task events, advances dependency graphs via ai-maestro REST API |
 | ProjectProteus | CI/CD pipelines; builds AchaeanFleet images, runs Myrmidons apply on merge |
 | ProjectOdyssey | Research sandbox; experimental agents not yet promoted to production |
-| ProjectScylla | Chaos/resilience testing; calls ai-maestro API to inject failures |
+| ProjectScylla | AI agent ablation benchmarking; evaluates agent architectures across tiered configurations (T0–T6) |
 | ProjectHephaestus | Shared utilities (changelog, system-info, markdown tools); not yet imported as a dependency by other repos |
 
 ---
@@ -70,8 +70,8 @@ Additional repos cover supporting concerns:
               │            │                      │                      │
               ▼            ▼                      ▼                      ▼
         Myrmidons     ProjectArgus          ProjectTelemachy        ProjectScylla
-        (apply YAML   (metrics/alerts       (workflow engine        (chaos inject
-         to /agents)   Grafana dashboards)   chains /tasks)          via /agents)
+        (apply YAML   (metrics/alerts       (workflow engine        (ablation
+         to /agents)   Grafana dashboards)   chains /tasks)          benchmarking)
               │
               ▼
            Nomad cluster  ◄── configs/nomad/client.hcl + server.hcl
@@ -114,4 +114,4 @@ Additional repos cover supporting concerns:
 | ProjectMnemosyne | shared | Agent template marketplace / registry | Consumed by AchaeanFleet + Myrmidons | `marketplace.json` catalog |
 | ProjectHephaestus | shared | Shared utilities and tooling | n/a (library only) | Not yet imported by other repos |
 | ProjectOdyssey | research | Experimental agent research sandbox | Full REST API access | Promotes to AchaeanFleet when stable |
-| ProjectScylla | research | Chaos and resilience testing | Calls `/agents` to inject failures | Uses NATS events from ProjectHermes |
+| ProjectScylla | research | AI agent ablation benchmarking | Standalone evaluation framework | Measures agent performance across T0–T6 tiers |


### PR DESCRIPTION
## Summary
- Update ProjectScylla description from "Chaos/resilience testing" to "AI agent ablation benchmarking"
- Remove incorrect references to ai-maestro fault injection and NATS event consumption
- Fix all three occurrences: summary table, ASCII diagram, and component table
- Align description with actual implementation (verified: 0 references to ai-maestro/NATS/chaos across 131 source files in ProjectScylla)

Closes HomericIntelligence/ProjectScylla#1522
See also: #40

## Test plan
- [x] Verified ProjectScylla has zero references to ai-maestro, NATS, fault injection, or chaos engineering
- [x] Updated description matches ProjectScylla's CLAUDE.md Project Overview
- [x] All three occurrences in architecture.md corrected
- [x] ADR 002 left unchanged (append-only policy per Odysseus CLAUDE.md)
- [ ] Cross-reference with ProjectScylla's tier table (T0–T6, 120 sub-tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)