### PR TITLE
fix(ci): stop silently swallowing yamllint failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,4 +20,4 @@ jobs:
       - name: Lint YAML configs
         run: |
           find configs/ -name '*.yml' -o -name '*.yaml' -o -name '*.json' | sort
-          find configs/ -name '*.yml' -o -name '*.yaml' | xargs yamllint -d "{extends: default, rules: {line-length: {max: 200}, truthy: disable, document-start: disable}}" || true
+          find configs/ -name '*.yml' -o -name '*.yaml' | xargs --no-run-if-empty yamllint -d "{extends: default, rules: {line-length: {max: 200}, truthy: disable, document-start: disable}}"


### PR DESCRIPTION
## Summary
- Remove `|| true` from yamllint step so lint failures actually break the build
- Add `--no-run-if-empty` to xargs to handle the case where `configs/` has no YAML files

## Test plan
- [ ] CI workflow passes (configs/ has no YAML files, so yamllint is not invoked)
- [ ] If a YAML file with errors is added to configs/, CI would now correctly fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)