### PR TITLE
config(nats): bind HTTP monitoring endpoint to localhost only

### DIFF
--- a/configs/nats/leaf.conf
+++ b/configs/nats/leaf.conf
@@ -24,4 +24,5 @@ leafnodes {
 }
 
 # HTTP monitoring endpoint
-http_port = 8222
+# Monitoring bound to localhost only — access via ssh tunnel or local curl
+http: "127.0.0.1:8222"

--- a/configs/nats/server.conf
+++ b/configs/nats/server.conf
@@ -22,4 +22,5 @@ cluster {
 }
 
 # HTTP monitoring endpoint
-http_port = 8222
+# Monitoring bound to localhost only — access via ssh tunnel or local curl
+http: "127.0.0.1:8222"


### PR DESCRIPTION
## Summary

Binds the NATS HTTP monitoring endpoint to `127.0.0.1:8222` in both `server.conf` and `leaf.conf`, preventing unauthenticated exposure of cluster topology and JetStream state.

Previously `http_port = 8222` listened on all interfaces. Now `http: "127.0.0.1:8222"` restricts access to localhost.

To access monitoring from a remote host:
```bash
ssh -L 8222:localhost:8222 <nats-host>
curl http://localhost:8222/varz
```

Closes #35