### PR TITLE
fix: doctor podman socket install handles missing systemd units

### DIFF
--- a/e2e/doctor.sh
+++ b/e2e/doctor.sh
@@ -234,6 +234,32 @@ if should_check_worker; then
             # SSH sessions and sudo strip these, breaking systemctl --user.
             export XDG_RUNTIME_DIR="${XDG_RUNTIME_DIR:-/run/user/$(id -u)}"
             export DBUS_SESSION_BUS_ADDRESS="${DBUS_SESSION_BUS_ADDRESS:-unix:path=${XDG_RUNTIME_DIR}/bus}"
+
+            # If the unit file doesn't exist (podman built from source), install it first.
+            if ! systemctl --user cat podman.socket &>/dev/null; then
+                PODMAN_SRC_UNIT=$(ls ~/.local/src/podman-*/contrib/systemd/user/podman.socket \
+                                     /usr/local/src/podman-*/contrib/systemd/user/podman.socket \
+                                     2>/dev/null | head -1)
+                PODMAN_SRC_SERVICE=$(ls ~/.local/src/podman-*/contrib/systemd/user/podman.service.in \
+                                        /usr/local/src/podman-*/contrib/systemd/user/podman.service.in \
+                                        2>/dev/null | head -1)
+                if [[ -n "$PODMAN_SRC_UNIT" ]]; then
+                    mkdir -p ~/.config/systemd/user
+                    cp "$PODMAN_SRC_UNIT" ~/.config/systemd/user/podman.socket
+                    if [[ -n "$PODMAN_SRC_SERVICE" ]]; then
+                        PODMAN_BIN=$(command -v podman)
+                        sed "s|@@PODMAN@@|${PODMAN_BIN}|g" "$PODMAN_SRC_SERVICE" \
+                            > ~/.config/systemd/user/podman.service
+                    fi
+                    systemctl --user daemon-reload
+                else
+                    check_warn "podman socket — unit files not found (podman built from source?)"
+                    echo -e "    ${DIM}Install unit files manually from your podman source tree:${NC}"
+                    echo -e "    ${DIM}  cp <src>/contrib/systemd/user/podman.socket ~/.config/systemd/user/${NC}"
+                    echo -e "    ${DIM}  systemctl --user daemon-reload${NC}"
+                fi
+            fi
+
             if systemctl --user enable --now podman.socket 2>/dev/null; then
                 check_pass "podman socket enabled"
             else


### PR DESCRIPTION
Closes #85

## Summary
- Detects when `podman.socket` unit is missing (podman built from source)
- Searches for unit files in `~/.local/src/podman-*/` and `/usr/local/src/podman-*/`
- Installs `podman.socket` and generates `podman.service` (processing the `.service.in` template to substitute `@@PODMAN@@` with the actual binary path)
- Reloads daemon and enables socket
- Falls back to actionable diagnostic if source tree not found
- Builds on PR #82 (SSH/DBUS env var handling)

## Test plan
- [x] `just doctor --role worker --install` — installs units and enables socket
- [x] `systemctl --user is-active podman.socket` → `active`
- [x] Socket file exists at `$XDG_RUNTIME_DIR/podman/podman.sock`

🤖 Generated with [Claude Code](https://claude.com/claude-code)