### PR TITLE
fix: rename deprecated [project] to [workspace] in pixi.toml

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -1,4 +1,4 @@
-[project]
+[workspace]
 name = "odysseus"
 version = "0.1.0"
 description = "Meta-repo and unified architecture hub for the HomericIntelligence distributed agent mesh"


### PR DESCRIPTION
Closes #79

## Summary
- Renames `[project]` to `[workspace]` in `pixi.toml` (1-line change)
- Suppresses the pixi 0.65.0+ deprecation warning emitted on every `pixi run` invocation

## Test plan
- [x] `pixi run just bootstrap` — no deprecation warning
- [x] `pixi install --locked` — resolves without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)