### PR TITLE
docs: add architectural analysis reports for Ruflo and ai-maestro

### DIFF
--- a/docs/odysseus-ai-maestro-analysis.md
+++ b/docs/odysseus-ai-maestro-analysis.md
@@ -1,0 +1,924 @@
+# Architectural Analysis: HomericIntelligence/Odysseus and ai-maestro
+
+**Date:** 2026-03-28
+**Repositories:**
+- Odysseus: `HomericIntelligence/Odysseus` (`/home/mvillmow/.agent-brain/Odysseus`)
+- ai-maestro: `23blocks-OS/ai-maestro` v0.26.5 (`/home/mvillmow/ai-maestro`)
+
+---
+
+## 1. Executive Summary
+
+ai-maestro is far richer than Odysseus's documentation implies. Odysseus treats ai-maestro as a simple REST platform with six endpoints (`/agents`, `/tasks`, `/messages`, `/memory`, `/docker/create`, `/host-sync`). In reality, ai-maestro v0.26.5 exposes **~100 REST API routes**, a **WebSocket layer** (terminal streaming, real-time status, AMP messaging), an **embedded CozoDB database** per agent with vector embeddings and semantic search, a **cerebellum subsystem** (memory consolidation, voice, terminal buffering), a **code graph** engine (ts-morph + Cytoscape.js), a **full web dashboard** (Next.js 14 + xterm.js), and a **plugin/skills system** with a marketplace.
+
+The HomericIntelligence ecosystem is using approximately **10% of ai-maestro's API surface**. This analysis maps the full capability set, identifies the integration gaps, and proposes how the ecosystem can leverage the 90% it currently ignores — particularly ai-maestro's built-in memory, search, teams/tasks, agent identity (AID), and skills systems.
+
+---
+
+## 2. ai-maestro: What It Actually Is
+
+### 2.1 Architecture Overview
+
+ai-maestro is a **web dashboard for orchestrating AI coding agents** running in tmux sessions. It is not a minimal REST API — it is a full application:
+
+```
+┌─────────────────────────────────────────────────────────┐
+│                    ai-maestro v0.26.5                    │
+├─────────────────────────────────────────────────────────┤
+│  Frontend: Next.js 14 + React 18 + xterm.js + Tailwind │
+│  ├── Agent dashboard (virtual tabs, instant switching)  │
+│  ├── Terminal streaming (WebGL renderer, Unicode 11)    │
+│  ├── Kanban board (5-column, drag-and-drop)             │
+│  ├── Team meetings (split-pane war rooms)               │
+│  ├── Code graph (Cytoscape.js + dagre layout)           │
+│  └── Agent playback (time-travel through sessions)      │
+├─────────────────────────────────────────────────────────┤
+│  Backend: Custom server.mjs (Node.js HTTP + WebSocket)  │
+│  ├── ~100 REST API routes (Next.js App Router)          │
+│  ├── Headless mode (regex router, no Next.js)           │
+│  ├── 4 WebSocket endpoints (/term, /status, /v1/ws,    │
+│  │   /companion-ws)                                     │
+│  ├── 24 service files (business logic layer)            │
+│  └── PM2 process management                             │
+├─────────────────────────────────────────────────────────┤
+│  Data: CozoDB (embedded Datalog + SQLite)               │
+│  ├── Per-agent database (~/.aimaestro/agents/{id}/)     │
+│  ├── Vector embeddings (HuggingFace Transformers+ONNX)  │
+│  ├── Hybrid search (semantic + BM25 + fusion)           │
+│  ├── Long-term memory (facts, patterns, decisions...)   │
+│  └── Code graph storage                                 │
+├─────────────────────────────────────────────────────────┤
+│  Protocols                                              │
+│  ├── AMP v0.1.3 (Agent Messaging Protocol)              │
+│  │   ├── Ed25519 cryptographic signatures               │
+│  │   ├── API key auth (SHA-256 hashed, rate-limited)    │
+│  │   ├── Federation (cross-host delivery)               │
+│  │   └── Real-time WebSocket + tmux push notifications  │
+│  ├── AID v0.2.0 (Agent Identity) — independent of AMP  │
+│  └── Host mesh sync (gossip protocol, peer exchange)    │
+├─────────────────────────────────────────────────────────┤
+│  Storage: File-based JSON registries                    │
+│  ├── ~/.aimaestro/agents/registry.json                  │
+│  ├── ~/.aimaestro/webhooks.json                         │
+│  ├── ~/.aimaestro/hosts.json                            │
+│  ├── ~/.aimaestro/amp-api-keys.json                     │
+│  └── ~/.aimaestro/teams/tasks-{teamId}.json             │
+└─────────────────────────────────────────────────────────┘
+```
+
+### 2.2 Tech Stack
+
+| Component | Technology |
+|-----------|-----------|
+| Runtime | Node.js (custom server.mjs wrapping Next.js 14) |
+| Frontend | React 18, xterm.js 6.0, Tailwind CSS, Cytoscape.js |
+| Database | CozoDB 0.7.6 (Datalog + SQLite) — one DB per agent |
+| Embeddings | HuggingFace Transformers 3.8.1 + ONNX Runtime |
+| Process management | PM2, tmux |
+| Container runtime | Docker/Podman socket |
+| Crypto | Ed25519 keypairs (node:crypto) |
+| Dual mode | `MAESTRO_MODE=full` (Next.js) or `headless` (regex router) |
+
+### 2.3 Version and Activity
+
+- **Current version:** 0.26.5 (released 2026-03-26)
+- **Stars:** 566 | **Forks:** 78
+- **License:** MIT
+- **Recent velocity:** 18 releases in 7 weeks (v0.21.24 → v0.26.5)
+- **Active development:** AMP protocol fixes, Agent Identity (AID) integration, plugin system
+- **Open issues:** 9 | **Recently closed:** 30+ in March 2026 alone
+
+---
+
+## 3. The Integration Gap: What Odysseus Uses vs. What Exists
+
+### 3.1 Odysseus's View of ai-maestro (from architecture.md and ADRs)
+
+Odysseus documents ai-maestro as providing six capabilities:
+
+```
+1. /agents        — Agent registry and lifecycle
+2. /tasks         — Task queue and dispatch
+3. /messages      — Agent-to-agent messaging (AMP)
+4. /memory        — Persistent memory/knowledge store
+5. /docker/create — Container creation via Docker socket
+6. /host-sync     — Multi-host peer sync
+```
+
+### 3.2 What Actually Exists (~100 Routes)
+
+| Route Group | Odysseus Uses | ai-maestro Provides | Gap |
+|-------------|---------------|---------------------|-----|
+| **Agents CRUD** | GET/POST/DELETE `/api/agents` | 30+ agent routes (session, hibernate, wake, transfer, import/export, skills, metadata, brain-inbox, playback, subconscious, tracking, metrics, docs, graph, repos) | **~85% unused** |
+| **Tasks** | GET/PUT `/api/teams/{id}/tasks` | Full team-scoped task CRUD with 5-status kanban, dependencies, drag-and-drop UI | Used correctly, but Odysseus docs say `/tasks` (no team scope) |
+| **Messages** | Not directly used by satellites | Full AMP v0.1.3 with Ed25519 signatures, federation, WebSocket real-time, read receipts, forwarding, batch ack | **Entirely unused by ecosystem** |
+| **Memory** | Not used by any satellite | Per-agent CozoDB with vector embeddings, hybrid search (semantic + BM25), long-term memory consolidation (facts, patterns, decisions, insights), delta indexing | **Entirely unused by ecosystem** |
+| **Docker** | Referenced in runbook only | Full container lifecycle: create, health, port allocation (23001-23100), resource limits, remote host forwarding | Minimally used |
+| **Host sync** | Referenced in add-host runbook | Gossip-based mesh sync, peer exchange, identity, health checks, circular propagation prevention | Used for onboarding only |
+| **Webhooks** | ProjectHermes receives 3 event types | 4 webhook event types: `agent.created`, `agent.updated`, `agent.deleted`, `agent.email.changed` | `agent.email.changed` may not be mapped to NATS |
+| **Teams** | ProjectKeystone reads teams | Full team CRUD, documents, notifications | Teams used for task scoping only |
+| **Sessions** | Not used | tmux session CRUD, command execution, activity monitoring, restore, rename | **Entirely unused** |
+| **Agent chat** | Not used | Conversation history per agent | Unused |
+| **Agent search** | Not used | Hybrid/semantic/BM25 search over conversations | **Major capability gap** |
+| **Agent skills** | Not used | Skills CRUD, settings, marketplace | Unused |
+| **Agent graph** | Not used | Code graph (ts-morph), DB schema graph, Cytoscape visualization | Unused |
+| **Meetings** | Not used | Team meetings CRUD, split-pane war rooms | Unused |
+| **Domains** | Not used | Domain management | Unused |
+| **Marketplace** | Not used | Skills marketplace browser | Unused |
+| **Plugin builder** | Not used | Scan repo, build plugin, push to GitHub | Unused |
+| **AID** | Not used | Agent Identity protocol v0.2.0 (independent of AMP) | Unused |
+| **WebSocket** | Not used | Terminal streaming, real-time status, AMP live, companion | Unused |
+| **Diagnostics** | Not used | System diagnostics endpoint | Unused |
+
+### 3.3 Integration Surface Currently Used (by ProjectKeystone)
+
+From `/home/mvillmow/ProjectKeystone/src/keystone/maestro_client.py`:
+
+```python
+# The entire ai-maestro integration in the HomericIntelligence ecosystem:
+GET  /api/teams/{team_id}/tasks    # Fetch tasks for DAG advancement
+GET  /api/agents/unified           # Fetch all agents for assignment
+GET  /api/teams                    # Fetch all teams for scanning
+PUT  /api/teams/{team_id}/tasks/{task_id}  # Update task (assign + status change)
+```
+
+That's **4 endpoints** out of ~100.
+
+---
+
+## 4. ai-maestro's Agent Model (What Odysseus Doesn't Know)
+
+### 4.1 Agent Entity (Full Shape)
+
+From `types/agent.ts` — ai-maestro agents are far richer than Odysseus assumes:
+
+```typescript
+interface Agent {
+  id: string                        // UUID
+  name: string                      // Identity name
+  label?: string                    // Auto-generated persona name (from hash)
+  avatar?: string                   // Auto-assigned avatar URL
+  ampIdentity?: AMPAgentIdentity    // Ed25519 cryptographic identity
+
+  // Execution context
+  workingDirectory?: string
+  sessions: AgentSession[]          // 0+ tmux sessions
+  hostId: string
+  program: string                   // "Claude Code" | "Aider" | "Cursor" | ...
+  model?: string                    // "Opus 4.1" | "GPT-4" | ...
+  runtime?: 'tmux' | 'docker' | 'api' | 'direct'
+
+  // Organization
+  taskDescription: string
+  tags?: string[]
+  capabilities?: string[]
+  owner?: string
+  role?: 'manager' | 'chief-of-staff' | 'member'
+  team?: string
+
+  // State
+  status: AgentStatus               // active, hibernated, deleted...
+  metrics?: AgentMetrics
+  metadata?: Record<string, any>
+  deployment: AgentDeployment        // local or cloud
+  tools: AgentTools                  // session, email, AMP tools
+  skills?: AgentSkillsConfig
+  deletedAt?: string                 // Soft-delete support
+}
+```
+
+**Key insight:** Odysseus's ADR-001 models agents as containers (Dockerfiles with `LABEL ai.maestro.agent-type`). But ai-maestro models agents as **tmux sessions running AI coding tools** — Claude Code, Aider, Cursor, etc. The container model is secondary (`runtime: 'docker'` is one of four runtime options).
+
+### 4.2 Agent Capabilities Odysseus Ignores
+
+| Capability | ai-maestro Feature | Odysseus Status |
+|------------|-------------------|-----------------|
+| **Hibernation** | `POST /api/agents/{id}/hibernate` — detach session, preserve state | Not used |
+| **Wake** | `POST /api/agents/{id}/wake` — reattach session | Not used |
+| **Transfer** | `POST /api/agents/{id}/transfer` — move to another host | Not used — Odysseus uses Nomad instead |
+| **Import/Export** | `POST /api/agents/{id}/import` (ZIP), `GET /api/agents/{id}/export` | Not used |
+| **Playback** | `GET /api/agents/{id}/playback` — time-travel through sessions | Not used |
+| **Subconscious** | `POST /api/agents/{id}/subconscious` — background processing | Not used |
+| **Brain inbox** | `GET /api/agents/{id}/brain-inbox` — cerebellum signals | Not used |
+| **Skills** | `GET/PATCH /api/agents/{id}/skills` — configurable skills per agent | Not used |
+| **Metrics** | `GET /api/agents/{id}/metrics` — performance tracking | Not used |
+| **Docs** | `GET/POST /api/agents/{id}/docs` — documentation indexing | Not used |
+| **Code graph** | `GET/POST /api/agents/{id}/graph/code` — codebase visualization | Not used |
+| **Repos** | `GET/POST /api/agents/{id}/repos` — git repo management | Not used |
+| **Tracking** | `GET/POST /api/agents/{id}/tracking` — progress tracking | Not used |
+| **Metadata** | `GET/PATCH /api/agents/{id}/metadata` — flexible KV store | Not used |
+
+### 4.3 Task System: What Odysseus Gets Wrong
+
+**Odysseus docs say:** `/tasks` — a standalone task endpoint.
+**Reality:** Tasks are **team-scoped** at `/api/teams/{id}/tasks`. There is no top-level `/tasks` endpoint.
+
+**Implications:**
+- Myrmidons would need team IDs to manage tasks (the docs don't mention this)
+- ProjectTelemachy would need team context for workflow chaining
+- The architecture doc's simplified notation (`/tasks`) hides a meaningful constraint
+
+**Task status lifecycle in ai-maestro:**
+```
+backlog → pending → in_progress → review → completed
+                                         → failed
+                                         → error
+                                         → cancelled
+```
+
+ProjectKeystone correctly models this with `TaskStatus` enum including `BACKLOG`, `PENDING`, `IN_PROGRESS`, `REVIEW`, `COMPLETED`, `FAILED`, `ERROR`, `CANCELLED`.
+
+---
+
+## 5. ai-maestro's Memory System (Odysseus's Biggest Missed Opportunity)
+
+### 5.1 What Exists
+
+ai-maestro has a **three-layer memory architecture** that the HomericIntelligence ecosystem completely ignores:
+
+**Layer 1 — Conversation Memory (CozoDB + Vector Embeddings)**
+```
+Per-agent CozoDB at ~/.aimaestro/agents/{id}/agent.db
+  ├── sessions table      — conversation session metadata
+  ├── conversations table — conversation entries
+  ├── messages table      — individual messages with embeddings
+  └── msg_vec table       — vector index for semantic search
+```
+
+Conversations are ingested from `~/.claude/projects/` JSONL files via delta indexing. Each message gets a HuggingFace embedding (ONNX Runtime, local inference).
+
+**Layer 2 — Long-Term Memory (Consolidated)**
+```
+Memory categories:
+  facts       — objective information discovered
+  preferences — user/agent preferences
+  patterns    — recurring patterns observed
+  decisions   — decisions made and rationale
+  insights    — synthesized observations
+
+Memory metadata:
+  confidence  — 0.0-1.0 confidence score
+  tier        — core | standard | peripheral
+  reinforced  — count of reinforcements
+```
+
+Memory consolidation runs as a background process, extracting structured knowledge from raw conversations and storing it in categorized, searchable form.
+
+**Layer 3 — Code Graph (ts-morph)**
+```
+Code analysis via ts-morph:
+  ├── Function/class/variable extraction
+  ├── Import/export dependency mapping
+  ├── Call graph construction
+  └── Cytoscape.js interactive visualization
+```
+
+### 5.2 Search Capabilities
+
+ai-maestro supports **three search modes** (per agent):
+
+| Mode | Method | Use Case |
+|------|--------|----------|
+| Semantic | HuggingFace embeddings + vector cosine similarity | "Find conversations about authentication" |
+| BM25 | Term frequency / inverse document frequency | "Find exact mentions of `webhook_secret`" |
+| Hybrid | Reciprocal Rank Fusion (RRF) of semantic + BM25 | Best of both — default mode |
+
+**API:**
+```
+GET /api/agents/{id}/search?q=...&mode=hybrid
+POST /api/agents/{id}/search           # Ingest conversations
+POST /api/agents/{id}/index-delta      # Delta indexing (new conversations only)
+```
+
+### 5.3 Why This Matters for HomericIntelligence
+
+**Current state:** The ecosystem has zero memory utilization. ADR-004 says "no new repo maintains its own memory/knowledge store." But it also doesn't _use_ ai-maestro's memory store. Agents in the ecosystem have no long-term memory, no semantic search, and no pattern recognition.
+
+**What could change:**
+1. ProjectKeystone could query agent memory before DAG advancement — "has this agent successfully handled similar tasks before?"
+2. ProjectTelemachy could store workflow execution history in agent memory — searchable by future workflow runs
+3. ProjectArgus could consolidate metrics into long-term memory patterns — "which agent types fail most often on which task types?"
+
+---
+
+## 6. AMP Protocol: Deeper Than Documented
+
+### 6.1 Current AMP Architecture (v0.1.3)
+
+```
+Agent A                    ai-maestro                    Agent B
+  │                            │                            │
+  ├─ POST /v1/register ───────►│ (generates API key)        │
+  │  ◄── amp_live_sk_... ──────┤                            │
+  │                            │                            │
+  ├─ POST /v1/route ──────────►│ (verify Ed25519 sig)       │
+  │  {to: "B", content: ...}   │                            │
+  │                            ├── Write to B's amp-inbox/ ─►│
+  │                            ├── WebSocket push (/v1/ws) ─►│
+  │                            ├── tmux notification ───────►│
+  │                            │                            │
+  │                            │◄── GET /v1/messages ────────┤
+  │                            │    (poll pending)           │
+  │                            │◄── DELETE /v1/messages/     │
+  │                            │    pending/{id} (ack)       │
+```
+
+**Security features:**
+- Ed25519 keypairs per agent (stored at `~/.aimaestro/agents/{id}/keys/`)
+- API keys: SHA-256 hashed storage, 24-hour grace period on rotation
+- Rate limiting: 60 requests/agent/60 seconds on `/v1/route`
+- Content security: 34 prompt injection patterns scanned, external content wrapped in `<external-content>` tags
+- Proof-of-possession for key rotation (v0.25.15)
+
+**Federation:** Messages to agents on other hosts route via `POST /v1/federation/deliver` to remote ai-maestro instances. The host mesh (`/api/hosts/`) provides peer discovery.
+
+### 6.2 Agent Identity (AID) v0.2.0
+
+As of v0.26.0, ai-maestro includes AID — an identity protocol **independent of AMP**:
+- Ed25519 identity documents
+- Proof of possession
+- OAuth 2.0 token exchange
+- Scoped JWT tokens
+
+This was not documented in any Odysseus ADR or architecture doc.
+
+### 6.3 What Odysseus Misses
+
+The HomericIntelligence ecosystem routes all inter-agent communication through NATS JetStream (ADR-002). But ai-maestro's AMP protocol provides:
+
+| AMP Feature | NATS Equivalent | Gap |
+|-------------|-----------------|-----|
+| Cryptographic signatures | None | NATS messages are unsigned |
+| Per-agent identity (Ed25519) | None | NATS has no agent identity |
+| Read receipts | None | NATS has at-least-once, no read confirmation |
+| Message forwarding | None | No built-in forward |
+| Content security scanning | None | No prompt injection detection |
+| Agent card / directory | None | No agent discovery protocol |
+| Real-time WebSocket | None (NATS is server-side) | No browser push |
+
+**Architectural tension:** ADR-002 states "AMP stays as the point-to-point channel for agent-to-agent communication... NATS is for infrastructure events only." But in practice, the ecosystem doesn't use AMP at all — it routes everything through NATS. AMP's richer security model is being bypassed.
+
+---
+
+## 7. Webhook System: Mismatches and Gaps
+
+### 7.1 Webhook Events
+
+ai-maestro fires four webhook event types:
+
+| Event | Description | Mapped to NATS? |
+|-------|-------------|------------------|
+| `agent.created` | Agent registered | Yes → `hi.agents.{host}.{name}.created` |
+| `agent.updated` | Agent state changed | Yes → `hi.agents.{host}.{name}.updated` |
+| `agent.deleted` | Agent removed | Yes → `hi.agents.{host}.{name}.deleted` |
+| `agent.email.changed` | Agent email addresses changed | **Unknown — likely dropped** |
+
+### 7.2 Missing Task Webhooks
+
+**Critical finding:** ai-maestro's webhook system only fires on **agent events**. There are **no webhook events for task status changes**.
+
+ProjectKeystone's NATS listener subscribes to `hi.tasks.>`, expecting task events. But if ai-maestro doesn't fire task webhooks, how does ProjectHermes publish task events to NATS?
+
+**Possible explanations:**
+1. ProjectHermes polls ai-maestro's task endpoints and generates synthetic NATS events
+2. ai-maestro has undocumented task webhook support not visible in the webhook service code
+3. The task NATS pipeline is not yet operational
+
+This is a **critical architectural question** that could not be resolved without inspecting ProjectHermes's source (submodule not checked out).
+
+### 7.3 Webhook Delivery Model
+
+```
+Delivery: Fire-and-forget via Promise.allSettled()
+Timeout:  10 seconds per delivery
+Retry:    None — failure count tracked but no retry queue
+Security: HMAC-SHA256 signature in X-Webhook-Signature header
+          (secret generated as whsec_{64 hex chars} on webhook creation)
+```
+
+**Gap:** No retry queue. If ProjectHermes is down when an event fires, the event is lost. NATS JetStream's durable consumers handle replay on the NATS side, but the webhook-to-Hermes link is fragile. This was identified in ai-maestro's BACKLOG.md as "Host Sync Phase 3 (retry queue for offline hosts with exponential backoff) not implemented."
+
+---
+
+## 8. Host Mesh: What Odysseus Duplicates
+
+### 8.1 ai-maestro's Built-in Mesh
+
+ai-maestro has a **gossip-based mesh networking** system built in:
+
+```
+POST /api/hosts/register-peer     — Register as peer
+POST /api/hosts/exchange-peers    — Exchange known peer lists
+POST /api/hosts/sync              — Full mesh sync trigger
+GET  /api/hosts/identity          — This host's identity
+GET  /api/hosts/health            — Remote host health
+```
+
+Features:
+- Auto-detect public URL (Tailscale IP preferred, then LAN, then hostname)
+- Circular propagation prevention via `propagationId` (60s TTL, max 3 hops)
+- Organization adoption from peer hosts
+- Health checks (5s timeout), registration (10s), exchange (15s)
+
+### 8.2 Overlap with Odysseus Infrastructure
+
+Odysseus adds **three additional networking layers** on top of ai-maestro's built-in mesh:
+
+| Layer | System | Purpose | Overlap with ai-maestro? |
+|-------|--------|---------|--------------------------|
+| Network mesh | Tailscale | WSL2 host-to-host connectivity | ai-maestro auto-detects Tailscale IPs |
+| Container scheduling | Nomad | Schedule containers across hosts | ai-maestro has `/docker/create` + remote forwarding |
+| Event distribution | NATS leaf nodes | Multi-host event mesh | ai-maestro has `/host-sync` + federation |
+
+**Key question:** Is this layering necessary, or is it duplicating what ai-maestro already provides?
+
+**Analysis:**
+- **Tailscale:** Necessary — ai-maestro needs network connectivity but doesn't provide it
+- **Nomad:** Partially redundant — ai-maestro's `/docker/create` supports remote host forwarding (`hostId` parameter routes to remote host's API), but Nomad provides richer scheduling (constraints, resource allocation, job specs). **Nomad adds genuine value beyond ai-maestro's capabilities.**
+- **NATS:** Necessary for fan-out — ai-maestro's webhooks are single-target, fire-and-forget. NATS JetStream adds durable pub/sub fan-out that ai-maestro does not provide. However, ai-maestro's AMP federation could partially replace NATS for agent-to-agent messaging.
+
+---
+
+## 9. Known Issues and Roadmap (from GitHub)
+
+### 9.1 Open Issues (9)
+
+| # | Title | Relevance to Odysseus |
+|---|-------|-----------------------|
+| **291** | Agent-program normalization and terminal-default patch | Medium — affects how agents report their program type |
+| **285** | DRY: Shared API validation middleware for 106 routes | Low — internal code quality |
+| **270** | Paste screenshots / upload files to agents | Low — UI feature |
+| **248** | Robotic avatars fixed | Low — cosmetic |
+| **241** | Team-based communication isolation | **HIGH** — proposes MANAGER/CHIEF-OF-STAFF roles, open/closed teams, messaging restrictions. Would significantly change how the ecosystem models agent organization |
+| **237** | Decouple voice subsystem from Claude Code files | Low — voice feature |
+| **236** | Decouple conversation indexing from Claude Code format | **HIGH** — currently hardcoded to `~/.claude/projects/` JSONL. Decoupling would allow indexing from any agent type |
+| **197** | Personal Assistant agents (Discord, WhatsApp, Telegram) | Medium — new agent runtime types |
+
+### 9.2 Recently Closed Issues (Notable)
+
+| # | Title | Lesson for Odysseus |
+|---|-------|-----------------------|
+| **295** | AMP data not cleaned up on soft-delete | Agent deletion has hidden state — Odysseus needs to handle this |
+| **292** | Soft-deleted agents reappear in UI as hibernating | Soft-delete semantics are subtle — `GET /api/agents` may return deleted agents |
+| **286** | CozoDB query injection via unescaped template literals | **Security** — ai-maestro had a query injection vulnerability; fixed in March 2026 |
+| **279** | `/plan` mode rendering in xterm.js | Terminal rendering bugs affect Claude Code specifically |
+| **276** | `agent.hostUrl` used directly breaks on WSL2/NAT | Cross-host URLs unreliable — Odysseus should use Tailscale IPs, not hostUrl |
+| **273** | Dashboard shows no agents on WSL2: unreachable internal IP | WSL2 networking issues — directly affects HomericIntelligence's target platform |
+| **252** | `useTasks` crashes on unknown task status | Task status values must be validated — relates to ecosystem-audit-remediation finding |
+| **251** | Task update (PUT) overwrites existing fields with undefined | **Critical for ProjectKeystone** — PUT semantics require sending ALL fields, not just changed ones. Partial updates silently null out omitted fields. |
+
+### 9.3 Development Trajectory
+
+ai-maestro is moving fast (18 releases in 7 weeks). Key directions:
+- **AMP protocol hardening** — v0.1.3 with key rotation, proof-of-possession, mesh routing fixes
+- **Agent Identity (AID)** — v0.2.0, now independent from AMP
+- **Plugin/skills system** — dynamic discovery, auto-install, marketplace
+- **OpenClaw compatibility** — decoupling from Claude Code-specific file formats
+
+---
+
+## 10. Documented Integration Mismatches
+
+### 10.1 Confirmed Mismatches
+
+| Issue | Odysseus Says | ai-maestro Actually Does | Impact |
+|-------|---------------|--------------------------|--------|
+| **Task endpoint** | `/tasks` (standalone) | `/api/teams/{id}/tasks` (team-scoped) | Myrmidons and Telemachy need team IDs |
+| **NATS prefix** | ADR-002 examples use `maestro.*` | Implemented as `hi.*` (ADR-005 corrects this) | Fixed in ADR-005, but disaster-recovery runbook still has stale `maestro.>` reference |
+| **Durable consumer** | ADR-005 says `keystone-dag` | ProjectKeystone code uses `keystone-daemon` | Documentation/code mismatch — two different consumer names |
+| **API prefix** | Architecture docs use `/agents`, `/tasks` | Actual routes are `/api/agents`, `/api/teams/{id}/tasks` | Shorthand in docs hides real path structure |
+| **Webhook events** | Implies events for all entity types | Only `agent.*` events — no `task.*` webhook events | Task NATS pipeline may not be functional via webhooks |
+| **PUT semantics** | Not documented | PUT overwrites all fields — omitted fields become undefined (issue #251) | ProjectKeystone MUST send complete task objects, not partial updates |
+| **Soft-delete** | Not documented | `DELETE /api/agents/{id}` is soft-delete by default; `?hard=true` for permanent | Deleted agents may still appear in `GET /api/agents` responses |
+| **Agent email changed** | Not mapped in ADR-005 | `agent.email.changed` webhook event type exists | No NATS subject for email change events |
+
+### 10.2 Potential Silent Failures
+
+1. **Task PUT partial update bug (issue #251):** If ProjectKeystone calls `PUT /api/teams/{id}/tasks/{taskId}` with only `{"assigneeAgentId": "...", "status": "in_progress"}`, all other task fields (title, dependencies, etc.) will be overwritten with `undefined`. This was fixed in ai-maestro but the fix may require sending the complete task object.
+
+2. **Soft-deleted agents in unified list:** `GET /api/agents/unified` may include soft-deleted agents. ProjectKeystone's DAG walker should filter by `deletedAt` being null/undefined.
+
+3. **hostUrl reliability (issue #276):** `agent.hostUrl` can contain unreachable internal IPs on WSL2. The ecosystem should use Tailscale IPs from host-sync, not hostUrl from agent records.
+
+---
+
+## 11. Untapped Capabilities: What the Ecosystem Should Use
+
+### 11.1 Immediate Value (No Architecture Changes)
+
+**1. Agent Memory and Search**
+
+ProjectKeystone could use ai-maestro's memory system for intelligent task assignment:
+
+```bash
+# Before assigning task to agent, check if agent has relevant experience
+GET /api/agents/{id}/search?q=<task_description>&mode=hybrid
+
+# Store task completion context for future reference
+POST /api/agents/{id}/memory/long-term
+{
+  "category": "patterns",
+  "content": "Successfully completed DAG task: <description>",
+  "confidence": 0.9,
+  "tier": "standard"
+}
+```
+
+**2. Agent Metrics**
+
+ProjectArgus could read agent metrics directly instead of inferring from NATS events:
+
+```bash
+GET /api/agents/{id}/metrics
+# Returns: tasks completed, success rate, average execution time
+```
+
+**3. Agent Skills**
+
+AchaeanFleet vessel definitions could include skills configuration:
+
+```bash
+PATCH /api/agents/{id}/skills
+{
+  "enabled": ["code-review", "test-generation", "security-audit"],
+  "settings": { "preferredLanguage": "python" }
+}
+```
+
+**4. Agent Hibernation/Wake**
+
+Instead of stopping and recreating agents, use ai-maestro's built-in lifecycle:
+
+```bash
+POST /api/agents/{id}/hibernate   # Detach session, preserve state
+POST /api/agents/{id}/wake        # Reattach session
+```
+
+### 11.2 Medium-Term Value (Minor Architecture Changes)
+
+**5. AMP for Agent-to-Agent Communication**
+
+ADR-002 already states AMP should be used for agent messaging. The ecosystem could actually implement this:
+
+```bash
+# Register agent with AMP
+POST /api/v1/register
+{
+  "agentId": "keystone-daemon",
+  "capabilities": ["dag-advancement", "task-routing"]
+}
+
+# Send signed message
+POST /api/v1/route
+{
+  "to": "target-agent-id",
+  "content": { "type": "request", "message": "Please review PR #42" },
+  "signature": "<ed25519_signature>"
+}
+```
+
+Benefits over NATS for agent messaging: cryptographic verification, read receipts, content security scanning, real-time WebSocket delivery.
+
+**6. Team-Scoped Organization**
+
+Use ai-maestro's teams system to organize the ecosystem's agents:
+
+```bash
+POST /api/teams
+{ "name": "infrastructure", "agents": ["hermes", "argus", "keystone"] }
+
+POST /api/teams
+{ "name": "provisioning", "agents": ["myrmidons", "telemachy"] }
+```
+
+**7. Agent Transfer Instead of Nomad Reschedule**
+
+For simple agent migration between hosts:
+
+```bash
+POST /api/agents/{id}/transfer
+{ "targetHostId": "hermes-host" }
+```
+
+This leverages ai-maestro's built-in host mesh instead of Nomad rescheduling.
+
+### 11.3 Long-Term Value (Architectural Leverage)
+
+**8. CozoDB as Ecosystem Knowledge Base**
+
+Each agent's CozoDB could store ecosystem-level knowledge:
+
+```
+Agent "keystone-daemon":
+  memory: DAG patterns, task dependencies, failure modes
+  code_graph: ecosystem service dependencies
+
+Agent "hermes-bridge":
+  memory: webhook reliability patterns, NATS subject evolution
+  long_term: consolidation of event flow anomalies
+```
+
+**9. Plugin System Integration**
+
+ai-maestro's plugin builder could create HomericIntelligence-specific plugins:
+
+```bash
+POST /api/plugin-builder/scan
+{ "repoPath": "/home/mvillmow/ProjectKeystone" }
+
+POST /api/plugin-builder/build
+# Generates a Claude Code plugin from ProjectKeystone
+```
+
+---
+
+## 12. Authentication: The Elephant in the Room
+
+### 12.1 Current State
+
+ai-maestro has **no authentication on its HTTP API** (Phase 1 design choice from `.env.example`):
+
+> "Phase 1 - Local-only, auto-discovery, no authentication."
+
+AMP has authentication (API keys + Ed25519), but the REST API is wide open.
+
+### 12.2 Implications for Odysseus
+
+- Any host on the Tailscale mesh can call any ai-maestro endpoint without credentials
+- `MAESTRO_API_KEY` exists in ProjectKeystone's config but defaults to empty string
+- No RBAC, no scoped tokens, no rate limiting on REST API (only on AMP `/v1/route`)
+- This is acceptable for a local development tool but **problematic for a production agent mesh**
+
+### 12.3 Future Path
+
+AID v0.2.0 (introduced in v0.26.0) provides the foundation for REST API authentication:
+- Ed25519 identity documents
+- OAuth 2.0 token exchange
+- Scoped JWT tokens
+
+The ecosystem should plan for ai-maestro eventually requiring authentication on REST endpoints. ProjectKeystone's `MAESTRO_API_KEY` config is forward-looking.
+
+---
+
+## 13. Recommendations
+
+### 13.1 Documentation Fixes (Immediate)
+
+1. **Fix architecture.md** endpoint references: `/tasks` → `/api/teams/{id}/tasks`, `/agents` → `/api/agents`, etc.
+2. **Fix disaster-recovery runbook** NATS reference: `maestro.>` → `hi.>`
+3. **Reconcile durable consumer name**: ADR-005 says `keystone-dag`, code says `keystone-daemon`
+4. **Document soft-delete semantics**: `DELETE /api/agents/{id}` is soft-delete by default
+5. **Document PUT full-replace semantics**: task updates must send complete objects
+6. **Add ADR for ai-maestro memory**: Document decision to use or not use ai-maestro's memory system
+7. **Document `agent.email.changed` webhook gap**: Either map to NATS or explicitly exclude
+
+### 13.2 Integration Improvements (Short-Term)
+
+1. **Use agent memory for intelligent assignment**: Query `/api/agents/{id}/search` before task assignment in ProjectKeystone
+2. **Use agent metrics in ProjectArgus**: Read `/api/agents/{id}/metrics` instead of inferring from events
+3. **Use hibernation instead of stop/start**: `POST /api/agents/{id}/hibernate|wake`
+4. **Filter soft-deleted agents**: Add `deletedAt` check in ProjectKeystone's DAG walker
+5. **Send complete objects on PUT**: Ensure ProjectKeystone doesn't trigger issue #251
+
+### 13.3 Architectural Decisions Needed (Medium-Term)
+
+1. **AMP vs NATS for agent messaging**: ADR-002 says to use AMP for agent-to-agent, but the ecosystem uses NATS for everything. Decide and document.
+2. **ai-maestro memory vs external memory**: Should the ecosystem use ai-maestro's CozoDB + vector search, or build a separate memory layer (as the Ruflo analysis suggested)?
+3. **Task webhook gap**: Investigate whether ProjectHermes generates task NATS events from polling or if ai-maestro actually fires task webhooks not visible in the webhook service code.
+4. **Authentication timeline**: When will ai-maestro REST API require auth? Plan for `MAESTRO_API_KEY` to become mandatory.
+5. **Nomad vs ai-maestro transfer**: For simple agent migration, `POST /api/agents/{id}/transfer` may be simpler than Nomad rescheduling. Define when each is appropriate.
+
+### 13.4 What NOT To Do
+
+- **Do not build a separate memory system** before evaluating ai-maestro's CozoDB + vector search. It already has hybrid search, long-term memory consolidation, and per-agent isolation.
+- **Do not duplicate agent identity** — AID v0.2.0 exists in ai-maestro. The ecosystem should adopt it, not create a parallel identity system.
+- **Do not bypass webhook+NATS for task events** by polling ai-maestro directly from every consumer. If the webhook→NATS pipeline has gaps, fix the pipeline.
+
+---
+
+## Appendix A: Complete ai-maestro API Route Map
+
+### Agent Routes (~40 endpoints)
+```
+GET    /api/agents
+POST   /api/agents
+GET    /api/agents/{id}
+PATCH  /api/agents/{id}
+DELETE /api/agents/{id}
+POST   /api/agents/register
+GET    /api/agents/by-name/{name}
+GET    /api/agents/unified
+GET    /api/agents/directory
+GET    /api/agents/directory/lookup/{name}
+POST   /api/agents/directory/sync
+GET/POST /api/agents/normalize-hosts
+GET/POST /api/agents/startup
+POST   /api/agents/health
+POST   /api/agents/docker/create
+POST   /api/agents/import
+GET    /api/agents/{id}/session
+POST   /api/agents/{id}/session
+PATCH  /api/agents/{id}/session
+DELETE /api/agents/{id}/session
+POST   /api/agents/{id}/wake
+POST   /api/agents/{id}/hibernate
+GET    /api/agents/{id}/chat
+POST   /api/agents/{id}/chat
+GET    /api/agents/{id}/memory
+POST   /api/agents/{id}/memory
+GET/POST/PATCH /api/agents/{id}/memory/consolidate
+GET/PATCH/DELETE /api/agents/{id}/memory/long-term
+GET    /api/agents/{id}/search
+POST   /api/agents/{id}/search
+POST   /api/agents/{id}/index-delta
+GET/POST /api/agents/{id}/tracking
+GET/PATCH /api/agents/{id}/metrics
+GET/POST/DELETE /api/agents/{id}/graph/code
+GET/POST/DELETE /api/agents/{id}/graph/db
+GET    /api/agents/{id}/graph/query
+GET/POST /api/agents/{id}/database
+GET    /api/agents/{id}/messages
+POST   /api/agents/{id}/messages
+GET/PATCH/POST/DELETE /api/agents/{id}/messages/{messageId}
+GET/POST /api/agents/{id}/amp/addresses
+GET/PATCH/DELETE /api/agents/{id}/amp/addresses/{address}
+GET/POST /api/agents/{id}/email/addresses
+GET/PATCH/DELETE /api/agents/{id}/email/addresses/{address}
+GET    /api/agents/email-index
+GET/PATCH/POST/DELETE /api/agents/{id}/skills
+GET/PUT /api/agents/{id}/skills/settings
+GET/POST/DELETE /api/agents/{id}/repos
+GET/POST/DELETE /api/agents/{id}/docs
+GET/POST /api/agents/{id}/subconscious
+GET    /api/agents/{id}/brain-inbox
+GET/POST /api/agents/{id}/playback
+GET/PATCH/DELETE /api/agents/{id}/metadata
+GET/POST /api/agents/{id}/export
+POST   /api/agents/{id}/transfer
+```
+
+### Team & Task Routes
+```
+GET/POST /api/teams
+GET/PUT/DELETE /api/teams/{id}
+GET/POST /api/teams/{id}/tasks
+PUT/DELETE /api/teams/{id}/tasks/{taskId}
+GET/POST /api/teams/{id}/documents
+GET/PUT/DELETE /api/teams/{id}/documents/{docId}
+POST /api/teams/notify
+```
+
+### Host Routes
+```
+GET    /api/hosts
+POST   /api/hosts
+PUT    /api/hosts/{id}
+DELETE /api/hosts/{id}
+GET    /api/hosts/identity
+GET    /api/hosts/health
+GET/POST /api/hosts/sync
+POST   /api/hosts/register-peer
+POST   /api/hosts/exchange-peers
+```
+
+### AMP v1 Routes
+```
+GET    /api/v1/health
+GET    /api/v1/info
+POST   /api/v1/register
+POST   /api/v1/route
+GET    /api/v1/messages
+GET    /api/v1/messages/pending
+DELETE /api/v1/messages/pending
+DELETE /api/v1/messages/pending/{id}
+POST   /api/v1/messages/pending/ack
+POST   /api/v1/messages/{id}/read
+GET    /api/v1/agents
+GET    /api/v1/agents/me
+GET    /api/v1/agents/me/card
+PATCH  /api/v1/agents/me
+DELETE /api/v1/agents/me
+GET    /api/v1/agents/resolve/{address}
+DELETE /api/v1/auth/revoke-key
+POST   /api/v1/auth/rotate-key
+POST   /api/v1/auth/rotate-keys
+POST   /api/v1/federation/deliver
+```
+
+### Other Routes
+```
+GET/POST /api/webhooks
+GET/DELETE /api/webhooks/{id}
+POST /api/webhooks/{id}/test
+GET/POST /api/messages
+PATCH/DELETE /api/messages
+GET /api/messages/meeting
+POST /api/messages/forward
+GET/POST /api/meetings
+GET/PATCH/DELETE /api/meetings/{id}
+GET/POST /api/sessions
+POST /api/sessions/create
+DELETE /api/sessions/{id}
+GET/POST /api/sessions/{id}/command
+PATCH /api/sessions/{id}/rename
+GET/POST/DELETE /api/sessions/restore
+GET /api/sessions/activity
+POST /api/sessions/activity/update
+GET/POST /api/domains
+GET/PATCH/DELETE /api/domains/{id}
+GET /api/marketplace/skills
+GET /api/marketplace/skills/{id}
+GET/POST/DELETE /api/help/agent
+POST /api/plugin-builder/scan
+POST/GET /api/plugin-builder/build
+POST /api/plugin-builder/push
+GET /api/config
+GET /api/organization
+POST /api/organization
+GET /api/diagnostics
+GET /api/docker/info
+POST /api/conversations/parse
+GET /api/conversations/{file}/messages
+GET/DELETE /api/export/jobs/{jobId}
+GET /api/subconscious
+GET /api/debug/pty
+GET /.well-known/agent-messaging.json
+```
+
+### WebSocket Endpoints
+```
+/term?name={sessionName}&host={hostId}   — Terminal streaming
+/status                                   — Real-time status updates
+/v1/ws                                    — AMP real-time messaging
+/companion-ws?agent={agentId}             — Companion app (voice/speech)
+```
+
+---
+
+## Appendix B: Ecosystem-to-ai-maestro Integration Map
+
+```
+HomericIntelligence Ecosystem
+│
+├── ProjectKeystone (DAG executor)
+│   ├── GET  /api/teams                    ← fetch all teams
+│   ├── GET  /api/teams/{id}/tasks         ← fetch tasks per team
+│   ├── GET  /api/agents/unified           ← fetch all agents
+│   └── PUT  /api/teams/{id}/tasks/{id}    ← assign agent + update status
+│
+├── ProjectHermes (NATS bridge)
+│   └── Receives webhooks: agent.created, agent.updated, agent.deleted
+│       └── Publishes to NATS: hi.agents.{host}.{name}.{verb}
+│       └── (Task events: mechanism unclear — no task webhooks in ai-maestro)
+│
+├── Myrmidons (GitOps)
+│   ├── POST /api/agents                   ← create agents from YAML
+│   ├── DELETE /api/agents/{id}            ← remove agents
+│   └── (Tasks: needs /api/teams/{id}/tasks, not /tasks)
+│
+├── ProjectTelemachy (workflows)
+│   └── (Tasks: needs /api/teams/{id}/tasks, not /tasks)
+│
+├── ProjectArgus (observability)
+│   └── (Could use: GET /api/agents/{id}/metrics)
+│
+├── ProjectScylla (chaos testing)
+│   └── (Uses: DELETE/PATCH /api/agents/{id} for failure injection)
+│
+└── Runbooks
+    ├── POST /api/agents/docker/create     ← add-new-agent-type
+    ├── POST /api/hosts/sync               ← add-new-host
+    ├── GET  /api/agents                   ← disaster-recovery
+    └── GET  /health                       ← disaster-recovery
+
+UNUSED by ecosystem (major capabilities):
+  ├── Agent memory: /api/agents/{id}/memory, /search, /memory/long-term
+  ├── Agent skills: /api/agents/{id}/skills
+  ├── Agent metrics: /api/agents/{id}/metrics
+  ├── Agent lifecycle: /hibernate, /wake, /transfer, /import, /export
+  ├── Agent cerebellum: /subconscious, /brain-inbox
+  ├── Agent graph: /graph/code, /graph/db
+  ├── AMP messaging: /api/v1/* (entire protocol)
+  ├── AID identity: Agent Identity v0.2.0
+  ├── Meetings: /api/meetings
+  ├── Plugin builder: /api/plugin-builder
+  ├── Marketplace: /api/marketplace
+  └── WebSocket: /term, /status, /v1/ws, /companion-ws
+```
+
+---
+
+## Appendix C: Version History Context
+
+| Version | Date | Significance |
+|---------|------|-------------|
+| v0.21.24 | 2026-02-08 | AMP Protocol, Mesh Networking, Kanban |
+| v0.25.0 | 2026-03-09 | Agent Skills Standard Compliant |
+| v0.25.15 | 2026-03-23 | AMP Key Rotation with Proof-of-Possession |
+| v0.25.16 | 2026-03-23 | AMP Plugin Sync to v0.1.3 |
+| v0.26.0 | 2026-03-24 | Agent Identity (AID) Integration |
+| v0.26.1 | 2026-03-24 | Rename installer, auto-discover skills |
+| v0.26.2 | 2026-03-24 | Dynamic discovery for all lists |
+| v0.26.3 | 2026-03-24 | AID v0.2.0: Independent from AMP |
+| v0.26.4 | 2026-03-25 | AMP Mesh Routing Fix |
+| v0.26.5 | 2026-03-26 | Auto-install Status Line |

--- a/docs/odysseus-ruflo-analysis.md
+++ b/docs/odysseus-ruflo-analysis.md
@@ -1,0 +1,831 @@
+# Architectural Analysis: HomericIntelligence/Odysseus vs. Ruflo
+
+**Date:** 2026-03-27
+**Repositories:**
+- Odysseus: `HomericIntelligence/Odysseus` (meta-repo, `/home/mvillmow/.agent-brain/Odysseus`)
+- Ruflo: `ruvnet/ruflo` (formerly Claude Flow, cloned to `/tmp/ruflo-analysis`)
+
+---
+
+## 1. Executive Summary
+
+Odysseus and Ruflo solve adjacent but fundamentally different problems. **Odysseus** is an infrastructure-centric coordination layer — it answers *where agents run, how they communicate across hosts, and how state recovers after failure*. It contains zero application code; its value is in governance, configuration, and composition of battle-tested external systems (NATS, Nomad, Podman, Tailscale). **Ruflo** is an application-centric intelligence layer — it answers *how agents think, how tasks are routed intelligently, and how the system learns from execution history*. It contains ~150k lines of TypeScript and Rust/WASM delivering in-process swarm coordination, neural routing, and hybrid vector memory.
+
+The central thesis of this analysis: **these systems occupy complementary architectural layers and could be composed.** Odysseus provides the infrastructure backbone that Ruflo lacks (real multi-host distribution, container isolation, GitOps recovery). Ruflo provides the cognitive capabilities that Odysseus lacks (intelligent routing, vector memory, consensus protocols, self-improvement). Together they could form a system with both infrastructure resilience and cognitive sophistication.
+
+---
+
+## 2. Architectural Paradigm Comparison
+
+### 2.1 Odysseus: Infrastructure-Centric, Extend-Not-Replace
+
+The foundational philosophy is stated explicitly in **ADR-004**:
+
+> "All HomericIntelligence repos integrate with ai-maestro exclusively via its documented REST API and webhook endpoints. No new repo maintains its own agent registry separate from ai-maestro, its own task queue, or its own memory/knowledge store."
+
+This produces an architecture of **process-boundary separation**: every concern lives in a separate repository and a separate running process. The architecture diagram from `docs/architecture.md` shows twelve satellites orbiting a single core:
+
+```
+                      ┌─────────────────────┐
+                      │     ai-maestro      │
+                      │  /agents /tasks     │
+                      │  /messages /memory  │
+                      └──────┬──────┬───────┘
+                             │ REST │ webhooks
+                             │      ▼
+                      ┌──────┼─── ProjectHermes ───────────┐
+                      │      │   (NATS JetStream fan-out)  │
+                      │      └──────────┬──────────────────┘
+                      │                 │ NATS pub/sub
+                      │    ┌────────────┼────────────┐
+                      │    ▼            ▼            ▼
+                 Myrmidons  ProjectArgus  ProjectTelemachy
+                 (GitOps)   (metrics)    (workflows)
+                      │
+                      ▼
+                   Nomad ◄── AchaeanFleet (images)
+```
+
+Odysseus itself is the meta-repo that **contains no application code** — just docs, configs, ADRs, a justfile, and git submodule pins. This is architectural discipline enforced structurally: you cannot accidentally put business logic in the coordination layer if the coordination layer has no executable files.
+
+**Key properties:**
+- Network boundaries between every component — faults are isolated by process/container
+- ai-maestro is the immutable single source of truth (never patched, never forked)
+- GitOps recovery: full agent state reconstructible from Myrmidons YAML via `just apply-all`
+- Decisions are durable ADRs (append-only documents that cannot be silently revised)
+
+### 2.2 Ruflo: Application-Centric, Monolithic-Modular
+
+Ruflo follows **ADR-002 (DDD Structure)**: code is organized by domain concern within a single Node.js runtime.
+
+```
+v3/src/
+├── agent-lifecycle/
+│   ├── api/cli/          ← CLI interface
+│   ├── api/mcp/          ← MCP tools
+│   ├── application/      ← Agent service
+│   ├── domain/Agent.ts   ← Domain entity
+│   └── infrastructure/   ← Agent repository
+├── task-execution/
+│   ├── application/WorkflowEngine.ts
+│   └── domain/Task.ts
+├── coordination/
+│   └── application/SwarmCoordinator.ts
+└── memory/
+    └── infrastructure/HybridBackend.ts
+```
+
+All coordination happens **in-process**: SwarmCoordinator, TopologyManager, ConsensusManager, AgentPool, MessageBus are TypeScript classes instantiated in a single Node.js runtime. Module boundaries replace process boundaries.
+
+**Key properties:**
+- Sub-millisecond agent coordination (no network hop on task assignment)
+- Rich in-process intelligence (Q-learning router, SONA, HNSW vector search)
+- 215+ MCP tools as primary API surface (ADR-005: MCP-first design)
+- Single Node.js process = single failure domain
+
+### 2.3 Paradigm Trade-off Analysis
+
+| Dimension | Odysseus (Process Boundaries) | Ruflo (Module Boundaries) |
+|-----------|-------------------------------|---------------------------|
+| Fault isolation | Per-process; one crash doesn't cascade | Single process; one crash loses all agents |
+| Coordination latency | Network RTT on every operation (ms range) | In-process call (<1ms for same-tier ops) |
+| Observability | NATS subjects visible via `nats sub`; REST calls logged | In-process state — requires debug hooks |
+| Team scaling | Each repo owned by separate team | Single codebase, harder to partition ownership |
+| Operational complexity | High — 12 processes to deploy and monitor | Low — single `npx claude-flow` command |
+| State recovery | GitOps: `just apply-all` from YAML | SQLite WAL + restart (no GitOps equivalent) |
+| Infrastructure cost | Requires NATS, Nomad, Tailscale, Podman | Requires Node.js 20+ |
+
+**Verdict:** Odysseus trades operational simplicity for fault isolation and architectural clarity. Ruflo trades fault isolation for cognitive power and developer experience. Neither is strictly superior — they optimize for different constraints.
+
+---
+
+## 3. Orchestration Models
+
+### 3.1 Odysseus: Three-Layer REST/NATS Pipeline
+
+Odysseus has a **three-layer orchestration stack**, each layer adding expressiveness:
+
+**Layer 1 — ai-maestro `/tasks`**: Individual task dispatch. Direct REST calls. No dependency tracking at this layer.
+
+**Layer 2 — ProjectTelemachy**: Multi-step workflow orchestration. Defines named workflows as YAML that chain `/tasks` calls sequentially. Invoked via `just telemachy-run WORKFLOW=<name>`.
+
+**Layer 3 — ProjectKeystone**: Automated DAG execution. Subscribes to the `keystone-dag` durable consumer on `hi.tasks.>` NATS subjects. Maintains dependency graphs, watches task completion events, advances DAGs by calling ai-maestro `/tasks` REST API.
+
+The NATS subject schema (ADR-005) is the communication glue:
+```
+hi.agents.{host}.{name}.{verb}     # agent lifecycle events
+hi.tasks.{team_id}.{task_id}.{verb}  # task state transitions
+```
+
+**Critical property**: All orchestration state is externalizable. NATS JetStream provides durable replay; Myrmidons YAML is the desired-state record. A complete system restart can reconstruct all state from git + `just apply-all`.
+
+### 3.2 Ruflo: In-Process Swarm Coordination
+
+Ruflo's orchestration is **layered within a single runtime**:
+
+```
+QueenCoordinator      (57k lines) — strategic analysis, task decomposition
+    └── UnifiedSwarmCoordinator (54k lines) — canonical coordination engine
+            ├── TopologyManager — mesh/hierarchical/ring/star topologies
+            ├── ConsensusManager — Raft / BFT / Gossip / CRDT
+            ├── AgentPool — agent lifecycle and assignment
+            └── WorkflowEngine — dependency-aware task execution
+
+MessageBus (circular buffer deque) — targets 1000+ msgs/sec inter-agent
+FederationHub — cross-instance coordination with TTL-based ephemeral agents
+```
+
+Task routing uses a **3-tier complexity model** (ADR-026):
+
+| Tier | Handler | Latency | Use Case |
+|------|---------|---------|----------|
+| 1 | Agent Booster (WASM) | <1ms | Simple transforms — skip LLM entirely |
+| 2 | Claude Haiku | ~500ms | Low-complexity tasks (<30% complexity score) |
+| 3 | Claude Sonnet/Opus + Swarm | 2-5s | Complex reasoning, architecture (>30%) |
+
+The QueenCoordinator performs **complexity scoring** before routing, enabling intelligent tier selection. This is a capability Odysseus has no equivalent for.
+
+### 3.3 Orchestration Comparison Matrix
+
+| Property | Odysseus | Ruflo |
+|----------|----------|-------|
+| DAG dependency resolution | External (ProjectKeystone watches NATS) | In-process topological sort |
+| Task routing intelligence | None — direct REST dispatch | Q-Learning + complexity scoring |
+| Workflow definition format | YAML files (ProjectTelemachy) | TypeScript WorkflowDefinition objects |
+| Failure recovery | NATS durable consumer + at-least-once replay | In-process state + SQLite WAL |
+| Rollback support | None documented | WorkflowEngine.rollback() with onRollback callbacks |
+| Parallelism | NATS fan-out + concurrent REST calls | Promise.all over agent pool |
+| Consensus protocols | None (ai-maestro is authoritative) | Raft, BFT, Gossip, CRDT |
+| Distributed execution | Nomad across Tailscale hosts (real) | FederationHub within Node.js (simulated) |
+| Observability | NATS subjects, Grafana (ProjectArgus) | In-process event log + metrics |
+
+**Key gap in Odysseus**: No intelligent routing. Tasks go directly to ai-maestro without complexity analysis or capability matching. If a task is too complex for the assigned agent, there is no automatic re-routing.
+
+**Key gap in Ruflo**: No durable replay. If the Node.js process crashes mid-workflow, in-flight task state is lost. The SQLite WAL persists completed task memory but not execution-in-progress state.
+
+---
+
+## 4. Agent Lifecycle Management
+
+### 4.1 Odysseus: Container-per-Agent Model
+
+Agent types in Odysseus are **OCI container images**. The full lifecycle (from `docs/runbooks/add-new-agent-type.md`):
+
+```
+1. Create Dockerfile in AchaeanFleet/vessels/<agent-name>/
+   └─ LABEL ai.maestro.agent-type=<agent-name>
+2. just build-vessel <agent-name>      # Podman build → OCI image
+3. Verify: POST $MAESTRO_URL/docker/create
+4. Add YAML template to Myrmidons/_templates/<agent-name>.yaml
+5. Register in ProjectMnemosyne/marketplace.json
+6. Commit each repo + update submodule pins in Odysseus
+```
+
+Each agent type is a full container with its own filesystem, process space, and resource limits. **Strong isolation** — a buggy agent cannot corrupt another agent's memory or crash another agent's process.
+
+The agent lifecycle is observed via NATS:
+```
+hi.agents.{host}.{name}.created
+hi.agents.{host}.{name}.updated
+hi.agents.{host}.{name}.deleted
+```
+
+**Registration in ProjectMnemosyne `marketplace.json`** mirrors the HomericIntelligence ecosystem to ProjectHephaestus skills — the same catalog serves both human developers (skills/runbooks) and automated systems (Myrmidons templates).
+
+### 4.2 Ruflo: Logical-Agent Model
+
+Ruflo agents are **TypeScript objects**, not containers. From `v3/src/agent-lifecycle/domain/Agent.ts`:
+
+```typescript
+export class Agent implements IAgent {
+  public readonly id: string;
+  public readonly type: AgentType;   // 60+ types: coder, tester, reviewer, architect...
+  public status: AgentStatus;        // active | idle | busy | terminated | error
+  public capabilities: string[];
+  public role?: AgentRole;           // leader | worker | peer
+  public parent?: string;            // hierarchical parent agent
+  // ...
+  async executeTask(task: Task): Promise<TaskResult> { ... }
+}
+```
+
+Agents are spawned via CLI (`npx claude-flow agent spawn --type coder`) or MCP tools. They are logical constructs — the actual AI work is performed by whichever LLM provider is configured (Claude, GPT, Gemini, Ollama). The agent is the *routing and memory context*, not the *execution process*.
+
+**60+ agent types** are pre-defined, including:
+- Software development: `coder`, `tester`, `reviewer`, `architect`, `debugger`, `documenter`
+- Coordination: `orchestrator`, `coordinator`, `planner`
+- Specialized: `security-auditor`, `performance-optimizer`, `ux-designer`
+- Infrastructure: `devops`, `database-admin`, `ml-engineer`
+
+### 4.3 Lifecycle Comparison
+
+| Dimension | Odysseus (Container-per-Agent) | Ruflo (Logical-Agent) |
+|-----------|-------------------------------|----------------------|
+| Isolation | Full container (filesystem, process, network) | TypeScript object in shared heap |
+| Resource overhead | ~50-200MB per container (image size) | ~kilobytes per agent object |
+| Spawn time | Seconds (container pull + start) | Milliseconds (object instantiation) |
+| Max concurrent agents | Limited by host resources (~dozens) | Limited by Node.js heap (~thousands) |
+| Agent type definition | Dockerfile + LABEL + marketplace.json | TypeScript AgentConfig object |
+| Crash blast radius | One container; others unaffected | Entire Node.js process |
+| Observability per agent | Container logs, NATS events | In-process metrics, event log |
+| Agent persistence | Container state persisted by ai-maestro | Agent objects lost on process restart |
+
+**Odysseus agents** are better for: long-running, stateful agents with unpredictable resource usage, agents that need strong isolation (e.g., running untrusted code), or heterogeneous agents built in different languages.
+
+**Ruflo agents** are better for: high-volume, ephemeral task processing, tightly coordinated swarms where inter-agent communication latency matters, and use cases where spawning hundreds of agents dynamically is needed.
+
+---
+
+## 5. Task Execution and Dependency Resolution
+
+### 5.1 Odysseus: Event-Driven External DAG
+
+ProjectKeystone watches the NATS `homeric-tasks` stream with a durable consumer (`keystone-dag`). When a task completes (`hi.tasks.{team}.{task}.completed`), it checks the dependency graph and calls ai-maestro `/tasks` to advance ready successors.
+
+**Properties:**
+- Dependency graph lives outside the task engine (in ProjectKeystone's state store)
+- At-least-once delivery via NATS durable consumer — KeyStone must be idempotent
+- No complexity-based routing — all tasks dispatched identically
+- No rollback — if a task fails, the DAG stalls; human intervention required
+
+### 5.2 Ruflo: In-Process Topological Sort + Intelligence
+
+From `v3/src/task-execution/domain/Task.ts`:
+
+```typescript
+export class Task implements ITask {
+  public dependencies: string[];
+
+  areDependenciesResolved(completedTasks: Set<string>): boolean {
+    return this.dependencies.every(dep => completedTasks.has(dep));
+  }
+
+  public onExecute?: () => void | Promise<void>;
+  public onRollback?: () => void | Promise<void>;  // ← rollback support
+}
+```
+
+The WorkflowEngine combines dependency resolution with intelligent routing:
+
+1. **Topological sort** — resolves execution order, detects circular dependencies
+2. **Complexity scoring** (QueenCoordinator) — scores tasks 0-100 for routing tier selection
+3. **Capability matching** — `SwarmCoordinator.distributeTasks()` matches task type to agent capabilities
+4. **Load balancing** — assigns to agent with lowest current task load
+5. **Rollback** — on failure, `executeRollback()` invokes `onRollback` in reverse topological order
+6. **Claims API** — humans and agents compete for task ownership with contest windows
+
+**3-tier routing** means simple tasks never pay the cost of an LLM call:
+- WASM Agent Booster handles ~40% of transforms at <1ms
+- Haiku handles ~40% of simple tasks at ~500ms
+- Sonnet/Opus handles ~20% of complex tasks at 2-5s
+
+### 5.3 Task Execution Comparison
+
+| Property | Odysseus | Ruflo |
+|----------|----------|-------|
+| DAG representation | External state in ProjectKeystone | In-process Task.dependencies array |
+| Cycle detection | Unknown (ProjectKeystone implementation) | In-process topological sort |
+| Routing intelligence | None | Q-Learning + complexity scoring + capability matching |
+| Rollback | Not documented | onRollback callbacks in reverse order |
+| Parallelism | NATS fan-out + concurrent REST | Promise.all within WorkflowEngine |
+| Task priority | ai-maestro queue (unknown implementation) | TaskPriority enum (high/medium/low) |
+| Human-agent coordination | None documented | Claims API with contest windows |
+| Task persistence | ai-maestro `/tasks` (authoritative) | SQLite WAL + in-process state |
+| Failure on crash | NATS replay from durable consumer | SQLite has completed history; in-flight lost |
+
+---
+
+## 6. Memory and State Management
+
+This is the dimension where the two systems diverge most dramatically.
+
+### 6.1 Odysseus: Single External Source of Truth
+
+**ADR-004** is explicit: no HomericIntelligence repo may maintain a memory/knowledge store intended to replace ai-maestro memory. The `/memory` endpoint of ai-maestro is the only persistent memory store.
+
+Recovery path: if ai-maestro restarts, its internal database is the authoritative record. The *desired state* of the agent mesh is recoverable from git (Myrmidons YAML), but agent *memory* (what agents have learned, task histories, context) is entirely dependent on ai-maestro's persistence guarantees.
+
+NATS JetStream provides **event replay** for infrastructure events (agent/task lifecycle), but this is not semantic memory — it's an audit log.
+
+**Memory capabilities:**
+- Structured key-value store via ai-maestro `/memory`
+- No semantic/vector search
+- No learning from execution history
+- No knowledge graph
+- Recovery: GitOps for desired state, ai-maestro database for content
+
+### 6.2 Ruflo: Multi-Layer Intelligence Stack
+
+Ruflo has the most sophisticated memory architecture of the two systems, combining several layers:
+
+**Layer 1 — HybridBackend** (`v3/src/memory/infrastructure/HybridBackend.ts`):
+```
+SQLiteBackend          AgentDBAdapter (HNSW)
+─────────────────      ────────────────────────
+• Exact matches        • Vector similarity search
+• Prefix queries       • 150x-12,500x faster search
+• Complex SQL joins    • Semantic similarity
+• ACID transactions    • LRU caching
+• WAL mode             • Embeddings storage
+```
+
+**Layer 2 — Knowledge Graph**: PageRank-based importance scoring, community detection, relationship traversal between memory entries.
+
+**Layer 3 — ReasoningBank**: Stores execution trajectories and patterns. When a similar task is encountered, the bank suggests approaches that worked historically.
+
+**Layer 4 — SONA (Self-Optimizing Neural Architecture)**: Online learning from task execution. Uses EWC++ (Elastic Weight Consolidation) for continual learning without catastrophic forgetting. Adaptation latency: <0.05ms.
+
+**Layer 5 — RuVector**: 77+ SQL functions for vector operations. ~61 microsecond search latency.
+
+**3-scope memory isolation**: Project scope (shared across team) / Local scope (single agent session) / User scope (persistent across sessions), with cross-agent transfer capabilities.
+
+### 6.3 Memory Comparison
+
+| Capability | Odysseus | Ruflo |
+|------------|----------|-------|
+| Structured storage | ai-maestro `/memory` (key-value) | SQLite with full SQL |
+| Vector/semantic search | None | HNSW via AgentDB (150x-12,500x vs linear) |
+| Knowledge graph | None | PageRank + community detection |
+| Learning from history | None | ReasoningBank + SONA + EWC++ |
+| Cross-agent memory sharing | Via ai-maestro `/memory` | 3-scope isolation with transfer |
+| Recovery mechanism | ai-maestro DB + NATS event replay | SQLite WAL + restart |
+| Scope isolation | None documented | Project / Local / User scopes |
+| Search latency | Unknown (REST round-trip) | ~61 microseconds (RuVector) |
+
+**Odysseus memory gap is its largest architectural weakness.** The system has no mechanism for agents to learn from past executions, no semantic search over historical context, and no pattern recognition across task histories. Every task execution starts from scratch.
+
+**Ruflo's memory architecture is its largest strength.** The ReasoningBank + SONA combination means the system genuinely improves over time — routing decisions get smarter, patterns are recognized, and the system avoids repeating past failures.
+
+---
+
+## 7. Communication Patterns
+
+### 7.1 Odysseus: Layered Network Protocols
+
+Odysseus uses a **clear protocol hierarchy**:
+
+```
+Layer 1 — REST (synchronous control plane)
+  ai-maestro /agents, /tasks, /messages, /memory, /docker, /host-sync
+  Used by: Myrmidons, ProjectTelemachy, ProjectKeystone, ProjectScylla
+
+Layer 2 — Webhooks (async event notification)
+  ai-maestro → ProjectHermes (single HTTP POST endpoint)
+  Used by: all ai-maestro event consumers
+
+Layer 3 — NATS JetStream (durable pub/sub fan-out)
+  Subject schema: hi.agents.{host}.{name}.{verb}
+                  hi.tasks.{team_id}.{task_id}.{verb}
+  Used by: ProjectArgus, ProjectTelemachy, ProjectKeystone, ProjectScylla
+
+Layer 4 — AMP (point-to-point agent messaging)
+  ai-maestro /messages endpoint
+  Used by: agent-to-agent communication
+
+Layer 5 — Tailscale (network mesh)
+  WSL2 host-to-host connectivity
+  Used by: NATS leaf nodes, Nomad client-server, ai-maestro /host-sync
+```
+
+**Critical property**: Every layer is externally observable. NATS subjects can be monitored with `nats sub 'hi.>'`. REST calls can be logged. This makes the entire system debuggable without code changes.
+
+### 7.2 Ruflo: In-Process + MCP + Federation
+
+```
+Layer 1 — MCP (Model Context Protocol, JSON-RPC)
+  Primary external API: 215+ tools
+  Transport: stdio (default) or HTTP port 3000
+  Used by: Claude Code, Codex, human operators
+
+Layer 2 — CLI (26 commands, 140+ subcommands)
+  Human interface: npx claude-flow agent spawn ...
+  Internally calls MCP tools (ADR-005: CLI delegates to MCP)
+
+Layer 3 — In-Process EventEmitter / MessageBus
+  Circular buffer deque targeting 1000+ msgs/sec
+  Used by: SwarmCoordinator ↔ agents, WorkflowEngine events
+
+Layer 4 — Federation Hub (cross-instance)
+  Cross-swarm messaging with timeouts
+  TTL-based ephemeral agents, federation-wide consensus
+  Uses: configured transport (HTTP or WebSocket)
+
+Layer 5 — Consensus Protocols
+  Raft (leader election, log replication)
+  BFT (Byzantine Fault Tolerance)
+  Gossip (eventual consistency)
+  CRDT (conflict-free replicated data types)
+```
+
+### 7.3 Communication Comparison
+
+| Property | Odysseus | Ruflo |
+|----------|----------|-------|
+| External API | REST (ai-maestro) | MCP JSON-RPC (215+ tools) |
+| Event bus | NATS JetStream (durable, external) | In-process EventEmitter (ephemeral) |
+| Agent-to-agent | AMP via ai-maestro /messages | In-process MessageBus (<1ms) |
+| Multi-host | Tailscale mesh + NATS leaf nodes | Federation Hub (application-layer) |
+| Observability | All network-visible | In-process, requires hooks |
+| Message durability | NATS JetStream (configurable retention) | In-process only — lost on crash |
+| Throughput ceiling | Network bandwidth | Node.js single-thread throughput |
+| Consensus | None (ai-maestro is authoritative) | Raft / BFT / Gossip / CRDT |
+
+---
+
+## 8. Plugin and Extension Models
+
+### 8.1 Odysseus: Repo-per-Extension
+
+The Odysseus extension model is **git submodules as plugins**. Adding a new capability means:
+1. Create a new GitHub repository
+2. Add it as a git submodule to Odysseus
+3. Integrate via ai-maestro REST API (ADR-004)
+4. Write an ADR documenting the decision
+
+This is **coarse-grained** extension: each extension is a full repository with its own CI, dependencies, and deployment. It is **maximally isolated** — a buggy extension cannot corrupt the core. But the overhead of a full repo for each extension is high, and coordinating across many repos is operationally expensive.
+
+The **ProjectMnemosyne marketplace** (`marketplace.json`) is a catalog of agent types and skills — it enables discovery but not dynamic loading.
+
+### 8.2 Ruflo: Microkernel + IPFS Marketplace
+
+Ruflo's plugin system (ADR-004) is a **microkernel architecture**:
+
+```typescript
+abstract class BasePlugin {
+  abstract initialize(context: PluginContext): Promise<void>;
+  abstract shutdown(): Promise<void>;
+  abstract getExtensionPoints(): ExtensionPoint[];
+}
+
+// Extension points are named hooks
+// e.g., 'workflow.beforeExecute', 'workflow.afterExecute'
+// Multiple plugins can handle the same extension point, invoked by priority
+```
+
+**PluginManager** handles:
+- Dependency resolution between plugins
+- Version compatibility (`minCoreVersion`/`maxCoreVersion` enforcement)
+- Configuration validation via Zod schemas
+- Priority-ordered extension point invocation
+
+**15 domain-specific plugins** include:
+- `gastown-bridge` — WASM-accelerated bridge to Go orchestrator (formula parsing 352x, DAG ops 150x, HNSW 1000-12,500x)
+- `quantum-optimizer` — quantum-inspired optimization
+- `healthcare-clinical`, `legal-contracts`, `financial-risk` — vertical-specific workflows
+- `hyperbolic-reasoning` — Poincare ball embeddings for hierarchical reasoning
+- `neural-coordination`, `code-intelligence`, `test-intelligence` — AI-native enhancements
+
+**IPFS/Pinata plugin marketplace**: decentralized plugin registry with signed manifests, version pinning, and security audits at `/tmp/ruflo-analysis/v3/@claude-flow/cli/src/transfer/store/`.
+
+**27 hooks + 12 background workers** as additional extension points beyond plugins.
+
+### 8.3 Extension Model Comparison
+
+| Property | Odysseus (Repo-per-Extension) | Ruflo (Microkernel) |
+|----------|-------------------------------|---------------------|
+| Extension granularity | Full repository | Single plugin class |
+| Isolation | Process/container boundary | In-process (shared heap) |
+| Discovery | ProjectMnemosyne marketplace.json | IPFS plugin registry |
+| Deployment | Git submodule + separate process | npm install + plugin registration |
+| Versioning | Git SHA pinning | semver with compat range |
+| Extension points | None (REST API is the only interface) | 27 named hooks + 12 worker types |
+| Security | Process isolation | Signed manifests + sandboxing |
+| Vertical domains | None yet | 15 domain plugins |
+
+---
+
+## 9. Distributed Execution Strategies
+
+### 9.1 Odysseus: Infrastructure-Real Distribution
+
+Odysseus distribution is **real multi-host distribution** via battle-tested infrastructure components:
+
+```
+WSL2 Host A (primary)              WSL2 Host B (secondary)
+┌──────────────────────┐           ┌──────────────────────┐
+│  ai-maestro          │           │  ai-maestro (headless)│
+│  NATS server         │◄─Tailscale├  NATS leaf node      │
+│  Nomad server        │           │  Nomad client        │
+│  Podman + containers │           │  Podman + containers │
+└──────────────────────┘           └──────────────────────┘
+```
+
+From **ADR-003**: Nomad is chosen over Kubernetes specifically because single-binary simplicity matches the scale (tens of agents, handful of hosts). Tailscale provides the mesh network without CNI complexity.
+
+The `add-new-host.md` runbook describes the procedure: install ai-maestro headless, Tailscale, NATS leaf node, Nomad client. Once registered, ai-maestro's `/host-sync` makes the new host visible to the scheduler.
+
+**Disaster recovery** (`runbooks/disaster-recovery.md`): primary host down → Myrmidons `apply-all` on any surviving host reconstructs the desired agent mesh from git.
+
+### 9.2 Ruflo: Application-Simulated Distribution
+
+Ruflo's "distribution" is **application-layer simulation** within a Node.js process:
+
+**Federation Hub** (`v3/@claude-flow/swarm/src/federation-hub.ts`, 28k lines):
+- Swarm registration across multiple coordinator instances
+- Ephemeral agent spawning with TTL-based lifecycle
+- Cross-swarm messaging with configurable timeouts
+- Federation-wide consensus with configurable quorum
+- Automatic cleanup of expired agents
+
+**TopologyManager** (`topology-manager.ts`, 20k lines):
+- Supports: mesh, hierarchical, centralized, ring, star topologies
+- O(1) role-based node indexing via Map structures
+- Failover: O(log n) successor detection
+- Auto-rebalancing on topology change
+- Partitioning strategies: hash, range, round-robin
+
+**Critical limitation**: While the TopologyManager models distribution topologically, actual execution happens in a single Node.js event loop. The "Federation Hub" coordinates between coordinator *instances* which must still run in separate Node.js processes for actual distribution — there is no built-in multi-host deployment mechanism.
+
+### 9.3 Distribution Comparison
+
+| Property | Odysseus | Ruflo |
+|----------|----------|-------|
+| Multi-host mechanism | Tailscale VPN + Nomad scheduler | Federation Hub (requires separate processes) |
+| Container scheduling | Nomad (real, across hosts) | None (logical agents only) |
+| Network topology | Tailscale mesh + NATS leaf nodes | Application-modeled topology |
+| Failover | Nomad reschedule + Myrmidons recovery | O(log n) successor detection in TopologyManager |
+| Host discovery | ai-maestro /host-sync | Manual Federation Hub registration |
+| Deployment tooling | Justfile recipes + runbooks | npx claude-flow daemon start |
+| Disaster recovery | Documented runbook: full re-bootstrap | SQLite WAL + process restart |
+| Production readiness | WSL2-tested infrastructure | TypeScript prototype with WASM kernels |
+
+---
+
+## 10. Integration Points and Synergies
+
+Six concrete integration proposals, ordered from simplest to most ambitious:
+
+### 10.1 Ruflo as AchaeanFleet Vessel
+
+**Complexity:** Low | **Value:** High
+
+Package Ruflo as a Docker/Podman container in AchaeanFleet. The Ruflo process runs inside a container scheduled by Nomad, receiving tasks from ai-maestro and reporting results via REST.
+
+```dockerfile
+# AchaeanFleet/vessels/ruflo-swarm/Dockerfile
+FROM node:20-slim
+LABEL ai.maestro.agent-type=ruflo-swarm
+WORKDIR /app
+RUN npm install -g claude-flow
+ENV MAESTRO_URL=http://172.20.0.1:23000
+ENTRYPOINT ["claude-flow", "daemon", "start"]
+```
+
+The Ruflo swarm becomes a first-class HomericIntelligence agent type — discoverable via ProjectMnemosyne, schedulable via Nomad, observable via ProjectArgus.
+
+### 10.2 MCP Wrapping ai-maestro REST
+
+**Complexity:** Medium | **Value:** High
+
+Create a `@claude-flow/maestro-bridge` plugin that wraps ai-maestro's REST endpoints as MCP tools:
+
+```typescript
+// MCP tool: maestro/agent/spawn
+// Internally: POST $MAESTRO_URL/agents
+// MCP tool: maestro/task/create
+// Internally: POST $MAESTRO_URL/tasks
+// MCP tool: maestro/memory/store
+// Internally: POST $MAESTRO_URL/memory
+```
+
+This gives Ruflo's Claude Code integration access to the full HomericIntelligence ecosystem via MCP. Claude Code agents can spawn HomericIntelligence agents, create tasks, and read memory through the unified 215+ tool interface.
+
+### 10.3 NATS as Ruflo's External Event Bus
+
+**Complexity:** Medium | **Value:** Medium
+
+Replace or supplement Ruflo's in-process EventEmitter with NATS JetStream subscriptions. The FederationHub becomes a NATS subscriber/publisher:
+
+```typescript
+// FederationHub connects to NATS instead of in-process EventEmitter
+natsClient.publish('hi.tasks.ruflo-swarm.{taskId}.completed', taskResult);
+natsClient.subscribe('hi.tasks.ruflo-swarm.>', handler);
+```
+
+Benefits: Ruflo gains durable event replay (solving the crash-recovery gap), external observability (ProjectArgus can monitor Ruflo tasks), and multi-process distribution via NATS leaf nodes.
+
+### 10.4 Ruflo's Intelligence Layer for Odysseus Routing
+
+**Complexity:** High | **Value:** Very High
+
+ProjectKeystone's DAG executor currently dispatches all tasks identically to ai-maestro. Integrate Ruflo's QueenCoordinator as a routing advisor:
+
+```
+ProjectKeystone receives task-ready event via NATS
+    └── Calls Ruflo MCP tool: ruflo/task/analyze
+            └── QueenCoordinator scores complexity
+            └── ReasoningBank checks past similar tasks
+            └── Returns: tier recommendation + agent type + expected duration
+    └── ProjectKeystone routes to appropriate ai-maestro agent type
+```
+
+This would give Odysseus intelligent routing without replacing its infrastructure architecture. The Ruflo swarm becomes a co-processor for routing decisions while ai-maestro remains the authoritative task store.
+
+### 10.5 AgentDB as Advanced ai-maestro Memory Backend
+
+**Complexity:** Very High | **Value:** High
+
+Deploy an AgentDB instance as a sidecar to ai-maestro. Create a thin adapter that proxies ai-maestro `/memory` calls to AgentDB, adding vector search capabilities:
+
+```
+ai-maestro /memory/search?query=...
+    → Adapter → AgentDB HNSW search (~61μs)
+    → Returns semantically similar memories
+```
+
+This respects ADR-004 (ai-maestro remains the API surface) while adding semantic search. HomericIntelligence agents gain the ability to query memory by meaning, not just by key — enabling the ReasoningBank pattern within the Odysseus architecture.
+
+### 10.6 Shared Memory Bridge via ProjectHephaestus
+
+**Complexity:** Low | **Value:** Medium
+
+ProjectHephaestus is noted in `docs/architecture.md` as "available for future shared code (e.g., maestro-client)" and is "not yet imported by other repos."
+
+Create a `maestro-client` library in ProjectHephaestus that Ruflo's memory backend can use as a storage provider — making ai-maestro `/memory` one of Ruflo's selectable backends:
+
+```typescript
+// HybridBackend.ts backend selection
+{
+  memory: {
+    backend: 'maestro',  // New option alongside 'sqlite' | 'agentdb' | 'hybrid'
+    maestroUrl: process.env.MAESTRO_URL
+  }
+}
+```
+
+---
+
+## 11. Strengths, Weaknesses, and Complementarity
+
+### 11.1 Odysseus Strengths
+
+| Strength | Evidence |
+|----------|----------|
+| ADR governance | 5 accepted ADRs with clear context/decision/consequences; decisions are durable |
+| Fault isolation | Container-per-agent via Nomad; process-boundary separation across 12 repos |
+| Battle-tested infrastructure | NATS, Nomad, Podman, Tailscale — each production-proven at scale |
+| GitOps recovery | Full agent mesh reconstructible from Myrmidons YAML + `just apply-all` |
+| Observability | NATS subjects externally visible; REST calls loggable; Grafana via ProjectArgus |
+| Single source of truth | ADR-004 prevents split-brain scenarios by keeping ai-maestro authoritative |
+| Operational runbooks | Documented procedures for add-host, add-agent-type, disaster-recovery |
+
+### 11.2 Odysseus Weaknesses
+
+| Weakness | Impact |
+|----------|--------|
+| No intelligent routing | All tasks dispatched identically regardless of complexity or agent capability match |
+| No vector/semantic memory | Agents cannot search past executions by meaning; no learning from history |
+| High operational complexity | 12 processes (ai-maestro, NATS, Nomad, ProjectHermes, ProjectArgus, ProjectKeystone, ProjectTelemachy, containers...) |
+| Network latency on every operation | REST + webhook + NATS adds milliseconds to every coordination step |
+| No rollback mechanism | Failed DAGs stall; no automated recovery path |
+| No self-improvement | System performance is static — no mechanism for the mesh to get smarter over time |
+| No human-agent coordination | No equivalent of Ruflo's Claims API for hybrid human/agent task ownership |
+
+### 11.3 Ruflo Strengths
+
+| Strength | Evidence |
+|----------|----------|
+| AI-native intelligence | Q-Learning router, SONA, EWC++ — the system learns and adapts |
+| Rich in-process coordination | Sub-millisecond agent coordination; MessageBus targeting 1000+ msgs/sec |
+| Sophisticated memory | HNSW (150x-12,500x faster), Knowledge Graph, ReasoningBank, 3-scope isolation |
+| 3-tier task routing | WASM/Haiku/Opus tier selection prevents over-provisioning |
+| Developer experience | Single CLI, 215+ MCP tools, 60+ agent types, CLAUDE.md behavioral guide |
+| Self-improving | ReasoningBank + SONA means routing and execution improve with use |
+| Vertical domain coverage | 15 plugins cover healthcare, legal, financial, security, performance domains |
+
+### 11.4 Ruflo Weaknesses
+
+| Weakness | Impact |
+|----------|--------|
+| Single-process failure domain | One Node.js crash loses all in-flight work and all in-memory agent state |
+| No container isolation | Agent bugs can corrupt shared heap; no resource limits per agent |
+| Application-simulated distribution | FederationHub models distribution but requires manual multi-process deployment |
+| No GitOps recovery | No git-based desired-state management; recovery requires SQLite backup |
+| Opaque internal state | In-process EventEmitter not externally observable without hooks |
+| Architectural drift risk | 77+ ADRs across 3 generations of code indicates significant churn |
+| Complex surface area | 215+ MCP tools, 60+ agent types, 27 hooks, 12 workers — high cognitive load |
+
+### 11.5 Complementarity Matrix
+
+| Capability | Odysseus Alone | Ruflo Alone | Composed |
+|------------|----------------|-------------|----------|
+| Multi-host distribution | Real (Nomad + Tailscale) | Simulated | Odysseus provides infrastructure |
+| Fault isolation | Strong (containers) | Weak (shared process) | Odysseus provides isolation |
+| Intelligent routing | None | Strong (Q-Learning) | Ruflo provides intelligence |
+| Semantic memory | None | Strong (HNSW) | Ruflo provides cognition |
+| Self-improvement | None | Strong (SONA) | Ruflo provides learning |
+| GitOps recovery | Strong (Myrmidons) | None | Odysseus provides resilience |
+| Developer UX | Minimal (justfile) | Rich (CLI + MCP) | Ruflo provides interface |
+| Observability | Strong (NATS + Grafana) | Weak (in-process) | Odysseus provides visibility |
+| Vertical domains | None | 15 plugins | Ruflo provides specialization |
+
+---
+
+## 12. Conclusion and Recommendations
+
+### 12.1 The Architectural Gap
+
+Odysseus and Ruflo were designed with different threat models:
+
+- **Odysseus** fears chaos: split-brain state, unrecoverable failures, opaque distributed systems. Its countermeasures are a single authoritative platform (ai-maestro), process boundaries, durable event replay, and GitOps. The architecture optimizes for *operational clarity and recovery confidence*.
+
+- **Ruflo** fears mediocrity: dumb routing, context amnesia, agents that never get smarter. Its countermeasures are SONA, ReasoningBank, HNSW, Q-Learning, and 215+ MCP tools. The architecture optimizes for *cognitive capability and developer productivity*.
+
+Neither system addresses the other's core concern. Odysseus has no learning layer. Ruflo has no infrastructure resilience layer.
+
+### 12.2 Recommended Integration Strategy
+
+**Short term (lowest risk, immediate value):**
+
+1. **Package Ruflo as an AchaeanFleet vessel** (Integration 10.1). This immediately makes Ruflo a schedulable, observable entity within the HomericIntelligence ecosystem. Nomad provides the container isolation Ruflo lacks; Odysseus provides the GitOps recovery.
+
+2. **Add NATS connectivity to Ruflo's FederationHub** (Integration 10.3). This solves Ruflo's in-flight crash-recovery problem and makes its task events visible to ProjectArgus dashboards.
+
+**Medium term (architectural leverage):**
+
+3. **Ruflo QueenCoordinator as Odysseus routing advisor** (Integration 10.4). ProjectKeystone queries Ruflo's complexity scorer before dispatching tasks. This adds intelligence to Odysseus without changing its infrastructure architecture.
+
+4. **MCP bridge for ai-maestro REST** (Integration 10.2). Makes the full HomericIntelligence ecosystem accessible via Ruflo's 215+ MCP tool interface — Claude Code agents get a single API surface.
+
+**Long term (architectural convergence):**
+
+5. **AgentDB as ai-maestro memory backend** (Integration 10.5). Semantic search across all agent memories without changing the ADR-004 constraint.
+
+6. **ProjectHephaestus maestro-client** (Integration 10.6). Formal SharedMemory bridge that allows Ruflo backends to treat ai-maestro as a memory provider.
+
+### 12.3 What NOT to Do
+
+- **Do not merge Ruflo's coordination into Odysseus's core.** ADR-004 prohibits modifying ai-maestro; the same principle should apply to the meta-architecture. Add capabilities at the periphery, not the core.
+- **Do not port Odysseus's infrastructure to TypeScript to live inside Ruflo.** NATS, Nomad, and Tailscale are battle-tested infrastructure systems. Reimplementing them in Node.js would be a significant downgrade.
+- **Do not add Ruflo as a direct submodule dependency before establishing REST contracts.** Ruflo's API surface (215+ MCP tools) is a better integration boundary than a TypeScript import.
+
+### 12.4 Summary Verdict
+
+Odysseus is **production infrastructure** built for reliability and clarity. Ruflo is **intelligence infrastructure** built for capability and adaptability. The integration opportunity is significant: Ruflo running inside Odysseus's container mesh, receiving NATS events, using ai-maestro as its task authoritative store, while providing the routing intelligence and semantic memory that Odysseus currently lacks. Each system's strengths directly address the other's gaps.
+
+---
+
+## Appendix A: Component Mapping Table
+
+| Odysseus Component | Ruflo Equivalent | Gap |
+|-------------------|-----------------|-----|
+| ai-maestro `/agents` | SwarmCoordinator agent registry | Odysseus: container-based; Ruflo: logical objects |
+| ai-maestro `/tasks` | WorkflowEngine task queue | Odysseus: external REST; Ruflo: in-process |
+| ProjectKeystone (DAG) | WorkflowEngine dependency resolution | Ruflo has rollback; Odysseus does not |
+| ProjectTelemachy (workflows) | WorkflowEngine.executeWorkflow() | Ruflo has richer routing; Odysseus has YAML DSL |
+| ProjectHermes (NATS bridge) | In-process EventEmitter / MessageBus | Odysseus: durable external bus; Ruflo: ephemeral in-process |
+| Myrmidons (GitOps) | No equivalent | Ruflo has no GitOps desired-state management |
+| AchaeanFleet (images) | No equivalent | Ruflo has no container image management |
+| ProjectArgus (observability) | In-process metrics + CLI status | Odysseus: Grafana dashboards; Ruflo: CLI only |
+| ProjectMnemosyne (marketplace) | IPFS plugin marketplace | Both have catalogs; different granularity |
+| ProjectHephaestus (utils) | @claude-flow/shared | Both: shared utility libraries |
+| ai-maestro `/memory` | HybridBackend (SQLite + AgentDB) | Ruflo dramatically richer (vector, graph, SONA) |
+| Tailscale + Nomad | FederationHub + TopologyManager | Odysseus: real infrastructure; Ruflo: application simulation |
+| NATS JetStream | In-process EventEmitter | Odysseus: durable, external; Ruflo: ephemeral, internal |
+| ADR governance | 77+ ADR files (some overlapping) | Odysseus: 5 focused ADRs; Ruflo: 77 across 3 generations |
+
+---
+
+## Appendix B: Technology Stack Comparison
+
+| Layer | Odysseus | Ruflo |
+|-------|----------|-------|
+| Language | Shell/YAML/HCL | TypeScript + Rust (WASM) |
+| Runtime | External processes | Node.js 20+ |
+| Core platform | ai-maestro (Node.js/Next.js) | In-process SwarmCoordinator |
+| Message bus | NATS JetStream | EventEmitter / MessageBus |
+| Container runtime | Podman (rootless, daemonless) | None (logical agents) |
+| Scheduler | Nomad | None (in-process load balancing) |
+| Networking | Tailscale VPN mesh | Application-layer Federation |
+| Memory storage | ai-maestro `/memory` | SQLite + AgentDB (HNSW) |
+| Package manager | pixi (conda-forge) + npm | pnpm workspaces |
+| Task runner | just (justfile) | npx claude-flow CLI |
+| CI | yamllint only (ProjectProteus has real CI) | Vitest test suite |
+| Observability | Prometheus + Grafana (ProjectArgus) | CLI status commands |
+| LLM providers | None (ai-maestro handles externally) | Anthropic, OpenAI, Google, Cohere, Ollama |
+| Performance | Network-bound (REST + NATS) | WASM kernels (352x-12,500x speedups) |
+
+---
+
+## Appendix C: Glossary
+
+| Term | System | Definition |
+|------|--------|-----------|
+| ai-maestro | Odysseus | External core platform; agent registry, task queue, memory, messaging. Read-only from HomericIntelligence perspective. |
+| AchaeanFleet | Odysseus | Container image library — one Dockerfile per agent type ("vessel"). |
+| Myrmidons | Odysseus | GitOps desired-state manager; applies YAML manifests to ai-maestro via REST. |
+| ProjectHermes | Odysseus | Webhook receiver that translates ai-maestro events to NATS JetStream subjects. |
+| ProjectKeystone | Odysseus | DAG executor; watches NATS task events, advances dependency graphs via REST. |
+| ProjectTelemachy | Odysseus | Workflow orchestrator; chains ai-maestro /tasks calls into named workflows. |
+| ProjectArgus | Odysseus | Observability stack (Prometheus + Grafana). |
+| SwarmCoordinator | Ruflo | Central in-process coordination engine for agent swarms. |
+| QueenCoordinator | Ruflo | Strategic layer above SwarmCoordinator; complexity scoring + task decomposition. |
+| WorkflowEngine | Ruflo | Dependency-aware task execution with rollback support. |
+| FederationHub | Ruflo | Cross-swarm coordination with TTL-based ephemeral agents. |
+| HybridBackend | Ruflo | SQLite + AgentDB (HNSW) combined memory backend. |
+| ReasoningBank | Ruflo | Pattern store for execution trajectories; enables learning from history. |
+| SONA | Ruflo | Self-Optimizing Neural Architecture; online learning with EWC++. |
+| MCP | Ruflo | Model Context Protocol; JSON-RPC API surface (215+ tools). |
+| ADR | Both | Architecture Decision Record; immutable governance document. |
+| Vessel | Odysseus | AchaeanFleet term for a container image per agent type. |
+| RuVector | Ruflo | 77+ SQL functions for vector operations; ~61μs search latency. |


### PR DESCRIPTION
## Summary

- Adds `docs/odysseus-ruflo-analysis.md` — 12-section deep comparison of Odysseus vs Ruflo (ruvnet/ruflo). Covers paradigm, orchestration, agent lifecycle, memory, distribution, recovery, and 6 concrete integration proposals.
- Adds `docs/odysseus-ai-maestro-analysis.md` — 13-section audit of ai-maestro v0.26.5 internals. Maps ~100 API routes vs the 4 actually used by the ecosystem. Documents critical mismatches and unused subsystems.

## Key Findings

**Ruflo analysis:**
- Odysseus (infrastructure layer) and Ruflo (intelligence layer) are complementary — each fills the other's biggest gap
- Odysseus missing: vector memory, intelligent routing, self-improvement
- Ruflo missing: real multi-host distribution, container isolation, GitOps recovery

**ai-maestro analysis:**
- Ecosystem uses ~10% of ai-maestro's API surface (4 of ~100 endpoints)
- No task webhook events exist in ai-maestro — `hi.tasks.*` NATS pipeline mechanism unclear
- `PUT /api/teams/{id}/tasks/{id}` overwrites all fields; partial updates silently null omitted fields (issue #251)
- Memory system (CozoDB + HuggingFace embeddings + hybrid search), AMP v0.1.3, and AID v0.2.0 entirely unused
- Soft-delete by default on agent deletion

## Related Skills
- HomericIntelligence/ProjectMnemosyne#1074 — `architecture-odysseus-ruflo-comparison`
- HomericIntelligence/ProjectMnemosyne#1099 — `architecture-odysseus-ai-maestro-integration-gap`

## Test Plan
- [ ] Review reports for accuracy against current codebase
- [ ] Verify file paths and endpoint references are correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>