### PR TITLE
docs(architecture): clarify Nomad multi-host scheduling is planned, not implemented

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -31,10 +31,10 @@ contains no application code.
 | **ProjectHermes** | infrastructure | External message delivery bridge. Routes external-service events into NATS and delivers outbound messages to external services. |
 | **ProjectArgus** | infrastructure | Observability: Prometheus metrics, Loki log aggregation, Grafana dashboards, Promtail scraping. Feeds Odysseus dashboards. |
 | **AchaeanFleet** | infrastructure | Container image library. All agent and service images. Built by Proteus; run on the `homeric-mesh` Podman network. |
-| **Myrmidons repo** | provisioning | GitOps source of truth. YAML manifests describe desired agent state; Agamemnon API reconciliation applies them. Also holds all agent templates and container specs. |
+| **Myrmidons repo** | provisioning | GitOps source of truth. YAML manifests describe desired agent state; Agamemnon API reconciliation applies them. Also holds all agent templates and container specs. Multi-host scheduling via Nomad is planned for a future phase; currently supports `local` and `docker` deployment types only. |
 | **ProjectTelemachy** | provisioning | Declarative workflow engine. Used programmatically by Agamemnon and Nestor. Not a user-facing service. |
 | **ProjectProteus** | ci-cd | CI/CD. Dagger TypeScript pipelines. Builds AchaeanFleet images; dispatches `agamemnon-apply` on merge. |
-| **Myrmidons (workers)** | workers | Single worker pool. Pull-based, rate-limited (MaxAckPending=1). Queue subscription determines role. |
+| **Myrmidons (workers)** | workers | Single-host worker pool. Pull-based, rate-limited (MaxAckPending=1). Queue subscription determines role. Multi-host clustering via Nomad is planned for a future phase. |
 | **ProjectScylla** | testing | AI agent ablation benchmarking; evaluates agent architectures across tiered configurations (T0–T6). |
 | **ProjectCharybdis** | testing | Chaos and resilience testing. Injects faults via Agamemnon `/v1/chaos/*` endpoints. |
 | **ProjectMnemosyne** | shared | Memory store for `advise` and `learn` plugins only. Not a template registry. |
@@ -180,6 +180,10 @@ YAML manifests in the Myrmidons repo describe the desired state of the agent mes
 dispatches `agamemnon-apply` on merge; Agamemnon reconciles live state against the manifests via
 its REST API. The Myrmidons repo is the authoritative source of container specs and agent
 templates (not ProjectMnemosyne).
+
+**Current state:** Myrmidons supports single-host deployments with `local` and `docker` deployment
+types. Multi-host agent scheduling via Nomad is planned for a future phase and is tracked in
+HomericIntelligence/Myrmidons#5.
 
 ### AchaeanFleet
 All container images are defined and versioned in AchaeanFleet. Images run on the `homeric-mesh`


### PR DESCRIPTION
## Summary

Updates Architecture.md to accurately state that Nomad-based multi-host agent scheduling is planned for a future phase, not currently implemented.

- Myrmidons currently only supports `local` and `docker` deployment types
- No Nomad job files, HCL templates, or Nomad API client exist in Myrmidons
- Cross-references HomericIntelligence/Myrmidons#5 where ADR-007 documents this gap

Closes #115