### PR TITLE
docs(nats): add payload schema and canonical task status lifecycle

### DIFF
--- a/docs/nats-subjects.md
+++ b/docs/nats-subjects.md
@@ -13,6 +13,111 @@ Central reference for the HomericIntelligence NATS event bus. See [ADR 005](adr/
 | `hi.tasks.{team_id}.{task_id}.completed` | Hermes | Keystone, Argus | Task completed |
 | `hi.tasks.{team_id}.{task_id}.failed` | Hermes | Keystone, Argus | Task failed |
 
+## Message Payload Schema
+
+All NATS messages follow a standard envelope structure:
+
+```json
+{
+  "event": "task.completed",
+  "data": { /* event-specific fields */ },
+  "timestamp": "2026-04-23T15:30:00Z"
+}
+```
+
+The `timestamp` field is ISO-8601 formatted UTC. The `data` object contains event-specific fields; **note that `status` is nested inside `data`, not at the top level**.
+
+### Event-Specific Data Fields
+
+**task.created**
+```json
+{
+  "event": "task.created",
+  "data": {
+    "task_id": "task-uuid",
+    "team_id": "team-id",
+    "title": "Task title",
+    "description": "Task description",
+    "status": "backlog",
+    "assigned_to": null
+  },
+  "timestamp": "2026-04-23T15:30:00Z"
+}
+```
+
+**task.updated**
+```json
+{
+  "event": "task.updated",
+  "data": {
+    "task_id": "task-uuid",
+    "team_id": "team-id",
+    "status": "in_progress",
+    "assigned_to": "agent-id",
+    "changes": ["status", "assigned_to"]
+  },
+  "timestamp": "2026-04-23T15:30:00Z"
+}
+```
+
+**task.completed**
+```json
+{
+  "event": "task.completed",
+  "data": {
+    "task_id": "task-uuid",
+    "team_id": "team-id",
+    "status": "completed",
+    "result": "Task completed successfully",
+    "completed_at": "2026-04-23T15:35:00Z"
+  },
+  "timestamp": "2026-04-23T15:35:00Z"
+}
+```
+
+**task.failed**
+```json
+{
+  "event": "task.failed",
+  "data": {
+    "task_id": "task-uuid",
+    "team_id": "team-id",
+    "status": "failed",
+    "error": "Task execution failed",
+    "error_code": "EXECUTION_ERROR",
+    "failed_at": "2026-04-23T15:35:00Z"
+  },
+  "timestamp": "2026-04-23T15:35:00Z"
+}
+```
+
+**agent.created**
+```json
+{
+  "event": "agent.created",
+  "data": {
+    "host": "hostname",
+    "name": "agent-name",
+    "type": "agent-type",
+    "capabilities": ["cap1", "cap2"]
+  },
+  "timestamp": "2026-04-23T15:30:00Z"
+}
+```
+
+**agent.removed**
+```json
+{
+  "event": "agent.removed",
+  "data": {
+    "host": "hostname",
+    "name": "agent-name",
+    "removed_at": "2026-04-23T15:35:00Z"
+  },
+  "timestamp": "2026-04-23T15:35:00Z"
+}
+```
+
 ## JetStream Streams
 
 | Stream | Subjects | Created By |
@@ -41,9 +146,24 @@ await js.subscribe("hi.tasks.*.*.completed", cb=handler)
 
 ## Task Status Lifecycle
 
-```
-pending -> in_progress -> review -> completed
-                                 -> failed
-```
+All tasks follow a canonical lifecycle with eight possible statuses:
 
-Keystone advances DAGs when it sees `completed` (either as the subject verb or in the payload status field).
+| Status | Category | Description | NATS Event |
+|---|---|---|---|
+| `backlog` | Initial | Task created but not yet scheduled | task.created |
+| `pending` | Active | Task scheduled and awaiting assignment | (task.updated) |
+| `in_progress` | Active | Task assigned and execution underway | (task.updated) |
+| `review` | Active | Task execution complete, awaiting human review | (task.updated) |
+| `completed` | Terminal (success) | Task completed successfully | **task.completed** |
+| `failed` | Terminal (failure) | Task execution failed | **task.failed** |
+| `error` | Terminal (system error) | Task encountered unrecoverable system error | (task.failed) |
+| `cancelled` | Terminal (manual) | Task manually cancelled before completion | (task.updated) |
+
+**Transition Rules:**
+- Initial state: `backlog`
+- Active states flow: `backlog` → `pending` → `in_progress` → (`review`) → terminal
+- Terminal states are final: no transitions out
+- Only `completed` and `failed` trigger dedicated NATS events; other transitions use `task.updated`
+
+**Canonical Source of Truth:**
+This lifecycle is the authoritative specification for the HomericIntelligence ecosystem. ProjectKeystone, ProjectTelemachy, ProjectAgamemnon, and ProjectHermes must conform to these statuses and transition rules. Keystone advances DAGs when tasks reach terminal states (`completed`, `failed`, `error`, `cancelled`).


### PR DESCRIPTION
## Summary

Combined fix for #20 and #21 — both affect `docs/nats-subjects.md`.

**Payload schema (#20):** Adds a new Message Payload Schema section documenting the standard NATS message envelope `{event, data, timestamp}` and field-level docs for each event type. Clarifies that `status` is nested inside `data`, resolving the Keystone/Hermes parsing mismatch (ProjectKeystone#107).

**Task status lifecycle (#21):** Expands the lifecycle diagram to include all 8 statuses (backlog, pending, in_progress, review, completed, failed, error, cancelled) with initial/active/terminal classification and NATS event triggers. Establishes this file as the canonical cross-repo source of truth.

Closes #20
Closes #21