### PR TITLE
docs(architecture): clarify Nomad multi-host scheduling is planned, not implemented

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,12 +21,15 @@ Odysseus/
 ├── docs/
 │   ├── architecture.md           # System-wide architecture overview and component map
 │   ├── adr/
+│   │   ├── README.md
+│   │   ├── template.md
 │   │   ├── 001-podman-over-docker.md
 │   │   ├── 002-nats-event-bridge.md
 │   │   ├── 003-nomad-over-k8s.md
 │   │   ├── 004-extend-not-replace-maestro.md
 │   │   ├── 005-nats-subject-schema.md
-│   │   └── 006-decouple-from-ai-maestro.md
+│   │   ├── 006-decouple-from-ai-maestro.md
+│   │   └── 007-symlinks-over-submodules.md
 │   └── runbooks/
 │       ├── add-new-host.md
 │       ├── add-new-agent-type.md
@@ -68,7 +71,7 @@ Odysseus/
 
 - Use `pixi run` or `just` for all task execution. Never run scripts directly.
 - When adding a new submodule: `git submodule add <url> <path>`, update `.gitmodules`, and document the repo in `docs/architecture.md`.
-- When writing a new ADR: copy the format from an existing ADR, use the next sequential number, and set Status to "Proposed" until merged.
+- When writing a new ADR: use `docs/adr/template.md` as the template, use the next sequential number, and set Status to "Proposed" until merged.
 - Runbooks should be written as numbered steps that can be executed top-to-bottom without prior context.
 - **ai-maestro has been fully removed per ADR-006.** ProjectAgamemnon replaces its task coordination role.
 

--- a/README.md
+++ b/README.md
@@ -24,11 +24,22 @@ If you already cloned without submodules:
 git submodule update --init --recursive
 ```
 
+## Documentation
+
+Complete documentation is available in the [docs/](docs/) directory:
+
+- **[Documentation Index](docs/README.md)** — Table of contents for all architecture, decisions, and operational guides
+- **[System Architecture](docs/architecture.md)** — Complete overview of all components and interactions
+- **[Architecture Decision Records](docs/adr/)** — All significant architectural decisions with rationale
+- **[Operational Runbooks](docs/runbooks/)** — Step-by-step guides for common operational tasks
+- **[NATS Subject Schema](docs/nats-subjects.md)** — Event bus subject patterns and streams
+
 ## Repository Layout
 
 ```
 Odysseus/
 ├── docs/
