### PR TITLE
docs: add deployment guide and developer onboarding guide

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,480 @@
+# Deployment Guide
+
+## End-to-End Ecosystem Deployment
+
+This guide walks through deploying the HomericIntelligence distributed agent mesh from scratch on a fresh infrastructure. Follow these steps top-to-bottom to bring the entire ecosystem online.
+
+---
+
+## Prerequisites
+
+Before starting, ensure the following are installed and available on all target hosts:
+
+### 1. Pixi (Package Manager)
+
+Pixi manages Python environments and project dependencies across all submodules.
+
+```bash
+# Install Pixi (see https://pixi.sh/latest/#installation)
+curl -fsSL https://pixi.sh/install.sh | bash
+```
+
+Verify installation:
+
+```bash
+pixi --version
+```
+
+### 2. Podman (Container Runtime)
+
+All services and agents run in Podman containers on a shared `homeric-mesh` network.
+
+```bash
+# On Debian/Ubuntu:
+sudo apt-get install -y podman podman-compose
+
+# On RHEL/Fedora/CentOS:
+sudo dnf install -y podman podman-compose
+```
+
+Start the Podman daemon (if not already running):
+
+```bash
+sudo systemctl start podman
+```
+
+Verify installation:
+
+```bash
+podman --version
+```
+
+### 3. Tailscale (VPN Mesh)
+
+All inter-host traffic flows over Tailscale. Install on every host that will participate in the mesh:
+
+```bash
+curl -fsSL https://tailscale.com/install.sh | sh
+sudo tailscale up --authkey=<your-tailscale-authkey>
+```
+
+Verify connectivity:
+
+```bash
+sudo tailscale ip -4
+```
+
+Record the Tailscale IP addresses; you will need them when configuring NATS and Nomad across hosts.
+
+### 4. Just (Task Runner)
+
+The `just` command-line tool orchestrates setup, deployment, and operational tasks:
+
+```bash
+# On macOS:
+brew install just
+
+# On Linux:
+# Via Cargo (requires Rust):
+cargo install just
+
+# Or download a binary from: https://github.com/casey/just/releases
+```
+
+Verify installation:
+
+```bash
+just --version
+```
+
+---
+
+## Step 1: Bootstrap the Repository
+
+Clone Odysseus and initialize all git submodules:
+
+```bash
+git clone https://github.com/HomericIntelligence/Odysseus.git
+cd Odysseus
+git submodule update --init --recursive
+```
+
+Or use the one-command bootstrap task:
+
+```bash
+just bootstrap
+```
+
+This downloads and initializes all 12 submodule repositories into their designated directories.
+
+---
+
+## Step 2: Install Dependencies
+
+Install project-wide Python dependencies using Pixi:
+
+```bash
+pixi install
+```
+
+This resolves dependencies across all submodules and creates the environment lock file.
+
+---
+
+## Step 3: Build All Components
+
+Build all compilable submodules (C++, CMake, and Mojo sources):
+
+```bash
+just build
+```
+
+Build artifacts are placed in `build/` subdirectories:
+
+- `build/ProjectAgamemnon/` — Planning and orchestration engine
+- `build/ProjectNestor/` — Research and ideation service
+- `build/ProjectCharybdis/` — Chaos and resilience testing
+- `build/ProjectKeystone/` — Transport layer (BlazingMQ + NATS)
+- `build/ProjectOdyssey/` — ML research sandbox
+
+Verify all builds succeeded:
+
+```bash
+ls -la build/
+```
+
+---
+
+## Step 4: Configure NATS (Message Bus)
+
+NATS JetStream is the cross-host event bus. Configure it on the primary host:
+
+### 4a. Review the NATS Configuration
+
+The canonical NATS server config is at `configs/nats/server.conf`. It configures:
+
+- JetStream persistence
+- TLS (if enabled)
+- Leaf nodes (for multi-cluster federation)
+- Max connections and per-client limits
+
+For a single-host setup, the default config requires no changes.
+
+### 4b. Start the NATS Server
+
+```bash
+podman run -d \
+  --name nats-server \
+  --network homeric-mesh \
+  -p 4222:4222 \
+  -v $(pwd)/configs/nats/server.conf:/etc/nats/server.conf:ro \
+  nats:3.12.0 -c /etc/nats/server.conf
+```
+
+Verify NATS is running:
+
+```bash
+podman logs nats-server
+```
+
+You should see: `Server is ready for connections on 0.0.0.0:4222`
+
+### 4c. Configure Leaf Nodes (Multi-Host Only)
+
+If deploying across multiple hosts, configure leaf node connections in `configs/nats/leaf.conf` to federate the NATS clusters over Tailscale. See `docs/runbooks/add-new-host.md` for details.
+
+---
+
+## Step 5: Configure Nomad (Job Scheduler)
+
+Nomad schedules and manages all agent workloads. Configure it on the primary host:
+
+### 5a. Review the Nomad Configuration
+
+The canonical Nomad configs are at:
+
+- `configs/nomad/server.hcl` — Primary cluster controller
+- `configs/nomad/client.hcl` — Worker node config
+
+For a single-host setup, run both server and client on the same host.
+
+### 5b. Start Nomad Server
+
+```bash
+mkdir -p /var/nomad/{data,plugins}
+sudo chown nomad:nomad /var/nomad
+
+podman run -d \
+  --name nomad-server \
+  --network homeric-mesh \
+  -p 4646:4646 \
+  -p 4647:4647 \
+  -p 4648:4648/udp \
+  -v /var/nomad:/nomad/data \
+  -v $(pwd)/configs/nomad/server.hcl:/etc/nomad/server.hcl:ro \
+  hashicorp/nomad:1.6 agent -config /etc/nomad/server.hcl
+```
+
+### 5c. Start Nomad Client
+
+```bash
+podman run -d \
+  --name nomad-client \
+  --network homeric-mesh \
+  -v /var/nomad:/nomad/data \
+  -v $(pwd)/configs/nomad/client.hcl:/etc/nomad/client.hcl:ro \
+  -v /var/run/podman:/var/run/podman:ro \
+  hashicorp/nomad:1.6 agent -config /etc/nomad/client.hcl
+```
+
+Verify Nomad is running:
+
+```bash
+nomad status
+```
+
+---
+
+## Step 6: Start ProjectKeystone (Transport Layer)
+
+ProjectKeystone wraps BlazingMQ (intra-host) and NATS (cross-host) behind a unified event interface. Start it on all hosts:
+
+```bash
+just keystone-start
+```
+
+This task:
+
+1. Builds ProjectKeystone (if not already built)
+2. Starts the Keystone service in a Podman container
+3. Registers it as the event bus for all downstream services
+
+Verify connectivity:
+
+```bash
+podman logs keystone
+```
+
+---
+
+## Step 7: Start ProjectAgamemnon (Control Plane)
+
+ProjectAgamemnon is the central orchestration engine. It coordinates planning, reconciliation, and HMAS (Hierarchical Multi-Agent System) orchestration.
+
+```bash
+just agamemnon-start
+```
+
+This task:
+
+1. Builds ProjectAgamemnon (if not already built)
+2. Starts the Agamemnon API service at `http://localhost:8080`
+3. Registers GitHub for backing storage
+
+Verify it is running:
+
+```bash
+curl http://localhost:8080/health
+```
+
+Expected response: `{"status":"healthy"}`
+
+---
+
+## Step 8: Deploy Initial Agent Fleet (Myrmidons)
+
+The Myrmidons repository contains declarative YAML manifests describing the desired agent state. Apply them via Agamemnon's reconciliation API:
+
+```bash
+just apply-all
+```
+
+This task:
+
+1. Reads all YAML files from `provisioning/Myrmidons/`
+2. Submits them to Agamemnon via the `/apply` API endpoint
+3. Agamemnon creates Nomad jobs to instantiate the agents
+
+Monitor agent startup:
+
+```bash
+nomad status
+```
+
+You should see agent jobs transitioning to the `running` state.
+
+---
+
+## Step 9: Start ProjectHermes (External Bridge)
+
+ProjectHermes bridges external service events (Slack, GitHub, email) into NATS and handles outbound message delivery:
+
+```bash
+just hermes-start
+```
+
+Verify it is running:
+
+```bash
+podman logs hermes
+```
+
+---
+
+## Step 10: Start ProjectArgus (Observability Stack)
+
+ProjectArgus provides metrics, logging, and dashboards via Prometheus, Loki, and Grafana:
+
+```bash
+just argus-start
+```
+
+This task:
+
+1. Starts Prometheus (metrics scraping)
+2. Starts Loki (log aggregation)
+3. Starts Grafana (dashboards)
+4. Configures Promtail (log shipper)
+
+Access Grafana:
+
+```
+http://localhost:3000
+```
+
+Default credentials: `admin / admin`
+
+---
+
+## Step 11: Verification
+
+Verify the full ecosystem is operational:
+
+### 11a. Check All Services
+
+```bash
+just status
+```
+
+This shows git status across all submodules and should show no uncommitted changes (all pinned at known-good commits).
+
+### 11b. Verify Network Connectivity
+
+Confirm all hosts can reach each other over Tailscale:
+
+```bash
+sudo tailscale ping <peer-tailscale-ip>
+```
+
+### 11c. Check Nomad Job Status
+
+```bash
+nomad status
+```
+
+All agent jobs should be in the `running` state.
+
+### 11d. Verify NATS JetStream
+
+```bash
+podman exec nats-server nats stream ls
+```
+
+You should see several streams (e.g., `research-requests`, `orchestration-commands`).
+
+### 11e. Test ProjectNestor (Research Service)
+
+Submit a research request and verify it is processed:
+
+```bash
+curl -X POST http://localhost:8080/research \
+  -H "Content-Type: application/json" \
+  -d '{"query":"test query"}'
+```
+
+Monitor the response through Agamemnon's task queue.
+
+---
+
+## Step 12: Production Hardening
+
+Before running in production, complete these additional steps:
+
+### 12a. Enable TLS
+
+Update `configs/nats/server.conf` and `configs/nomad/server.hcl` to enable TLS certificates.
+
+### 12b. Configure Persistent Storage
+
+Ensure NATS, Nomad, and Loki are backed by persistent storage (not ephemeral containers). Use mounted volumes or cloud object storage.
+
+### 12c. Set Up Monitoring Alerts
+
+Configure Grafana alert rules to notify on service degradation, high error rates, or agent failures.
+
+### 12d. Enable Audit Logging
+
+Enable GitHub audit logging to capture all Agamemnon decisions for compliance and debugging.
+
+### 12e. Secure Tailscale
+
+Configure Tailscale ACLs to restrict which hosts can communicate. See `docs/runbooks/add-new-host.md`.
+
+---
+
+## Troubleshooting
+
+### Services Fail to Start
+
+Check container logs:
+
+```bash
+podman logs <container-name>
+```
+
+### Network Connectivity Issues
+
+Verify Tailscale is connected:
+
+```bash
+sudo tailscale status
+```
+
+If not connected, re-authenticate:
+
+```bash
+sudo tailscale up --authkey=<new-authkey>
+```
+
+### Agents Not Spawning
+
+Verify Nomad client is registered:
+
+```bash
+nomad node status
+```
+
+If no clients appear, restart the Nomad client:
+
+```bash
+podman restart nomad-client
+```
+
+### NATS Cluster Not Forming
+
+Check NATS logs and verify all hosts have matching NATS cluster IDs in their configs:
+
+```bash
+podman logs nats-server
+```
+
+---
+
+## Next Steps
+
+After deployment is complete:
+
+1. **Add New Hosts** — See `docs/runbooks/add-new-host.md` to scale the mesh.
+2. **Add New Agent Types** — See `docs/runbooks/add-new-agent-type.md` to create custom agents.
+3. **Disaster Recovery** — Review `docs/runbooks/disaster-recovery.md` for backup and recovery procedures.
+4. **Architecture Deep Dive** — Read `docs/architecture.md` for system internals and component relationships.

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -1,0 +1,475 @@
+# Developer Onboarding Guide
+
+Welcome to the HomericIntelligence ecosystem. This guide introduces the system architecture, development workflow, and key commands to get you productive quickly.
+
+---
+
+## What You Need to Install
+
+Before starting, ensure you have these tools installed:
+
+### Required
+
+1. **Git** — Version control. [Installation](https://git-scm.com/downloads)
+
+2. **Pixi** — Package manager for Python environments. [Installation](https://pixi.sh/latest/#installation)
+
+   ```bash
+   curl -fsSL https://pixi.sh/install.sh | bash
+   ```
+
+3. **Just** — Task runner (like Make, but better). [Installation](https://github.com/casey/just)
+
+   ```bash
+   # macOS:
+   brew install just
+   
+   # Linux (via Cargo):
+   cargo install just
+   ```
+
+4. **Podman** — Container runtime (Docker alternative). [Installation](https://podman.io/docs/installation)
+
+   ```bash
+   # Debian/Ubuntu:
+   sudo apt-get install podman
+   
+   # RHEL/Fedora:
+   sudo dnf install podman
+   ```
+
+### Highly Recommended (for local testing and multi-host scenarios)
+
+5. **Tailscale** — VPN mesh for cross-host communication. [Installation](https://tailscale.com/download)
+
+   ```bash
+   curl -fsSL https://tailscale.com/install.sh | sh
+   ```
+
+Verify all installations:
+
+```bash
+git --version
+pixi --version
+just --version
+podman --version
+```
+
+---
+
+## Ecosystem Overview: The 12 Repositories
+
+HomericIntelligence is a distributed system built from 12 specialized repositories. **Odysseus** is the top-level meta-repo that coordinates them all.
+
+### The Big Picture
+
+```
+User
+  ↓ (bidirectional interaction)
+Odysseus (meta-repo, orchestration hub)
+  ├─→ ProjectAgamemnon (control plane, task coordination)
+  ├─→ ProjectNestor (research & ideation)
+  ├─→ ProjectKeystone (transport/event bus)
+  ├─→ ProjectArgus (observability)
+  ├─→ ProjectHermes (external integrations)
+  ├─→ AchaeanFleet (container images)
+  ├─→ Myrmidons (agent fleet & GitOps)
+  ├─→ ProjectTelemachy (workflow engine)
+  ├─→ ProjectProteus (CI/CD pipelines)
+  ├─→ ProjectCharybdis (chaos testing)
+  ├─→ ProjectScylla (ablation benchmarks)
+  ├─→ ProjectMnemosyne (shared memory)
+  └─→ ProjectHephaestus (shared utilities & skills)
+```
+
+### Quick Reference: What Each Repo Does
+
+| Repo | Category | Role | Language | Status |
+|------|----------|------|----------|--------|
+| **Odysseus** | meta | User interface, observability hub, meta-repo | Markdown, Bash | You are here |
+| **ProjectAgamemnon** | control | Task planning, HMAS orchestration, GitHub-backed | C++, Python | Core system |
+| **ProjectNestor** | control | Research, ideation, multi-step workflows | Python, C++ | Core system |
+| **ProjectKeystone** | transport | Event bus (BlazingMQ intra-host, NATS cross-host) | C++ | Core system |
+| **ProjectArgus** | infrastructure | Metrics (Prometheus), logs (Loki), dashboards (Grafana) | TypeScript, Python | Observability |
+| **ProjectHermes** | infrastructure | Slack, GitHub, email integrations | Python | Bridge |
+| **AchaeanFleet** | infrastructure | Container image registry and definitions | Dockerfile, OCI | Build artifacts |
+| **Myrmidons** | provisioning | Agent fleet YAML manifests (GitOps source of truth) | YAML | Config |
+| **ProjectTelemachy** | provisioning | Declarative workflow engine | Python, C++ | Internal tool |
+| **ProjectProteus** | ci-cd | Build pipelines (Dagger TypeScript) | TypeScript | Automation |
+| **ProjectCharybdis** | testing | Chaos and resilience testing | Python | Testing |
+| **ProjectScylla** | testing | AI agent ablation and benchmarking | Python, Mojo | Research |
+| **ProjectMnemosyne** | shared | Memory store for `advise` and `learn` plugins | Python | Utility |
+| **ProjectHephaestus** | shared | Shared utilities, Claude Code plugins | Python, TypeScript | Utility |
+
+---
+
+## Developer Workflow
+
+### 1. Fork and Clone
+
+Fork Odysseus on GitHub (if contributing upstream):
+
+```bash
+git clone https://github.com/<your-username>/Odysseus.git
+cd Odysseus
+```
+
+Or clone the canonical repo:
+
+```bash
+git clone https://github.com/HomericIntelligence/Odysseus.git
+cd Odysseus
+```
+
+### 2. Initialize Submodules
+
+All 12 repos are checked in as git submodules. Initialize them:
+
+```bash
+just bootstrap
+```
+
+This runs `git submodule update --init --recursive`. **Always do this after cloning.**
+
+You can verify submodules are present:
+
+```bash
+ls -la control/ provisioning/ infrastructure/ ci-cd/ research/ testing/ shared/
+```
+
+### 3. Install Project Dependencies
+
+Install Python environment and dependencies:
+
+```bash
+pixi install
+```
+
+This creates a project-local Python environment with all transitive dependencies resolved.
+
+### 4. Build (Optional, but Recommended)
+
+Build all compilable submodules:
+
+```bash
+just build
+```
+
+Artifacts land in `build/<submodule-name>/`. This is useful for testing locally before pushing.
+
+### 5. Make Changes
+
+Edit files in any submodule. Most day-to-day changes happen in the individual submodule repos, not in Odysseus itself.
+
+Examples:
+
+- Fixing a bug in ProjectAgamemnon → edit `control/ProjectAgamemnon/src/...`
+- Adding a runbook → edit `docs/runbooks/...` in Odysseus
+- Adding an agent template → edit `provisioning/Myrmidons/templates/...`
+
+### 6. Test Locally
+
+Use the individual submodule test suites. See each repo's README for testing instructions.
+
+For integration testing, use `just` tasks or the e2e scripts in `e2e/`.
+
+### 7. Commit and Push
+
+Create a branch and push:
+
+```bash
+git checkout -b feature/my-feature
+git add <specific-files>
+git commit -m "feat: description of change
+
+Details...
+
+Co-Authored-By: Your Name <your.email@example.com>"
+git push -u origin feature/my-feature
+```
+
+**Important:** Never use `git add .` or `git add -A`. Always stage specific files to avoid committing sensitive configs or build artifacts.
+
+### 8. Create a Pull Request
+
+```bash
+gh pr create --title "feat: short description" --body "Detailed description..."
+```
+
+See `docs/adr/` for architectural decisions and ADR format if your change crosses repo boundaries.
+
+### 9. Code Review
+
+A maintainer reviews your PR. Address feedback and push additional commits (do not force-push).
+
+### 10. Merge
+
+Once approved, the PR is merged via rebase:
+
+```bash
+gh pr merge --auto --rebase
+```
+
+---
+
+## Key Commands
+
+All tasks are orchestrated via `just`. See the full list:
+
+```bash
+just --list
+```
+
+### Common Tasks
+
+| Command | What It Does |
+|---------|--------------|
+| `just bootstrap` | Initialize all 12 git submodules |
+| `just status` | Show git status across all submodules |
+| `just build` | Build all C++/CMake/Mojo components |
+| `just setup` | One-command setup (bootstrap + build) |
+| `just update-submodules` | Pull latest from all upstream submodule remotes |
+| `just agamemnon-start` | Start ProjectAgamemnon (control plane) |
+| `just nestor-start` | Start ProjectNestor (research service) |
+| `just keystone-start` | Start ProjectKeystone (event bus) |
+| `just hermes-start` | Start ProjectHermes (external bridge) |
+| `just argus-start` | Start ProjectArgus (observability stack) |
+| `just apply-all` | Deploy Myrmidons YAML manifests via Agamemnon |
+| `just telemachy-run WORKFLOW=<name>` | Execute a named workflow |
+| `just install PREFIX=/usr/local` | Install all binaries to a prefix |
+
+---
+
+## Where to Find What
+
+### Architecture & Design
+
+- **System Overview** → `docs/architecture.md`
+- **Architectural Decisions** → `docs/adr/` (numbered ADRs, append-only, never edited)
+- **Component Relationships** → `docs/architecture.md` (component inventory and system diagram)
+
+### Deployment & Operations
+
+- **Deployment Guide** → `docs/deployment.md` (end-to-end fresh ecosystem setup)
+- **Runbooks** → `docs/runbooks/` (step-by-step operations guides)
+  - `add-new-host.md` — Scale the mesh to new hosts
+  - `add-new-agent-type.md` — Create custom agent types
+  - `disaster-recovery.md` — Backup and recovery procedures
+  - `wsl2-podman-setup.md` — Windows WSL2 Podman configuration
+
+### Development
+
+- **Project Structure** → `CLAUDE.md` (repo layout and development guidelines)
+- **CI/CD Pipelines** → `ci-cd/ProjectProteus/` (Dagger TypeScript)
+- **E2E Tests** → `e2e/` (integration and topology tests)
+
+### Configuration
+
+- **NATS Server Config** → `configs/nats/server.conf`
+- **Nomad Server Config** → `configs/nomad/server.hcl`
+- **Nomad Client Config** → `configs/nomad/client.hcl`
+
+### Submodule Repos (Detailed Information)
+
+Each submodule has its own `README.md`. Start there for specifics:
+
+- `control/ProjectAgamemnon/README.md`
+- `control/ProjectNestor/README.md`
+- etc.
+
+---
+
+## Typical Development Scenarios
+
+### Scenario 1: Fix a Bug in ProjectAgamemnon
+
+```bash
+# Clone and setup
+git clone https://github.com/HomericIntelligence/Odysseus.git
+cd Odysseus
+just bootstrap
+just build
+
+# Create a feature branch
+git checkout -b fix/agamemnon-bug
+
+# Edit the source (it's checked in as a submodule)
+cd control/ProjectAgamemnon
+# ... make changes ...
+cd ../..
+
+# Test it (see ProjectAgamemnon's README for test commands)
+# ... run tests ...
+
+# Commit the submodule update
+git add control/ProjectAgamemnon
+git commit -m "fix(agamemnon): describe the bug fix"
+git push -u origin fix/agamemnon-bug
+
+# Create PR
+gh pr create --title "fix(agamemnon): ..." --body "..."
+```
+
+### Scenario 2: Add a New Runbook
+
+```bash
+# Create a feature branch
+git checkout -b docs/new-runbook
+
+# Add the runbook
+cat > docs/runbooks/my-runbook.md << 'EOF'
+# Runbook: My Operation
+
+## Prerequisites
+...
+
+## Steps
+
+### 1. Do this
+
+### 2. Do that
+
+...
+EOF
+
+# Commit
+git add docs/runbooks/my-runbook.md
+git commit -m "docs: add runbook for my operation"
+git push -u origin docs/new-runbook
+
+# Create PR
+gh pr create --title "docs: add runbook for my operation"
+```
+
+### Scenario 3: Update a Submodule Pin (After a Release)
+
+```bash
+# Create a feature branch
+git checkout -b chore/bump-submodules
+
+# Pull latest upstream
+just update-submodules
+
+# Verify everything still works
+just build
+just status
+
+# Commit the new pins
+git add control/ provisioning/ infrastructure/ ci-cd/ research/ testing/ shared/
+git commit -m "chore: bump submodule pins to latest origin/main"
+git push -u origin chore/bump-submodules
+
+# Create PR
+gh pr create --title "chore: bump submodule pins to latest origin/main"
+```
+
+---
+
+## Important Principles
+
+### 1. Odysseus is Read-Mostly
+
+Most changes happen in the individual submodule repos, not in Odysseus. Odysseus itself contains:
+
+- ADRs (architecture decisions)
+- Runbooks (operational procedures)
+- Canonical configs (NATS, Nomad)
+- Submodule pins (as git submodules)
+
+**Application code lives in the submodules.**
+
+### 2. ADRs Are Append-Only
+
+Once an ADR is merged, it is never edited. If a decision changes, write a new ADR that references the old one. See `docs/adr/006-decouple-from-ai-maestro.md` for an example.
+
+### 3. Configs Are Canonical
+
+The NATS and Nomad configs in `configs/` are the authoritative source. Hosts copy or symlink from here, never diverge locally.
+
+### 4. Submodule Pins Matter
+
+The git submodule SHAs checked into this repo represent the last known-good cross-repo integration point. Update them deliberately and test the full system before committing.
+
+### 5. Use Just, Not Direct Scripts
+
+Always use `just` tasks instead of running scripts directly. This ensures consistency and documentation.
+
+---
+
+## Getting Help
+
+### Read the Docs
+
+1. **Architecture**: `docs/architecture.md`
+2. **Deployment**: `docs/deployment.md`
+3. **Runbooks**: `docs/runbooks/`
+4. **ADRs**: `docs/adr/`
+5. **Individual Submodule READMEs**: `<path>/<repo>/README.md`
+
+### Check Existing Code
+
+All repos are well-commented. Search before asking:
+
+```bash
+git log --all --grep="<keyword>"
+grep -r "<term>" control/ provisioning/ infrastructure/
+```
+
+### Ask in Issues
+
+If you're stuck, open an issue on GitHub describing:
+
+1. What you were trying to do
+2. What happened
+3. The full error message
+4. Your OS and tool versions (`git --version`, `pixi --version`, etc.)
+
+---
+
+## Next Steps
+
+1. **Read `docs/architecture.md`** — Understand the full system.
+2. **Read a Submodule README** — Pick one that interests you (e.g., ProjectAgamemnon).
+3. **Run `just bootstrap` and `just build`** — Get it running locally.
+4. **Pick a Small Issue** — Find a good-first-issue and fix it.
+5. **Join the Discussion** — Open a PR and engage with the team.
+
+---
+
+## Quick Reference: Submodule Paths
+
+```
+control/
+├── ProjectAgamemnon          # Task planning, orchestration
+└── ProjectNestor             # Research, ideation
+
+provisioning/
+├── ProjectTelemachy          # Workflow engine
+├── ProjectKeystone           # Transport layer
+└── Myrmidons                 # Agent fleet (GitOps)
+
+infrastructure/
+├── AchaeanFleet              # Container images
+├── ProjectArgus              # Observability
+└── ProjectHermes             # External integrations
+
+ci-cd/
+└── ProjectProteus            # Build pipelines
+
+research/
+├── ProjectOdyssey            # ML sandbox
+└── ProjectScylla             # Ablation benchmarks
+
+testing/
+└── ProjectCharybdis          # Chaos testing
+
+shared/
+├── ProjectMnemosyne          # Memory store
+└── ProjectHephaestus         # Shared utilities
+```
+
+---
+
+## Welcome!
+
+You're now ready to contribute to HomericIntelligence. Start small, ask questions, and enjoy building distributed AI systems!

--- a/docs/runbooks/add-new-agent-type.md
+++ b/docs/runbooks/add-new-agent-type.md
@@ -1,8 +1,20 @@
 # Runbook: Add a New Agent Type to the HomericIntelligence Ecosystem
 
+## Important: Symlink-Based Submodule Layout
+
+Per ADR-007, the subdirectories referenced in this runbook (`infrastructure/AchaeanFleet`, `provisioning/Myrmidons`, `shared/ProjectMnemosyne`) are **symlinks to standalone git repositories**, not git submodule worktrees. When making changes to these repos, you must:
+
+1. Clone or navigate to the actual repository (not via the Odysseus symlink).
+2. Make your commits in that standalone repo clone.
+3. Push changes to that repo's GitHub remote.
+4. Return to Odysseus and update the submodule pin if tracking a specific commit SHA.
+
+Do not attempt `cd infrastructure/AchaeanFleet && git add ...` — the symlink does not have its own `.git/` directory.
+
 ## Prerequisites
 
 - You have cloned the Odysseus repo with submodules (`just bootstrap`).
+- You have standalone clones of AchaeanFleet, Myrmidons, and ProjectMnemosyne repositories (see Step 6).
 - You have write access to AchaeanFleet, Myrmidons, and ProjectMnemosyne repos.
 - Podman is installed and the Podman socket is running (ADR 001).
 - Agamemnon is running and accessible at `$AGAMEMNON_URL`.
@@ -99,23 +111,53 @@ Edit `marketplace.json` to add an entry for the new agent type. Include:
 
 ### 6. Commit and push changes
 
-Commit changes in each modified repo separately, then update the submodule pins in Odysseus:
+Because the subdirectories in Odysseus are symlinks (ADR-007), you must commit changes in each repo's standalone clone, not in the symlinked paths:
+
+#### 6a. Commit in AchaeanFleet standalone clone
+
+Navigate to your AchaeanFleet repository clone (not the Odysseus symlink):
 
 ```bash
-# Commit in AchaeanFleet
-cd infrastructure/AchaeanFleet && git add vessels/<agent-name>/ && git commit -m "feat: add <agent-name> vessel"
-
-# Commit in Myrmidons
-cd provisioning/Myrmidons && git add _templates/<agent-name>.yaml && git commit -m "feat: add <agent-name> template"
-
-# Commit in ProjectMnemosyne
-cd shared/ProjectMnemosyne && git add marketplace.json && git commit -m "feat: register <agent-name> in marketplace"
-
-# Update submodule pins in Odysseus root
-cd /path/to/Odysseus
-git add infrastructure/AchaeanFleet provisioning/Myrmidons shared/ProjectMnemosyne
-git commit -m "chore: update submodule pins for <agent-name> agent type"
+cd /path/to/AchaeanFleet
+git add vessels/<agent-name>/
+git commit -m "feat: add <agent-name> vessel"
+git push origin main
 ```
+
+#### 6b. Commit in Myrmidons standalone clone
+
+Navigate to your Myrmidons repository clone:
+
+```bash
+cd /path/to/Myrmidons
+git add _templates/<agent-name>.yaml
+git commit -m "feat: add <agent-name> template"
+git push origin main
+```
+
+#### 6c. Commit in ProjectMnemosyne standalone clone
+
+Navigate to your ProjectMnemosyne repository clone:
+
+```bash
+cd /path/to/ProjectMnemosyne
+git add marketplace.json
+git commit -m "feat: register <agent-name> in marketplace"
+git push origin main
+```
+
+#### 6d. Update submodule pins in Odysseus (optional)
+
+If you have pinned specific commit SHAs in the Odysseus `.gitmodules` for these repos, return to Odysseus and update those pins:
+
+```bash
+cd /path/to/Odysseus
+git add .gitmodules
+git commit -m "chore: update submodule pins for <agent-name> agent type"
+git push origin main
+```
+
+Otherwise, the symlinks in Odysseus will point to the latest main branch of each repo, and no pin update is needed.
 
 ---
 


### PR DESCRIPTION
## Summary

Adds two new guides to `docs/`:
- `docs/deployment.md`: end-to-end steps for deploying the ecosystem from scratch (prerequisites, init, verify)
- `docs/onboarding.md`: developer onboarding covering repo relationships, workflow, and key commands

Closes #9