### PR TITLE
feat(e2e): fix myrmidon pipeline agents, add ADR-007, inline console

### DIFF
--- a/docs/adr/007-symlinks-over-submodules.md
+++ b/docs/adr/007-symlinks-over-submodules.md
@@ -1,0 +1,94 @@
+# ADR 007: Replace Symlinks with Real Git Submodules
+
+**Status:** Proposed
+
+---
+
+## Context
+
+Odysseus is the meta-repo for the HomericIntelligence ecosystem. It declares 15 submodule entries in `.gitmodules`, each with a proper GitHub URL under `https://github.com/HomericIntelligence/`. However, 12 of those 15 entries are actually symlinks (git mode `120000`) pointing to absolute local paths on the original developer's machine (under `/home/mvillmow/`), not real git submodule gitlinks.
+
+The 12 symlinked paths are:
+
+- `infrastructure/AchaeanFleet` → `/home/mvillmow/AchaeanFleet`
+- `infrastructure/ProjectArgus` → `/home/mvillmow/ProjectArgus`
+- `infrastructure/ProjectHermes` → `/home/mvillmow/ProjectHermes`
+- `provisioning/ProjectTelemachy` → `/home/mvillmow/ProjectTelemachy`
+- `provisioning/ProjectKeystone` → `/home/mvillmow/ProjectKeystone`
+- `provisioning/Myrmidons` → `/home/mvillmow/Myrmidons`
+- `ci-cd/ProjectProteus` → `/home/mvillmow/ProjectProteus`
+- `research/ProjectOdyssey` → `/home/mvillmow/ProjectOdyssey`
+- `research/ProjectScylla` → `/home/mvillmow/ProjectScylla`
+- `shared/ProjectMnemosyne` → `/home/mvillmow/ProjectMnemosyne`
+- `shared/ProjectHephaestus` → `/home/mvillmow/ProjectHephaestus`
+
+Only 3 of the 15 are proper gitlinks (git mode `160000`), functioning as real submodules:
+
+- `control/ProjectAgamemnon`
+- `control/ProjectNestor`
+- `testing/ProjectCharybdis`
+
+This happened because the original developer used symlinks for convenience during initial local development — changes in the local repo checkouts were instantly visible under Odysseus without any submodule update ceremony.
+
+This approach breaks multiple critical workflows:
+
+1. **Cloning:** `git clone --recurse-submodules` cannot resolve absolute paths to another machine's filesystem. A fresh clone produces broken symlinks for 12 of 15 components.
+2. **CI/CD:** Containers and CI runners do not have `/home/mvillmow/` on their filesystem. Any pipeline that depends on submodule content fails silently or errors out.
+3. **Onboarding:** New developers cannot bootstrap the ecosystem from a single `git clone`. They must manually discover and clone each repo, then recreate the symlinks.
+4. **Disaster recovery:** The repository cannot be fully reconstituted from GitHub alone. Losing the original developer's machine means losing the ability to resolve 12 of the 15 component paths.
+
+The three already-correct gitlinks (ProjectAgamemnon, ProjectNestor, ProjectCharybdis) prove that the real submodule model works and can coexist with the rest of the ecosystem.
+
+## Decision
+
+Convert all 12 symlinks to real git submodule gitlinks. The conversion workflow for each symlink is:
+
+```bash
+git rm <symlink-path>
+git submodule add <github-url> <path>
+git -C <path> checkout main
+```
+
+After conversion, all 15 entries will be proper gitlinks (mode `160000`), and `git ls-files -s` will show no remaining `120000` entries under the submodule paths.
+
+### Why submodules over symlinks
+
+- **Portability:** `git clone --recurse-submodules` works on any machine, any OS, any CI runner — no host-specific paths required.
+- **CI/CD compatibility:** Pipelines can initialize submodules with standard git commands. No assumptions about the host filesystem.
+- **Disaster recovery:** The entire ecosystem is reconstitutable from GitHub. Every component is referenced by URL and pinned by SHA in Odysseus.
+- **Git-native tooling:** `git submodule update`, `git diff --submodule`, `git submodule status`, and IDE integrations all work correctly with real gitlinks. They do not work with symlinks.
+
+### How myrmidons work with submodules
+
+Myrmidon workers operate within individual repo worktrees, not the Odysseus meta-repo. A myrmidon receives a task scoped to a specific repository (e.g., ProjectArgus), clones or checks out that repo, performs its work, and reports results back through Agamemnon. The submodule relationship in Odysseus is for coordination and integration pinning, not for myrmidon task execution.
+
+### How worktrees work with submodules
+
+`git worktree add` creates an isolated working copy of Odysseus. Within that worktree, submodules are initialized via `git submodule update --init` to get a self-contained copy of the full ecosystem. Each worktree can independently track different submodule SHAs without interfering with other worktrees or the main checkout.
+
+### How sub-agents work with submodules
+
+Each Claude Code sub-agent is launched with `isolation: "worktree"` for safe parallel work. Agents operate within a single submodule repo, not across the full Odysseus tree. This isolation ensures that concurrent agents modifying different repos cannot conflict with each other or with the developer's main working copy.
+
+### Task scoping principle
+
+All implementation work happens in individual submodule repos. Odysseus coordinates; repos execute. Cross-cutting changes that span multiple repos are decomposed into per-repo sub-tasks by ProjectAgamemnon, each dispatched to a myrmidon or sub-agent operating within the relevant repo's worktree.
+
+## Consequences
+
+**Positive:**
+- `git clone --recurse-submodules` works out of the box on any machine.
+- CI/CD pipelines and containers work without host-specific path assumptions.
+- New developers and agents onboard with a single clone command.
+- Disaster recovery is possible: the entire ecosystem is reconstitutable from GitHub alone.
+- Submodule SHAs in Odysseus serve as a cross-repo integration checkpoint — a known-good configuration of the full ecosystem at a point in time.
+
+**Negative:**
+- Developers on the original host lose the convenience of symlinked local edits being instantly visible in Odysseus. Changes in a submodule repo must be committed there, then the submodule pin in Odysseus updated with a separate commit.
+- `git submodule update` adds a step after pulling Odysseus. Developers must run `git submodule update --init --recursive` or use `git pull --recurse-submodules` to stay current.
+- Submodule pin updates require an explicit commit in Odysseus after changes land in submodule repos. This is intentional (pins represent integration checkpoints) but adds friction.
+
+**Neutral:**
+- The `.gitmodules` file requires no changes. All 15 entries already have correct GitHub URLs pointing to `https://github.com/HomericIntelligence/<RepoName>.git`.
+- The three already-correct gitlinks (ProjectAgamemnon, ProjectNestor, ProjectCharybdis) require no action.
+- Odysseus remains a coordination-only meta-repo with no application code. This ADR reinforces that role.