+│   ├── README.md             # Documentation index and table of contents
 │   ├── architecture.md       # Full system architecture overview
 │   ├── adr/                  # Architecture Decision Records
 │   └── runbooks/             # Operational runbooks

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,64 @@
+# Documentation Index
+
+Welcome to the HomericIntelligence documentation hub. This page serves as a table of contents for all architecture, decisions, and operational guides.
+
+---
+
+## Architecture Overview
+
+Start here to understand the HomericIntelligence system as a whole:
+
+- **[System Architecture](architecture.md)** — Complete overview of all components, their roles, and how they interact. Post-ADR-006 architecture with ProjectAgamemnon as the coordination hub.
+
+---
+
+## Architecture Decision Records (ADRs)
+
+All significant architectural decisions are recorded here. ADRs are append-only—once accepted, they are never edited. Superseding decisions get a new ADR that references the old one.
+
+| # | Title | Status | Supersedes |
+|---|-------|--------|-----------|
+| [001](adr/001-podman-over-docker.md) | Use Podman as Primary Container Runtime | Accepted | — |
+| [002](adr/002-nats-event-bridge.md) | Use NATS JetStream as Event Bridge for ai-maestro Webhooks | Accepted | — |
+| [003](adr/003-nomad-over-k8s.md) | Use Nomad for Multi-Host Container Scheduling Instead of Kubernetes | Accepted | — |
+| [004](adr/004-extend-not-replace-maestro.md) | Extend ai-maestro via APIs Rather Than Replacing Its Capabilities | Superseded by ADR-006 | — |
+| [005](adr/005-nats-subject-schema.md) | NATS Subject Schema | Accepted | Subject examples in ADR-002 |
+| [006](adr/006-decouple-from-ai-maestro.md) | Decouple HomericIntelligence from ai-maestro | Accepted | — |
+| [007](adr/007-symlinks-over-submodules.md) | Replace Symlinks with Real Git Submodules | Proposed | — |
+
+---
+
+## Operational Runbooks
+
+Step-by-step guides for common operational tasks. Execute each runbook top-to-bottom without prior context.
+
+| Runbook | When to Use |
+|---------|------------|
+| [Add a New Host](runbooks/add-new-host.md) | Adding a new machine to the HomericIntelligence mesh |
+| [Add a New Agent Type](runbooks/add-new-agent-type.md) | Creating a new agent type and integrating it into the ecosystem |
+| [WSL2 Rootless Podman Setup](runbooks/wsl2-podman-setup.md) | Enabling rootless podman on WSL2 for local development |
+| [Disaster Recovery](runbooks/disaster-recovery.md) | Recovery procedures for system failure scenarios (e.g., primary Agamemnon host loss) |
+
+---
+
+## NATS Event Bus Reference
+
+- **[NATS Subject Schema](nats-subjects.md)** — Subject patterns, streams, consumers, and lifecycle documentation for the HomericIntelligence event bus. See [ADR 005](adr/005-nats-subject-schema.md) for decision context.
+
+---
+
+## Additional Resources
+
+- **[Architecture Analysis: ai-maestro Migration](odysseus-ai-maestro-analysis.md)** — Historical analysis of the ai-maestro integration and subsequent decoupling.
+- **[Architecture Analysis: Ruflo Integration](odysseus-ruflo-analysis.md)** — Analysis of Ruflo system integration patterns.
+- **[E2E Walkthrough Report](e2e-walkthrough-report.md)** — End-to-end system test results and topology validation.
+
+---
+
+## Key Principles
+
+1. **Odysseus is read-mostly.** Most day-to-day changes happen in individual submodule repos, not here.
+2. **ADRs are append-only.** Once accepted, never edited. Superseding decisions get a new ADR.
+3. **Configs are canonical.** The Nomad and NATS configs in `../configs/` are authoritative.
+4. **Submodule pins matter.** Submodule SHAs represent the last known-good cross-repo integration point.
+5. **ai-maestro has been fully removed per ADR-006.** ProjectAgamemnon replaces its task coordination role.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,32 @@
+# Architecture Decision Records (ADRs)
+
+This directory contains all Architecture Decision Records for the HomericIntelligence ecosystem. Each ADR documents a significant architectural choice, its context, decision rationale, and consequences.
+
+## Decision Log
+
+| Number | Title | Status | Supersedes | Superseded By |
+|--------|-------|--------|------------|---------------|
+| [001](001-podman-over-docker.md) | Use Podman as Primary Container Runtime | Accepted | — | — |
+| [002](002-nats-event-bridge.md) | Use NATS JetStream as Event Bridge for ai-maestro Webhooks | Accepted | — | — |
+| [003](003-nomad-over-k8s.md) | Use Nomad for Multi-Host Container Scheduling Instead of Kubernetes | Accepted | — | — |
+| [004](004-extend-not-replace-maestro.md) | Extend ai-maestro via APIs Rather Than Replacing Its Capabilities | Superseded | — | [ADR-006](006-decouple-from-ai-maestro.md) |
+| [005](005-nats-subject-schema.md) | NATS Subject Schema | Accepted | Subject examples in ADR 002 | — |
+| [006](006-decouple-from-ai-maestro.md) | Decouple HomericIntelligence from ai-maestro | Accepted | — | — |
+| [007](007-symlinks-over-submodules.md) | Replace Symlinks with Real Git Submodules | Proposed | — | — |
+
+## How to Create a New ADR
+
+1. Copy the [template.md](template.md) to a new file: `NNN-kebab-case-title.md`, where `NNN` is the next sequential number.
+2. Fill in all sections: Context, Decision, Consequences (Positive, Negative, Neutral), and References.
+3. Set **Status** to `Proposed` until the ADR is merged and accepted.
+4. If your ADR supersedes or is superseded by another, link them both ways (e.g., `Supersedes: [ADR-004](004-...)` and update that ADR with `Superseded By: [ADR-006](...)`).
+5. Create a pull request with your new ADR.
+6. Once merged, you may update the Status field if the decision is formally accepted by the team.
+
+## ADR Process
+
+- **Proposed:** A new ADR that has not yet been reviewed or accepted.
+- **Accepted:** A decision that has been reviewed and approved. Accepted ADRs are frozen and never edited.
+- **Superseded:** A decision that has been replaced by a later ADR. The superseded ADR is kept for historical reference and linked to its replacement.
+
+ADRs are **append-only.** Once accepted, an ADR is never edited or deleted. If a decision needs to change, create a new ADR that references and supersedes the old one.

--- a/docs/adr/template.md
+++ b/docs/adr/template.md
@@ -1,0 +1,41 @@
+# ADR NNN: [Brief Title]
+
+**Status:** Proposed
+
+---
+
+## Context
+
+Describe the issue or question that prompted this decision. Include:
+- The problem being faced
+- Any relevant background or constraints
+- Why this matters for the ecosystem
+
+## Decision
+
+State the decision clearly and concisely. Include:
+- What was chosen
+- Why this option was selected
+- Any key constraints or trade-offs
+
+## Consequences
+
+Describe the expected outcomes and implications of this decision. Include three subsections:
+
+**Positive:**
+- Expected benefits
+- Improvements in the ecosystem
+
+**Negative:**
+- Costs or drawbacks
+- Mitigations where applicable
+
+**Neutral:**
+- Changes that are neither good nor bad
+- Expected but not problematic shifts in workflow or architecture
+
+## References
+
+Link to related ADRs, issues, or documentation:
+- [ADR XXX](XXX-title.md) - Related decision
+- [Issue #NNN](https://github.com/HomericIntelligence/Odysseus/issues/NNN) - Corresponding issue


### PR DESCRIPTION
## Summary

Updates Architecture.md to accurately state that Nomad-based multi-host agent scheduling is planned for a future phase, not currently implemented.

- Myrmidons currently only supports `local` and `docker` deployment types
- No Nomad job files, HCL templates, or Nomad API client exist in Myrmidons
- Cross-references HomericIntelligence/Myrmidons#5 where ADR-007 documents this gap

Closes #115