### PR TITLE
fix: add .gitignore, .editorconfig, CHANGELOG, fix URL casing, add Nomad comment

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,38 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.{md,markdown}]
+trim_trailing_whitespace = false
+max_line_length = off
+
+[*.{yaml,yml}]
+indent_style = space
+indent_size = 2
+
+[*.{json,toml}]
+indent_style = space
+indent_size = 2
+
+[*.{hcl,conf}]
+indent_style = space
+indent_size = 2
+
+[justfile]
+indent_style = space
+indent_size = 4
+
+[Makefile]
+indent_style = tab
+
+[*.{cpp,hpp,h,c}]
+indent_style = space
+indent_size = 4
+
+[*.py]
+indent_style = space
+indent_size = 4

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,40 @@
+# Build outputs
+build/
+dist/
+*.o
+*.a
+*.so
+*.dylib
+
+# pixi environments
+.pixi/
+pixi.lock
+
+# CMake
+CMakeCache.txt
+CMakeFiles/
+cmake_install.cmake
+Makefile
+
+# Python
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+.venv/
+*.egg-info/
+
+# IDE and editor files
+.idea/
+.vscode/
+*.swp
+*.swo
+*~
+.DS_Store
+
+# Logs
+*.log
+
+# Temporary files
+*.tmp
+*.bak

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,64 @@
+# Changelog
+
+All notable changes to Odysseus are documented here.
+Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+
+---
+
+## [Unreleased]
+
+---
+
+## [0.4.0] - 2026-03-29
+
+### Changed
+- Rewrote `docs/architecture.md` to reflect post-ADR-006 state: ai-maestro removed as active
+  component, ProjectAgamemnon + ProjectNestor + ProjectCharybdis documented with accurate roles,
+  Keystone transport layer detailed, NATS subject schema table added.
+- Updated `CLAUDE.md` structure tree: added ADR-005 and ADR-006, refreshed submodule descriptions.
+- Updated runbooks to replace all ai-maestro references with Agamemnon equivalents.
+
+### Added
+- ADR-006: Decouple from ai-maestro (full migration rationale and decisions).
+- Submodules: `control/ProjectAgamemnon`, `control/ProjectNestor`, `testing/ProjectCharybdis`.
+- Architectural analysis reports: `docs/odysseus-ruflo-analysis.md`, `docs/odysseus-ai-maestro-analysis.md`.
+
+### Removed
+- `infrastructure/ai-maestro` submodule removed per ADR-006.
+
+---
+
+## [0.3.0] - 2026-03-27
+
+### Added
+- `.claude/settings.json`: enable `hephaestus@ProjectHephaestus` plugin for Claude Code sessions.
+
+---
+
+## [0.2.0] - 2026-03-23
+
+### Added
+- `.github/workflows/ci.yml`: CI workflow that validates YAML/JSON in `configs/` on every push and PR.
+
+---
+
+## [0.1.1] - 2026-03-16
+
+### Fixed
+- Corrected ProjectKeystone and ProjectHephaestus documentation.
+- Documented NATS subject schema.
+- Added justfile recipes for infrastructure and provisioning services.
+
+---
+
+## [0.1.0] - 2026-03-15
+
+### Added
+- Initial Odysseus meta-repo scaffold.
+- Architecture Decision Records: ADR-001 through ADR-005.
+- Runbooks: add-new-host, add-new-agent-type, disaster-recovery.
+- Nomad configs: `configs/nomad/client.hcl`, `configs/nomad/server.hcl`.
+- NATS configs: `configs/nats/server.conf`, `configs/nats/leaf.conf`.
+- `justfile` with bootstrap, status, apply-all, and service-start recipes.
+- `pixi.toml` with `just` dependency.
+- Local dev symlinks for all submodule paths (dev convenience, not portable).

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Odysseus serves as the single source of truth for:
 ## Quick Start
 
 ```bash
-git clone --recurse-submodules https://github.com/homeric-intelligence/Odysseus.git
+git clone --recurse-submodules https://github.com/HomericIntelligence/Odysseus.git
 cd Odysseus
 just bootstrap
 ```
