### PR TITLE
fix(ci): detect conan profile before build idempotency test

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,5 +18,7 @@ jobs:
         with:
           submodules: recursive
       - uses: prefix-dev/setup-pixi@v0.8.1
+      - name: Detect conan profile
+        run: pixi run conan profile detect
       - name: Run idempotency test
         run: bash e2e/test-build-idempotent.sh


### PR DESCRIPTION
Fixes the Build idempotency CI failure where conan install fails because no default profile exists on the runner.

- Adds `conan profile detect` step after pixi setup, before the idempotency test script runs
- CI error was: 'The default build profile does not exist'

Fixes CI run 24871840714.