--- a/e2e/claude-myrmidon.py
+++ b/e2e/claude-myrmidon.py
@@ -41,6 +41,11 @@ MAX_ITERATIONS = int(os.environ.get("MAX_ITERATIONS", "5"))
 DRY_RUN = os.environ.get("DRY_RUN", "0") == "1"
 NO_GITHUB = os.environ.get("NO_GITHUB", "0") == "1"
 
+# Container configuration — claude CLI always runs inside the achaean-claude vessel
+CLAUDE_IMAGE = os.environ.get("CLAUDE_IMAGE", "achaean-claude:latest")
+CONTAINER_WORKSPACE = "/workspace"
+CONTAINER_RUNTIME = os.environ.get("CONTAINER_RUNTIME", "podman")
+
 STREAM_NAME = "homeric-myrmidon"
 LOG_SUBJECT = "hi.logs.myrmidon.claude"
 
@@ -182,9 +187,33 @@ def _get_session_id(task_id: str, stage: str) -> str:
     return _session_ids[key]
 
 
+def _build_container_cmd(claude_args: list[str], cwd: str = WORKING_DIR) -> list[str]:
+    """Build a container run command with proper volume mappings.
+
+    Maps the host WORKING_DIR to /workspace inside the achaean-claude container,
+    plus the user's .claude config and ANTHROPIC_API_KEY for authentication.
+    """
+    home = os.path.expanduser("~")
+    cmd = [
+        CONTAINER_RUNTIME, "run", "--rm",
+        "--network", "homeric-mesh",
+        "-v", f"{cwd}:{CONTAINER_WORKSPACE}",
+        "-v", f"{home}/.claude:{home}/.claude",
+        "-w", CONTAINER_WORKSPACE,
+        "-e", f"ANTHROPIC_API_KEY={os.environ.get('ANTHROPIC_API_KEY', '')}",
+        "-e", f"HOME={home}",
+        CLAUDE_IMAGE,
+    ]
+    cmd.extend(claude_args)
+    return cmd
+
+
 def invoke_claude(prompt: str, cwd: str = WORKING_DIR, stage: str = "",
                   iteration: int = 0, task_id: str = "") -> str:
-    """Invoke Claude Code CLI. Resumes the same session for iterations > 0."""
+    """Invoke Claude Code CLI inside the achaean-claude container.
+
+    Resumes the same session for iterations > 0.
+    """
     if DRY_RUN:
         log("claude", f"[DRY-RUN] Skipping claude -p ({len(prompt)} chars)")
         return mock_claude_response(stage, iteration)
@@ -192,30 +221,27 @@ def invoke_claude(prompt: str, cwd: str = WORKING_DIR, stage: str = "",
     session_id = _get_session_id(task_id, stage) if task_id else ""
     is_resume = iteration > 0 and session_id
 
+    claude_args = [
+        "claude", "-p", prompt,
+        "--permission-mode", "acceptEdits",
+        "--allowedTools", "Bash,Read,Write,Edit,Glob,Grep",
+    ]
+
     if is_resume:
         log("claude", f"Resuming session {session_id[:8]}... ({len(prompt)} chars)")
-        cmd = [
-            "claude", "-p", prompt,
-            "--resume", session_id,
-            "--permission-mode", "acceptEdits",
-            "--allowedTools", "Bash,Read,Write,Edit,Glob,Grep",
-        ]
+        claude_args.extend(["--resume", session_id])
     else:
         log("claude", f"Starting new session ({len(prompt)} chars)")
-        cmd = [
-            "claude", "-p", prompt,
-            "--permission-mode", "acceptEdits",
-            "--allowedTools", "Bash,Read,Write,Edit,Glob,Grep",
-        ]
         if session_id:
-            cmd.extend(["--session-id", session_id])
+            claude_args.extend(["--session-id", session_id])
+
+    cmd = _build_container_cmd(claude_args, cwd=cwd)
 
     try:
         result = subprocess.run(
             cmd,
             capture_output=True,
             text=True,
-            cwd=cwd,
             stdin=subprocess.DEVNULL,
             timeout=600,  # 10 minute timeout per stage
         )
@@ -232,17 +258,61 @@ def invoke_claude(prompt: str, cwd: str = WORKING_DIR, stage: str = "",
         log("claude", f"{RED}Timed out after 600s{NC}")
         return "ERROR: Claude invocation timed out after 10 minutes"
     except FileNotFoundError:
-        log("claude", f"{RED}claude CLI not found in PATH{NC}")
-        return "ERROR: claude CLI not found"
+        log("claude", f"{RED}{CONTAINER_RUNTIME} not found in PATH{NC}")
+        return f"ERROR: {CONTAINER_RUNTIME} not found"
 
 
 # ─── GitHub Issue Comments ───────────────────────────────────────────────────
 # Track comment IDs so we can edit-in-place instead of creating duplicates
 _comment_ids: dict[str, int] = {}  # key: "stage-iteration" → GitHub comment ID
+_comment_ids_loaded: set[int] = set()  # issue numbers already scanned
 
 
 def _comment_key(stage: str, iteration: int) -> str:
     return f"{stage}-{iteration}"
+
+
+def _load_existing_comment_ids(issue_number: int):
+    """Fetch existing issue comments and populate _comment_ids for deduplication.
+
+    Parses each comment body for '## Stage: STAGE (iteration N)' headers.
+    Called lazily on first post_issue_comment per issue. Survives process restarts.
+    """
+    if issue_number in _comment_ids_loaded:
+        return
+    _comment_ids_loaded.add(issue_number)
+
+    try:
+        result = subprocess.run(
+            ["gh", "api", "--paginate",
+             f"repos/{REPO}/issues/{issue_number}/comments",
+             "--jq", r'.[] | "\(.id)\t\(.body[0:80])"'],
+            capture_output=True, text=True, stdin=subprocess.DEVNULL, timeout=30,
+        )
+        if result.returncode != 0:
+            log("github", f"{YELLOW}Failed to load existing comments: {result.stderr[:200]}{NC}")
+            return
+
+        import re
+        pattern = re.compile(r"## Stage: (\w+)(?:\s+\(iteration (\d+)\))?")
+        for line in result.stdout.strip().splitlines():
+            parts = line.split("\t", 1)
+            if len(parts) < 2:
+                continue
+            comment_id_str, body_prefix = parts
+            if not comment_id_str.isdigit():
+                continue
+            m = pattern.search(body_prefix)
+            if m:
+                stage_name = m.group(1).lower()
+                iteration_num = int(m.group(2)) if m.group(2) else 0
+                key = _comment_key(stage_name, iteration_num)
+                _comment_ids[key] = int(comment_id_str)
+
+        if _comment_ids:
+            log("github", f"Loaded {len(_comment_ids)} existing comment(s) for issue #{issue_number}")
+    except Exception as e:
+        log("github", f"{YELLOW}Could not load existing comments: {e}{NC}")
 
 
 def post_issue_comment(issue_number: int, stage: str, iteration: int, content: str):
@@ -253,6 +323,8 @@ def post_issue_comment(issue_number: int, stage: str, iteration: int, content: s
     if NO_GITHUB:
         log(stage, f"[NO_GITHUB] Would post to issue #{issue_number} ({len(content)} chars)")
         return
+
+    _load_existing_comment_ids(issue_number)
 
     header = f"## Stage: {stage.upper()}"
     if iteration > 0:
@@ -704,6 +776,8 @@ async def main():
     print(f"{BOLD}╠══════════════════════════════════════════════════════╣{NC}")
     print(f"{BOLD}║{NC}  NATS: {NATS_URL}")
     print(f"{BOLD}║{NC}  Mode: {'DRY-RUN' if DRY_RUN else 'LIVE'} | GitHub: {'DISABLED' if NO_GITHUB else 'ENABLED'}")
+    print(f"{BOLD}║{NC}  Container: {CLAUDE_IMAGE} via {CONTAINER_RUNTIME}")
+    print(f"{BOLD}║{NC}  Workspace: {WORKING_DIR} → {CONTAINER_WORKSPACE}")
     print(f"{BOLD}║{NC}  Stages: plan → test → implement → review → ship")
     print(f"{BOLD}║{NC}  Max iterations: {MAX_ITERATIONS}")
     print(f"{BOLD}╚══════════════════════════════════════════════════════╝{NC}")

--- a/e2e/test-adr-007.sh
+++ b/e2e/test-adr-007.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# ADR-007 Validation Script
+# Runs ~45 checks across 7 acceptance criteria against docs/adr/007-symlinks-over-submodules.md
+
+ADR_FILE="docs/adr/007-symlinks-over-submodules.md"
+PASS_COUNT=0
+FAIL_COUNT=0
+
+pass() { PASS_COUNT=$((PASS_COUNT + 1)); echo "  PASS: $1"; }
+fail() { FAIL_COUNT=$((FAIL_COUNT + 1)); echo "  FAIL: $1"; }
+
+check() {
+    local desc="$1"; shift
+    if "$@" >/dev/null 2>&1; then pass "$desc"; else fail "$desc"; fi
+}
+
+check_grep() {
+    local desc="$1"; local pattern="$2"
+    if grep -qiE "$pattern" "$ADR_FILE" 2>/dev/null; then pass "$desc"; else fail "$desc"; fi
+}
+
+# ═════════════════════════���═══════════════════════════════════���═════
+echo "=== Criterion 1: File existence ==="
+# ═══════════════════════════════════════════════════════════════════
+
+if [ ! -f "$ADR_FILE" ]; then
+    fail "File exists at $ADR_FILE"
+    echo ""
+    echo "FATAL: ADR file not found. Cannot continue."
+    echo "Result: 0 passed, 1 failed"
+    exit 1
+fi
+pass "File exists at $ADR_FILE"
+
+# ═══════════════════════════════════════════════════════════════════
+echo "=== Criterion 2: Status field ==="
+# ═══════════════════════════════════════════════════════════════════
+
+check_grep "Status field is present" '^\*\*Status:\*\*'
+check_grep "Status is Proposed or Accepted" '^\*\*Status:\*\* (Proposed|Accepted)'
+
+# ═══════════════════════════════════════════════════════════════════
+echo "=== Criterion 3: Context content ==="
+# ═══════════════════════════════════════════════════════════════════
+
+check_grep "Mentions 15 submodule entries" '15.*(submodule|entries|submodules)'
+check_grep "Mentions 12 are symlinks" '12.*(symlink|symlinks|mode.*120000)'
+check_grep "Mentions 3 are real gitlinks" '3.*(gitlink|real|mode.*160000|proper)'
+check_grep "Mentions cloning is broken" '[Cc]lon(e|ing)'
+check_grep "Mentions CI/CD is broken" 'CI(/|-)CD'
+check_grep "Mentions onboarding is broken" '[Oo]nboard'
+check_grep "Mentions disaster recovery" '[Dd]isaster.*(recovery|recoverable)'
+check_grep "Mentions absolute local paths" '(absolute|local).*(path|director)'
+
+# ═══════════════════════════════════════════════════════════════════
+echo "=== Criterion 4: Decision content ==="
+# ═══════════════════════════════════════════════════════════════════
+
+check_grep "Documents conversion workflow (git rm + submodule add)" 'git rm|git submodule add'
+check_grep "Portability rationale" '[Pp]ortab(le|ility)'
+check_grep "Covers myrmidons with submodules" '[Mm]yrmidon'
+check_grep "Covers worktrees with submodules" '[Ww]orktree'
+check_grep "Covers sub-agents with submodules" '[Ss]ub.agent|[Cc]laude.*(Code|agent)|isolation.*worktree'
+check_grep "Task scoping principle documented" '[Tt]ask.*(scop|priorit)|[Rr]epo.*(level|execute)|Odysseus.*coordinate'
+
+# ═══════════════════════════════════════════════════════════════════
+echo "=== Criterion 5: Consequences ==="
+# ═══════════════════════════════════════════════════════════════════
+
+check_grep "Positive: clone works" '[Pp]ositive|clone.*works|out of the box'
+check_grep "Positive: CI/CD works" 'CI.*pipeline|pipeline.*work|container.*work'
+check_grep "Positive: onboarding works" 'onboard|single clone'
+check_grep "Positive: disaster recovery" 'reconstit|disaster|recoverable'
+check_grep "Negative: lost symlink convenience" 'convenience|symlinked.*local|lose'
+check_grep "Negative: extra update step" 'submodule update|extra.*step|additional.*step'
+check_grep "Neutral section has substance" '^\*\*Neutral:\*\*'
+
+# ═══════════════════════════════════════════════════════════════════
+echo "=== Criterion 6: Format compliance ==="
+# ═══════════════════════════════════════════════════════════════════
+
+# H1 title with ADR number
+LINE1=$(head -1 "$ADR_FILE")
+if echo "$LINE1" | grep -qE '^# ADR 007:'; then pass "H1 title starts with '# ADR 007:'"; else fail "H1 title starts with '# ADR 007:'"; fi
+
+# Title is on line 1
+if [ "$(sed -n '1p' "$ADR_FILE" | grep -c '^# ')" -eq 1 ]; then pass "Title is on line 1"; else fail "Title is on line 1"; fi
+
+# Status near top (within first 5 lines)
+if head -5 "$ADR_FILE" | grep -qE '^\*\*Status:\*\*'; then pass "Status within first 5 lines"; else fail "Status within first 5 lines"; fi
+
+# Horizontal rule divider
+check_grep "Horizontal rule divider present" '^---$'
+
+# H2 Context section
+check_grep "H2 Context section exists" '^## Context'
+
+# H2 Decision section
+check_grep "H2 Decision section exists" '^## Decision'
+
+# H2 Consequences section
+check_grep "H2 Consequences section exists" '^## Consequences'
+
+# Section order: Context before Decision before Consequences
+CTX_LINE=$(grep -n '^## Context' "$ADR_FILE" | head -1 | cut -d: -f1)
+DEC_LINE=$(grep -n '^## Decision' "$ADR_FILE" | head -1 | cut -d: -f1)
+CON_LINE=$(grep -n '^## Consequences' "$ADR_FILE" | head -1 | cut -d: -f1)
+if [ -n "$CTX_LINE" ] && [ -n "$DEC_LINE" ] && [ -n "$CON_LINE" ] && \
+   [ "$CTX_LINE" -lt "$DEC_LINE" ] && [ "$DEC_LINE" -lt "$CON_LINE" ]; then
+    pass "Section order: Context < Decision < Consequences"
+else
+    fail "Section order: Context < Decision < Consequences"
+fi
+
+# Positive/Negative/Neutral subsection headers
+check_grep "Positive subsection header" '^\*\*Positive:\*\*'
+check_grep "Negative subsection header" '^\*\*Negative:\*\*'
+check_grep "Neutral subsection header" '^\*\*Neutral:\*\*'
+
+# ═══════════════════════════════════════════════════════════════════
+echo "=== Criterion 7: Factual accuracy ==="
+# ═══════════════════════════════════════════════════════════════════
+
+check_grep "Mentions 15 total submodules" '15'
+check_grep "Mentions 12 symlinks" '12'
+check_grep "Mentions 3 gitlinks" '\b3\b.*(gitlink|real|proper|correct)'
+
+# Check for specific symlinked repo names
+check_grep "Mentions AchaeanFleet" 'AchaeanFleet'
+check_grep "Mentions ProjectArgus" 'ProjectArgus'
+check_grep "Mentions ProjectHermes" 'ProjectHermes'
+check_grep "Mentions ProjectScylla" 'ProjectScylla'
+check_grep "Mentions ProjectHephaestus" 'ProjectHephaestus'
+
+# Check for the 3 gitlink repos
+check_grep "Mentions ProjectAgamemnon as gitlink" 'ProjectAgamemnon'
+check_grep "Mentions ProjectNestor as gitlink" 'ProjectNestor'
+check_grep "Mentions ProjectCharybdis as gitlink" 'ProjectCharybdis'
+
+# .gitmodules note
+check_grep "Notes .gitmodules URLs are correct" '\.gitmodules.*(no change|correct|already|require.*no)'
+
+# ═══════════════════════════════════════════════════════════════════
+echo ""
+echo "══════════════════════════════════════════════════════��════"
+TOTAL=$((PASS_COUNT + FAIL_COUNT))
+echo "Result: $PASS_COUNT passed, $FAIL_COUNT failed (out of $TOTAL checks)"
+echo "═══════════════════════════════════════════════════════════"
+
+if [ "$FAIL_COUNT" -gt 0 ]; then
+    exit 1
+else
+    echo "ALL CHECKS PASSED"
+    exit 0
+fi

--- a/tools/odysseus-console.py
+++ b/tools/odysseus-console.py
@@ -82,10 +82,44 @@ def _ts() -> str:
     return datetime.now(timezone.utc).strftime("%H:%M:%S")
 
 
-def print_status(state: str, detail: str = ""):
+# Track whether the last output was an inline status (needs \r overwrite)
+_last_was_inline = False
+
+
+def _term_width() -> int:
+    try:
+        return os.get_terminal_size().columns
+    except OSError:
+        return 80
+
+
+def print_status(state: str, detail: str = "", inline: bool = False):
+    """Print a status line. Inline=True overwrites the current line (for transient states)."""
+    global _last_was_inline
     colors = {"connected": GREEN, "disconnected": RED, "reconnecting": YELLOW}
     c = colors.get(state, DIM)
-    print(f"{DIM}{_ts()}{RESET} {c}{BOLD}[{state.upper()}]{RESET} {detail}", flush=True)
+    line = f"{DIM}{_ts()}{RESET} {c}{BOLD}[{state.upper()}]{RESET} {detail}"
+
+    if inline:
+        # Pad to terminal width to overwrite previous content, then \r back
+        visible_len = len(f"{_ts()} [{state.upper()}] {detail}")
+        padding = max(0, _term_width() - visible_len)
+        print(f"\r{line}{' ' * padding}", end="", flush=True)
+        _last_was_inline = True
+    else:
+        # If previous output was inline, move to a new line first
+        if _last_was_inline:
+            print(flush=True)  # newline
+        print(line, flush=True)
+        _last_was_inline = False
+
+
+def clear_inline():
+    """Emit a newline if the last status was inline, so events print cleanly."""
+    global _last_was_inline
+    if _last_was_inline:
+        print(flush=True)
+        _last_was_inline = False
 
 
 async def main() -> None:
@@ -118,15 +152,16 @@ async def main() -> None:
 
     # nats-py lifecycle callbacks (must be coroutines)
     async def on_disconnected():
-        print_status("disconnected", NATS_URL)
+        print_status("disconnected", NATS_URL, inline=True)
 
     async def on_reconnected():
         print_status("connected", f"Reconnected to {NATS_URL}")
 
     async def on_closed():
-        print_status("disconnected", "Connection closed")
+        print_status("disconnected", "Connection closed", inline=True)
 
     async def on_message(msg):
+        clear_inline()
         print(format_event(msg.subject, msg.data), flush=True)
 
     # Outer loop: handles initial connection failures.
@@ -134,7 +169,7 @@ async def main() -> None:
     while not stop.is_set():
         nc = None
         try:
-            print_status("reconnecting", f"Connecting to {NATS_URL}...")
+            print_status("reconnecting", f"Connecting to {NATS_URL}...", inline=True)
 
             # Use allow_reconnect=False so connect() fails fast on first
             # attempt. Our outer loop handles retry. Once connected, transient
@@ -180,16 +215,16 @@ async def main() -> None:
                 break
 
             # Connection permanently closed — outer loop retries
-            print_status("disconnected", "Connection lost")
+            print_status("disconnected", "Connection lost", inline=True)
 
         except asyncio.TimeoutError:
-            print_status("disconnected", f"Connection timed out ({NATS_URL})")
+            print_status("disconnected", f"Connection timed out ({NATS_URL})", inline=True)
         except Exception as e:
             # Initial connection failed — friendly message, no stack trace
             err_msg = str(e)
             if not err_msg:
                 err_msg = type(e).__name__
-            print_status("disconnected", err_msg)
+            print_status("disconnected", err_msg, inline=True)
 
             # Clean up partial connection
             if nc is not None:
@@ -200,12 +235,13 @@ async def main() -> None:
 
         # Wait before retrying, but stop immediately on Ctrl+C
         if not stop.is_set():
-            print_status("reconnecting", f"Retrying in {RETRY_INTERVAL}s...")
+            print_status("reconnecting", f"Retrying in {RETRY_INTERVAL}s...", inline=True)
             try:
                 await asyncio.wait_for(stop.wait(), timeout=RETRY_INTERVAL)
             except asyncio.TimeoutError:
                 pass
 
+    clear_inline()
     print(f"\n{DIM}Disconnected.{RESET}")
 
 


### PR DESCRIPTION
## Summary

- **ADR-007** (`docs/adr/007-symlinks-over-submodules.md`): Documents submodule architecture, myrmidon/worktree/sub-agent workflows, and repo-level task scoping principle
- **Real e2e test script** (`e2e/test-adr-007.sh`): 47 executable checks across 7 acceptance criteria — replaces the markdown description the pipeline agent incorrectly wrote
- **Container execution** (`e2e/claude-myrmidon.py`): Claude CLI now runs inside `achaean-claude` container via podman with proper volume mappings (`WORKING_DIR` -> `/workspace`, `~/.claude` for config, `ANTHROPIC_API_KEY` via env, `homeric-mesh` network)
- **Comment deduplication** (`e2e/claude-myrmidon.py`): `_load_existing_comment_ids()` fetches existing issue comments on startup so stage+iteration combos are PATCHed in-place even after process restarts
- **Inline console updates** (`tools/odysseus-console.py`): Disconnect/reconnect/retry status uses `\r` carriage return to overwrite a single line instead of spamming the terminal

Closes #7

## Test plan

- [ ] `bash e2e/test-adr-007.sh` — all 47 checks pass
- [ ] `python3 -m py_compile e2e/claude-myrmidon.py` — no syntax errors or warnings
- [ ] `python3 -m py_compile tools/odysseus-console.py` — no syntax errors
- [ ] `DRY_RUN=1 NO_GITHUB=1 NATS_URL=nats://localhost:4222 python3 e2e/claude-myrmidon.py` — dry-run pipeline runs with container config in banner
- [ ] `python3 tools/odysseus-console.py` with NATS down — single updating status line, no wall of text

🤖 Generated with [Claude Code](https://claude.com/claude-code)