@@ -35,7 +35,7 @@ Odysseus/
 ├── configs/
 │   ├── nomad/                # Nomad client/server HCL configs
 │   └── nats/                 # NATS server and leaf node configs
-├── infrastructure/           # Submodules: ai-maestro (deprecated, see ADR-006), AchaeanFleet, ProjectArgus, ProjectHermes
+├── infrastructure/           # Submodules: AchaeanFleet, ProjectArgus, ProjectHermes
 ├── provisioning/             # Submodules: ProjectTelemachy, ProjectKeystone, Myrmidons
 ├── ci-cd/                    # Submodules: ProjectProteus
 ├── research/                 # Submodules: ProjectOdyssey, ProjectScylla
@@ -58,5 +58,6 @@ Odysseus/
 
 ## Important Notes
 
-- **`infrastructure/ai-maestro` is deprecated per ADR-006.** The submodule is pinned for backward compatibility only and will be removed once all dependents are migrated to ProjectAgamemnon. Do not add new integrations against ai-maestro.
-- All new task coordination features use ProjectAgamemnon (`control/ProjectAgamemnon`, REST API at `$AGAMEMNON_URL`).
+- **ai-maestro has been removed per ADR-006.** All task coordination uses ProjectAgamemnon (`control/ProjectAgamemnon`, REST API at `$AGAMEMNON_URL`).
+- See [docs/architecture.md](docs/architecture.md) for the current system architecture.
+- See [docs/adr/](docs/adr/) for Architecture Decision Records.

--- a/configs/nomad/client.hcl
+++ b/configs/nomad/client.hcl
@@ -8,6 +8,11 @@ client {
   servers = ["172.20.0.1:4647"]
 }
 
+# Nomad uses the Docker driver with the podman-docker shim (per ADR-001).
+# The podman-docker shim exposes a Docker-compatible socket at
+# /run/user/<UID>/podman/podman.sock or /run/podman/podman.sock.
+# Nomad communicates with Podman exclusively through this shim;
+# no Docker daemon is installed or required.
 plugin "docker" {
   config {
     allow_privileged = false

--- a/docs/runbooks/disaster-recovery.md
+++ b/docs/runbooks/disaster-recovery.md
@@ -147,7 +147,7 @@ Use this when setting up a net-new replacement for a completely lost host with n
 
 ```bash
 # 1. Clone Odysseus with all submodules
-git clone --recurse-submodules https://github.com/homeric-intelligence/Odysseus.git
+git clone --recurse-submodules https://github.com/HomericIntelligence/Odysseus.git
 cd Odysseus
 
 # 2. Install pixi and just


### PR DESCRIPTION
## Summary

- Add `.gitignore` — build/, .pixi/, IDE files, Python artifacts
- Add `.editorconfig` — LF line endings, per-filetype indentation rules
- Add `CHANGELOG.md` — Keep a Changelog format, covers v0.1.0–v0.4.0
- Fix clone URL casing in README.md and disaster-recovery.md runbook (`homeric-intelligence` → `HomericIntelligence`)
- Add Podman shim comment to `configs/nomad/client.hcl` explaining why the Docker plugin is used
- Update README: remove stale ai-maestro reference in layout section, refresh Important Notes

## Issues Closed

Closes #23, #37, #29, #51, #19, #10

## Test plan

- [ ] Verify `.gitignore` has no syntax errors (`git check-ignore -v` on a `.pixi/` path)
- [ ] Verify `.editorconfig` parseable by editors
- [ ] Verify README clone URL is `HomericIntelligence/Odysseus.git`
- [ ] Verify disaster-recovery runbook clone URL is `HomericIntelligence/Odysseus.git`
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)