### PR TITLE
chore(ci): add unified org ruleset source-of-truth and tooling

### DIFF
--- a/configs/github/backups/branch-protection-pre-ruleset.json
+++ b/configs/github/backups/branch-protection-pre-ruleset.json
@@ -1,0 +1,1101 @@
+[
+  {
+    "repo": "Odysseus",
+    "protection": {
+      "url": "https://api.github.com/repos/HomericIntelligence/Odysseus/branches/main/protection",
+      "required_status_checks": {
+        "url": "https://api.github.com/repos/HomericIntelligence/Odysseus/branches/main/protection/required_status_checks",
+        "strict": false,
+        "contexts": [
+          "Validate configs"
+        ],
+        "contexts_url": "https://api.github.com/repos/HomericIntelligence/Odysseus/branches/main/protection/required_status_checks/contexts",
+        "checks": [
+          {
+            "context": "Validate configs",
+            "app_id": 15368
+          }
+        ]
+      },
+      "required_pull_request_reviews": {
+        "url": "https://api.github.com/repos/HomericIntelligence/Odysseus/branches/main/protection/required_pull_request_reviews",
+        "dismiss_stale_reviews": false,
+        "require_code_owner_reviews": false,
+        "require_last_push_approval": false,
+        "required_approving_review_count": 0
+      },
+      "required_signatures": {
+        "url": "https://api.github.com/repos/HomericIntelligence/Odysseus/branches/main/protection/required_signatures",
+        "enabled": false
+      },
+      "enforce_admins": {
+        "url": "https://api.github.com/repos/HomericIntelligence/Odysseus/branches/main/protection/enforce_admins",
+        "enabled": false
+      },
+      "required_linear_history": {
+        "enabled": true
+      },
+      "allow_force_pushes": {
+        "enabled": false
+      },
+      "allow_deletions": {
+        "enabled": false
+      },
+      "block_creations": {
+        "enabled": false
+      },
+      "required_conversation_resolution": {
+        "enabled": true
+      },
+      "lock_branch": {
+        "enabled": false
+      },
+      "allow_fork_syncing": {
+        "enabled": false
+      }
+    }
+  },
+  {
+    "repo": "AchaeanFleet",
+    "protection": {
+      "url": "https://api.github.com/repos/HomericIntelligence/AchaeanFleet/branches/main/protection",
+      "required_status_checks": {
+        "url": "https://api.github.com/repos/HomericIntelligence/AchaeanFleet/branches/main/protection/required_status_checks",
+        "strict": false,
+        "contexts": [],
+        "contexts_url": "https://api.github.com/repos/HomericIntelligence/AchaeanFleet/branches/main/protection/required_status_checks/contexts",
+        "checks": []
+      },
+      "required_pull_request_reviews": {
+        "url": "https://api.github.com/repos/HomericIntelligence/AchaeanFleet/branches/main/protection/required_pull_request_reviews",
+        "dismiss_stale_reviews": false,
+        "require_code_owner_reviews": false,
+        "require_last_push_approval": false,
+        "required_approving_review_count": 0
+      },
+      "required_signatures": {
+        "url": "https://api.github.com/repos/HomericIntelligence/AchaeanFleet/branches/main/protection/required_signatures",
+        "enabled": false
+      },
+      "enforce_admins": {
+        "url": "https://api.github.com/repos/HomericIntelligence/AchaeanFleet/branches/main/protection/enforce_admins",
+        "enabled": false
+      },
+      "required_linear_history": {
+        "enabled": true
+      },
+      "allow_force_pushes": {
+        "enabled": false
+      },
+      "allow_deletions": {
+        "enabled": false
+      },
+      "block_creations": {
+        "enabled": false
+      },
+      "required_conversation_resolution": {
+        "enabled": true
+      },
+      "lock_branch": {
+        "enabled": false
+      },
+      "allow_fork_syncing": {
+        "enabled": false
+      }
+    }
+  },
+  {
+    "repo": "ProjectArgus",
+    "protection": {
+      "url": "https://api.github.com/repos/HomericIntelligence/ProjectArgus/branches/main/protection",
+      "required_status_checks": {
+        "url": "https://api.github.com/repos/HomericIntelligence/ProjectArgus/branches/main/protection/required_status_checks",
+        "strict": false,
+        "contexts": [
+          "Validate configs"
+        ],
+        "contexts_url": "https://api.github.com/repos/HomericIntelligence/ProjectArgus/branches/main/protection/required_status_checks/contexts",
+        "checks": [
+          {
+            "context": "Validate configs",
+            "app_id": 15368
+          }
+        ]
+      },
+      "required_pull_request_reviews": {
+        "url": "https://api.github.com/repos/HomericIntelligence/ProjectArgus/branches/main/protection/required_pull_request_reviews",
+        "dismiss_stale_reviews": false,
+        "require_code_owner_reviews": false,
+        "require_last_push_approval": false,
+        "required_approving_review_count": 0
+      },
+      "required_signatures": {
+        "url": "https://api.github.com/repos/HomericIntelligence/ProjectArgus/branches/main/protection/required_signatures",
+        "enabled": false
+      },
+      "enforce_admins": {
+        "url": "https://api.github.com/repos/HomericIntelligence/ProjectArgus/branches/main/protection/enforce_admins",
+        "enabled": false
+      },
+      "required_linear_history": {
+        "enabled": true
+      },
+      "allow_force_pushes": {
+        "enabled": false
+      },
+      "allow_deletions": {
+        "enabled": false
+      },
+      "block_creations": {
+        "enabled": false
+      },
+      "required_conversation_resolution": {
+        "enabled": true
+      },
+      "lock_branch": {
+        "enabled": false
+      },
+      "allow_fork_syncing": {
+        "enabled": false
+      }
+    }
+  },
+  {
+    "repo": "ProjectHermes",
+    "protection": {
+      "url": "https://api.github.com/repos/HomericIntelligence/ProjectHermes/branches/main/protection",
+      "required_status_checks": {
+        "url": "https://api.github.com/repos/HomericIntelligence/ProjectHermes/branches/main/protection/required_status_checks",
+        "strict": false,
+        "contexts": [
+          "Lint & Test",
+          "Integration Tests (NATS)",
+          "Secret Scanning (gitleaks)"
+        ],
+        "contexts_url": "https://api.github.com/repos/HomericIntelligence/ProjectHermes/branches/main/protection/required_status_checks/contexts",
+        "checks": [
+          {
+            "context": "Lint & Test",
+            "app_id": 15368
+          },
+          {
+            "context": "Integration Tests (NATS)",
+            "app_id": 15368
+          },
+          {
+            "context": "Secret Scanning (gitleaks)",
+            "app_id": 15368
+          }
+        ]
+      },
+      "required_pull_request_reviews": {
+        "url": "https://api.github.com/repos/HomericIntelligence/ProjectHermes/branches/main/protection/required_pull_request_reviews",
+        "dismiss_stale_reviews": false,
+        "require_code_owner_reviews": false,
+        "require_last_push_approval": false,
+        "required_approving_review_count": 0
+      },
+      "required_signatures": {
+        "url": "https://api.github.com/repos/HomericIntelligence/ProjectHermes/branches/main/protection/required_signatures",
+        "enabled": false
+      },
+      "enforce_admins": {
+        "url": "https://api.github.com/repos/HomericIntelligence/ProjectHermes/branches/main/protection/enforce_admins",
+        "enabled": false
+      },
+      "required_linear_history": {
+        "enabled": true
+      },
+      "allow_force_pushes": {
+        "enabled": false
+      },
+      "allow_deletions": {
+        "enabled": false
+      },
+      "block_creations": {
+        "enabled": false
+      },
+      "required_conversation_resolution": {
+        "enabled": true
+      },
+      "lock_branch": {
+        "enabled": false
+      },
+      "allow_fork_syncing": {
+        "enabled": false
+      }
+    }
+  },
+  {
+    "repo": "ProjectTelemachy",
+    "protection": {
+      "url": "https://api.github.com/repos/HomericIntelligence/ProjectTelemachy/branches/main/protection",
+      "required_status_checks": {
+        "url": "https://api.github.com/repos/HomericIntelligence/ProjectTelemachy/branches/main/protection/required_status_checks",
+        "strict": false,
+        "contexts": [],
+        "contexts_url": "https://api.github.com/repos/HomericIntelligence/ProjectTelemachy/branches/main/protection/required_status_checks/contexts",
+        "checks": []
+      },
+      "required_pull_request_reviews": {
+        "url": "https://api.github.com/repos/HomericIntelligence/ProjectTelemachy/branches/main/protection/required_pull_request_reviews",
+        "dismiss_stale_reviews": false,
+        "require_code_owner_reviews": false,
+        "require_last_push_approval": false,
+        "required_approving_review_count": 0
+      },
+      "required_signatures": {
+        "url": "https://api.github.com/repos/HomericIntelligence/ProjectTelemachy/branches/main/protection/required_signatures",
+        "enabled": false
+      },
+      "enforce_admins": {
+        "url": "https://api.github.com/repos/HomericIntelligence/ProjectTelemachy/branches/main/protection/enforce_admins",
+        "enabled": false
+      },
+      "required_linear_history": {
+        "enabled": true
+      },
+      "allow_force_pushes": {
+        "enabled": false
+      },
+      "allow_deletions": {
+        "enabled": false
+      },
+      "block_creations": {
+        "enabled": false
+      },
+      "required_conversation_resolution": {
+        "enabled": true
+      },
+      "lock_branch": {
+        "enabled": false
+      },
+      "allow_fork_syncing": {
+        "enabled": false
+      }
+    }
+  },
+  {
+    "repo": "ProjectKeystone",
+    "protection": {
+      "url": "https://api.github.com/repos/HomericIntelligence/ProjectKeystone/branches/main/protection",
+      "required_status_checks": {
+        "url": "https://api.github.com/repos/HomericIntelligence/ProjectKeystone/branches/main/protection/required_status_checks",
+        "strict": false,
+        "contexts": [
+          "Benchmarks",
+          "Code Coverage",
+          "Test (asan)",
+          "Test (lsan)",
+          "Test (ubsan)"
+        ],
+        "contexts_url": "https://api.github.com/repos/HomericIntelligence/ProjectKeystone/branches/main/protection/required_status_checks/contexts",
+        "checks": [
+          {
+            "context": "Benchmarks",
+            "app_id": 15368
+          },
+          {
+            "context": "Code Coverage",
+            "app_id": 15368
+          },
+          {
+            "context": "Test (asan)",
+            "app_id": 15368
+          },
+          {
+            "context": "Test (lsan)",
+            "app_id": 15368
+          },
+          {
+            "context": "Test (ubsan)",
+            "app_id": 15368
+          }
+        ]
+      },
+      "required_pull_request_reviews": {
+        "url": "https://api.github.com/repos/HomericIntelligence/ProjectKeystone/branches/main/protection/required_pull_request_reviews",
+        "dismiss_stale_reviews": false,
+        "require_code_owner_reviews": false,
+        "require_last_push_approval": false,
+        "required_approving_review_count": 0
+      },
+      "required_signatures": {
+        "url": "https://api.github.com/repos/HomericIntelligence/ProjectKeystone/branches/main/protection/required_signatures",
+        "enabled": false
+      },
+      "enforce_admins": {
+        "url": "https://api.github.com/repos/HomericIntelligence/ProjectKeystone/branches/main/protection/enforce_admins",
+        "enabled": false
+      },
+      "required_linear_history": {
+        "enabled": true
+      },
+      "allow_force_pushes": {
+        "enabled": false
+      },
+      "allow_deletions": {
+        "enabled": false
+      },
+      "block_creations": {
+        "enabled": false
+      },
+      "required_conversation_resolution": {
+        "enabled": true
+      },
+      "lock_branch": {
+        "enabled": false
+      },
+      "allow_fork_syncing": {
+        "enabled": false
+      }
+    }
+  },
+  {
+    "repo": "Myrmidons",
+    "protection": {
+      "url": "https://api.github.com/repos/HomericIntelligence/Myrmidons/branches/main/protection",
+      "required_status_checks": {
+        "url": "https://api.github.com/repos/HomericIntelligence/Myrmidons/branches/main/protection/required_status_checks",
+        "strict": false,
+        "contexts": [],
+        "contexts_url": "https://api.github.com/repos/HomericIntelligence/Myrmidons/branches/main/protection/required_status_checks/contexts",
+        "checks": []
+      },
+      "required_pull_request_reviews": {
+        "url": "https://api.github.com/repos/HomericIntelligence/Myrmidons/branches/main/protection/required_pull_request_reviews",
+        "dismiss_stale_reviews": false,
+        "require_code_owner_reviews": false,
+        "require_last_push_approval": false,
+        "required_approving_review_count": 0
+      },
+      "required_signatures": {
+        "url": "https://api.github.com/repos/HomericIntelligence/Myrmidons/branches/main/protection/required_signatures",
+        "enabled": false
+      },
+      "enforce_admins": {
+        "url": "https://api.github.com/repos/HomericIntelligence/Myrmidons/branches/main/protection/enforce_admins",
+        "enabled": true
+      },
+      "required_linear_history": {
+        "enabled": true
+      },
+      "allow_force_pushes": {
+        "enabled": false
+      },
+      "allow_deletions": {
+        "enabled": false
+      },
+      "block_creations": {
+        "enabled": false
+      },
+      "required_conversation_resolution": {
+        "enabled": true
+      },
+      "lock_branch": {
+        "enabled": false
+      },
+      "allow_fork_syncing": {
+        "enabled": false
+      }
+    }
+  },
+  {
+    "repo": "ProjectProteus",
+    "protection": {
+      "url": "https://api.github.com/repos/HomericIntelligence/ProjectProteus/branches/main/protection",
+      "required_status_checks": {
+        "url": "https://api.github.com/repos/HomericIntelligence/ProjectProteus/branches/main/protection/required_status_checks",
+        "strict": false,
+        "contexts": [
+          "Lint Shell Scripts",
+          "Validate Pipeline Configs"
+        ],
+        "contexts_url": "https://api.github.com/repos/HomericIntelligence/ProjectProteus/branches/main/protection/required_status_checks/contexts",
+        "checks": [
+          {
+            "context": "Lint Shell Scripts",
+            "app_id": 15368
+          },
+          {
+            "context": "Validate Pipeline Configs",
+            "app_id": 15368
+          }
+        ]
+      },
+      "required_pull_request_reviews": {
+        "url": "https://api.github.com/repos/HomericIntelligence/ProjectProteus/branches/main/protection/required_pull_request_reviews",
+        "dismiss_stale_reviews": false,
+        "require_code_owner_reviews": false,
+        "require_last_push_approval": false,
+        "required_approving_review_count": 0
+      },
+      "required_signatures": {
+        "url": "https://api.github.com/repos/HomericIntelligence/ProjectProteus/branches/main/protection/required_signatures",
+        "enabled": false
+      },
+      "enforce_admins": {
+        "url": "https://api.github.com/repos/HomericIntelligence/ProjectProteus/branches/main/protection/enforce_admins",
+        "enabled": false
+      },
+      "required_linear_history": {
+        "enabled": true
+      },
+      "allow_force_pushes": {
+        "enabled": false
+      },
+      "allow_deletions": {
+        "enabled": false
+      },
+      "block_creations": {
+        "enabled": false
+      },
+      "required_conversation_resolution": {
+        "enabled": true
+      },
+      "lock_branch": {
+        "enabled": false
+      },
+      "allow_fork_syncing": {
+        "enabled": false
+      }
+    }
+  },
+  {
+    "repo": "ProjectOdyssey",
+    "protection": {
+      "url": "https://api.github.com/repos/HomericIntelligence/ProjectOdyssey/branches/main/protection",
+      "required_status_checks": {
+        "url": "https://api.github.com/repos/HomericIntelligence/ProjectOdyssey/branches/main/protection/required_status_checks",
+        "strict": false,
+        "contexts": [
+          "pre-commit",
+          "Mojo Package Compilation",
+          "Code Quality Analysis",
+          "Gradient Checking Tests",
+          "Data Utilities Test Suite",
+          "Python Tests",
+          "Test Coverage Validation",
+          "Test Metrics",
+          "Audit Shared Links",
+          "Mojo Syntax Validation",
+          "build-and-push (ci)",
+          "build-and-push (production)",
+          "build-and-push (runtime)",
+          "lint-notebooks",
+          "mypy",
+          "python-syntax",
+          "security-scan",
+          "summary",
+          "test-images",
+          "validate-notebooks",
+          "Autograd",
+          "Base",
+          "Build Validation",
+          "Core Gradient",
+          "Core Loss",
+          "Core Tensors",
+          "Examples",
+          "Gradient Coverage Report",
+          "Core Layers",
+          "Core Types & Fuzz",
+          "Integration Tests",
+          "Other Workflow Property Checks",
+          "Security Workflow Property Checks",
+          "Data Core",
+          "Data Datasets",
+          "Data Loaders",
+          "Data Transforms",
+          "Data Samplers",
+          "Data Formats"
+        ],
+        "contexts_url": "https://api.github.com/repos/HomericIntelligence/ProjectOdyssey/branches/main/protection/required_status_checks/contexts",
+        "checks": [
+          {
+            "context": "pre-commit",
+            "app_id": 15368
+          },
+          {
+            "context": "Mojo Package Compilation",
+            "app_id": 15368
+          },
+          {
+            "context": "Code Quality Analysis",
+            "app_id": 15368
+          },
+          {
+            "context": "Gradient Checking Tests",
+            "app_id": 15368
+          },
+          {
+            "context": "Data Utilities Test Suite",
+            "app_id": 15368
+          },
+          {
+            "context": "Python Tests",
+            "app_id": 15368
+          },
+          {
+            "context": "Test Coverage Validation",
+            "app_id": 15368
+          },
+          {
+            "context": "Test Metrics",
+            "app_id": 15368
+          },
+          {
+            "context": "Audit Shared Links",
+            "app_id": 15368
+          },
+          {
+            "context": "Mojo Syntax Validation",
+            "app_id": 15368
+          },
+          {
+            "context": "build-and-push (ci)",
+            "app_id": 15368
+          },
+          {
+            "context": "build-and-push (production)",
+            "app_id": 15368
+          },
+          {
+            "context": "build-and-push (runtime)",
+            "app_id": 15368
+          },
+          {
+            "context": "lint-notebooks",
+            "app_id": 15368
+          },
+          {
+            "context": "mypy",
+            "app_id": 15368
+          },
+          {
+            "context": "python-syntax",
+            "app_id": 15368
+          },
+          {
+            "context": "security-scan",
+            "app_id": 15368
+          },
+          {
+            "context": "summary",
+            "app_id": 15368
+          },
+          {
+            "context": "test-images",
+            "app_id": 15368
+          },
+          {
+            "context": "validate-notebooks",
+            "app_id": 15368
+          },
+          {
+            "context": "Autograd",
+            "app_id": 15368
+          },
+          {
+            "context": "Base",
+            "app_id": 15368
+          },
+          {
+            "context": "Build Validation",
+            "app_id": 15368
+          },
+          {
+            "context": "Core Gradient",
+            "app_id": 15368
+          },
+          {
+            "context": "Core Loss",
+            "app_id": 15368
+          },
+          {
+            "context": "Core Tensors",
+            "app_id": 15368
+          },
+          {
+            "context": "Examples",
+            "app_id": 15368
+          },
+          {
+            "context": "Gradient Coverage Report",
+            "app_id": 15368
+          },
+          {
+            "context": "Core Layers",
+            "app_id": 15368
+          },
+          {
+            "context": "Core Types & Fuzz",
+            "app_id": 15368
+          },
+          {
+            "context": "Integration Tests",
+            "app_id": 15368
+          },
+          {
+            "context": "Other Workflow Property Checks",
+            "app_id": 15368
+          },
+          {
+            "context": "Security Workflow Property Checks",
+            "app_id": 15368
+          },
+          {
+            "context": "Data Core",
+            "app_id": 15368
+          },
+          {
+            "context": "Data Datasets",
+            "app_id": 15368
+          },
+          {
+            "context": "Data Loaders",
+            "app_id": 15368
+          },
+          {
+            "context": "Data Transforms",
+            "app_id": 15368
+          },
+          {
+            "context": "Data Samplers",
+            "app_id": 15368
+          },
+          {
+            "context": "Data Formats",
+            "app_id": 15368
+          }
+        ]
+      },
+      "required_pull_request_reviews": {
+        "url": "https://api.github.com/repos/HomericIntelligence/ProjectOdyssey/branches/main/protection/required_pull_request_reviews",
+        "dismiss_stale_reviews": false,
+        "require_code_owner_reviews": false,
+        "require_last_push_approval": false,
+        "required_approving_review_count": 0
+      },
+      "required_signatures": {
+        "url": "https://api.github.com/repos/HomericIntelligence/ProjectOdyssey/branches/main/protection/required_signatures",
+        "enabled": false
+      },
+      "enforce_admins": {
+        "url": "https://api.github.com/repos/HomericIntelligence/ProjectOdyssey/branches/main/protection/enforce_admins",
+        "enabled": false
+      },
+      "required_linear_history": {
+        "enabled": true
+      },
+      "allow_force_pushes": {
+        "enabled": false
+      },
+      "allow_deletions": {
+        "enabled": false
+      },
+      "block_creations": {
+        "enabled": false
+      },
+      "required_conversation_resolution": {
+        "enabled": true
+      },
+      "lock_branch": {
+        "enabled": false
+      },
+      "allow_fork_syncing": {
+        "enabled": false
+      }
+    }
+  },
+  {
+    "repo": "ProjectScylla",
+    "protection": {
+      "url": "https://api.github.com/repos/HomericIntelligence/ProjectScylla/branches/main/protection",
+      "required_status_checks": {
+        "url": "https://api.github.com/repos/HomericIntelligence/ProjectScylla/branches/main/protection/required_status_checks",
+        "strict": false,
+        "contexts": [
+          "pre-commit",
+          "test (unit, tests/unit)",
+          "Dependency vulnerability scan",
+          "Secrets scan (gitleaks)",
+          "test (integration, tests/integration)"
+        ],
+        "contexts_url": "https://api.github.com/repos/HomericIntelligence/ProjectScylla/branches/main/protection/required_status_checks/contexts",
+        "checks": [
+          {
+            "context": "pre-commit",
+            "app_id": 15368
+          },
+          {
+            "context": "test (unit, tests/unit)",
+            "app_id": 15368
+          },
+          {
+            "context": "Dependency vulnerability scan",
+            "app_id": 15368
+          },
+          {
+            "context": "Secrets scan (gitleaks)",
+            "app_id": 15368
+          },
+          {
+            "context": "test (integration, tests/integration)",
+            "app_id": 15368
+          }
+        ]
+      },
+      "required_pull_request_reviews": {
+        "url": "https://api.github.com/repos/HomericIntelligence/ProjectScylla/branches/main/protection/required_pull_request_reviews",
+        "dismiss_stale_reviews": false,
+        "require_code_owner_reviews": false,
+        "require_last_push_approval": false,
+        "required_approving_review_count": 0
+      },
+      "required_signatures": {
+        "url": "https://api.github.com/repos/HomericIntelligence/ProjectScylla/branches/main/protection/required_signatures",
+        "enabled": false
+      },
+      "enforce_admins": {
+        "url": "https://api.github.com/repos/HomericIntelligence/ProjectScylla/branches/main/protection/enforce_admins",
+        "enabled": false
+      },
+      "required_linear_history": {
+        "enabled": true
+      },
+      "allow_force_pushes": {
+        "enabled": false
+      },
+      "allow_deletions": {
+        "enabled": false
+      },
+      "block_creations": {
+        "enabled": false
+      },
+      "required_conversation_resolution": {
+        "enabled": true
+      },
+      "lock_branch": {
+        "enabled": false
+      },
+      "allow_fork_syncing": {
+        "enabled": false
+      }
+    }
+  },
+  {
+    "repo": "ProjectMnemosyne",
+    "protection": {
+      "url": "https://api.github.com/repos/HomericIntelligence/ProjectMnemosyne/branches/main/protection",
+      "required_status_checks": {
+        "url": "https://api.github.com/repos/HomericIntelligence/ProjectMnemosyne/branches/main/protection/required_status_checks",
+        "strict": false,
+        "contexts": [
+          "validate"
+        ],
+        "contexts_url": "https://api.github.com/repos/HomericIntelligence/ProjectMnemosyne/branches/main/protection/required_status_checks/contexts",
+        "checks": [
+          {
+            "context": "validate",
+            "app_id": 15368
+          }
+        ]
+      },
+      "required_pull_request_reviews": {
+        "url": "https://api.github.com/repos/HomericIntelligence/ProjectMnemosyne/branches/main/protection/required_pull_request_reviews",
+        "dismiss_stale_reviews": false,
+        "require_code_owner_reviews": false,
+        "require_last_push_approval": false,
+        "required_approving_review_count": 0
+      },
+      "required_signatures": {
+        "url": "https://api.github.com/repos/HomericIntelligence/ProjectMnemosyne/branches/main/protection/required_signatures",
+        "enabled": false
+      },
+      "enforce_admins": {
+        "url": "https://api.github.com/repos/HomericIntelligence/ProjectMnemosyne/branches/main/protection/enforce_admins",
+        "enabled": false
+      },
+      "required_linear_history": {
+        "enabled": true
+      },
+      "allow_force_pushes": {
+        "enabled": false
+      },
+      "allow_deletions": {
+        "enabled": false
+      },
+      "block_creations": {
+        "enabled": false
+      },
+      "required_conversation_resolution": {
+        "enabled": true
+      },
+      "lock_branch": {
+        "enabled": false
+      },
+      "allow_fork_syncing": {
+        "enabled": false
+      }
+    }
+  },
+  {
+    "repo": "ProjectHephaestus",
+    "protection": {
+      "url": "https://api.github.com/repos/HomericIntelligence/ProjectHephaestus/branches/main/protection",
+      "required_status_checks": {
+        "url": "https://api.github.com/repos/HomericIntelligence/ProjectHephaestus/branches/main/protection/required_status_checks",
+        "strict": false,
+        "contexts": [
+          "test (ubuntu-latest, 3.12, integration)",
+          "test (ubuntu-latest, 3.12, unit)",
+          "lint"
+        ],
+        "contexts_url": "https://api.github.com/repos/HomericIntelligence/ProjectHephaestus/branches/main/protection/required_status_checks/contexts",
+        "checks": [
+          {
+            "context": "test (ubuntu-latest, 3.12, integration)",
+            "app_id": 15368
+          },
+          {
+            "context": "test (ubuntu-latest, 3.12, unit)",
+            "app_id": 15368
+          },
+          {
+            "context": "lint",
+            "app_id": 15368
+          }
+        ]
+      },
+      "required_pull_request_reviews": {
+        "url": "https://api.github.com/repos/HomericIntelligence/ProjectHephaestus/branches/main/protection/required_pull_request_reviews",
+        "dismiss_stale_reviews": false,
+        "require_code_owner_reviews": false,
+        "require_last_push_approval": false,
+        "required_approving_review_count": 0
+      },
+      "required_signatures": {
+        "url": "https://api.github.com/repos/HomericIntelligence/ProjectHephaestus/branches/main/protection/required_signatures",
+        "enabled": false
+      },
+      "enforce_admins": {
+        "url": "https://api.github.com/repos/HomericIntelligence/ProjectHephaestus/branches/main/protection/enforce_admins",
+        "enabled": false
+      },
+      "required_linear_history": {
+        "enabled": true
+      },
+      "allow_force_pushes": {
+        "enabled": false
+      },
+      "allow_deletions": {
+        "enabled": false
+      },
+      "block_creations": {
+        "enabled": false
+      },
+      "required_conversation_resolution": {
+        "enabled": true
+      },
+      "lock_branch": {
+        "enabled": false
+      },
+      "allow_fork_syncing": {
+        "enabled": false
+      }
+    }
+  },
+  {
+    "repo": "ProjectAgamemnon",
+    "protection": {
+      "url": "https://api.github.com/repos/HomericIntelligence/ProjectAgamemnon/branches/main/protection",
+      "required_status_checks": {
+        "url": "https://api.github.com/repos/HomericIntelligence/ProjectAgamemnon/branches/main/protection/required_status_checks",
+        "strict": false,
+        "contexts": [
+          "All Build/Test Checks",
+          "All Static Analysis Checks"
+        ],
+        "contexts_url": "https://api.github.com/repos/HomericIntelligence/ProjectAgamemnon/branches/main/protection/required_status_checks/contexts",
+        "checks": [
+          {
+            "context": "All Build/Test Checks",
+            "app_id": 15368
+          },
+          {
+            "context": "All Static Analysis Checks",
+            "app_id": 15368
+          }
+        ]
+      },
+      "required_pull_request_reviews": {
+        "url": "https://api.github.com/repos/HomericIntelligence/ProjectAgamemnon/branches/main/protection/required_pull_request_reviews",
+        "dismiss_stale_reviews": false,
+        "require_code_owner_reviews": false,
+        "require_last_push_approval": false,
+        "required_approving_review_count": 0
+      },
+      "required_signatures": {
+        "url": "https://api.github.com/repos/HomericIntelligence/ProjectAgamemnon/branches/main/protection/required_signatures",
+        "enabled": false
+      },
+      "enforce_admins": {
+        "url": "https://api.github.com/repos/HomericIntelligence/ProjectAgamemnon/branches/main/protection/enforce_admins",
+        "enabled": false
+      },
+      "required_linear_history": {
+        "enabled": true
+      },
+      "allow_force_pushes": {
+        "enabled": false
+      },
+      "allow_deletions": {
+        "enabled": false
+      },
+      "block_creations": {
+        "enabled": false
+      },
+      "required_conversation_resolution": {
+        "enabled": true
+      },
+      "lock_branch": {
+        "enabled": false
+      },
+      "allow_fork_syncing": {
+        "enabled": false
+      }
+    }
+  },
+  {
+    "repo": "ProjectNestor",
+    "protection": {
+      "url": "https://api.github.com/repos/HomericIntelligence/ProjectNestor/branches/main/protection",
+      "required_status_checks": {
+        "url": "https://api.github.com/repos/HomericIntelligence/ProjectNestor/branches/main/protection/required_status_checks",
+        "strict": false,
+        "contexts": [
+          "All Build/Test Checks",
+          "All Static Analysis Checks",
+          "All Coverage Checks"
+        ],
+        "contexts_url": "https://api.github.com/repos/HomericIntelligence/ProjectNestor/branches/main/protection/required_status_checks/contexts",
+        "checks": [
+          {
+            "context": "All Build/Test Checks",
+            "app_id": 15368
+          },
+          {
+            "context": "All Static Analysis Checks",
+            "app_id": 15368
+          },
+          {
+            "context": "All Coverage Checks",
+            "app_id": 15368
+          }
+        ]
+      },
+      "required_pull_request_reviews": {
+        "url": "https://api.github.com/repos/HomericIntelligence/ProjectNestor/branches/main/protection/required_pull_request_reviews",
+        "dismiss_stale_reviews": false,
+        "require_code_owner_reviews": false,
+        "require_last_push_approval": false,
+        "required_approving_review_count": 0
+      },
+      "required_signatures": {
+        "url": "https://api.github.com/repos/HomericIntelligence/ProjectNestor/branches/main/protection/required_signatures",
+        "enabled": false
+      },
+      "enforce_admins": {
+        "url": "https://api.github.com/repos/HomericIntelligence/ProjectNestor/branches/main/protection/enforce_admins",
+        "enabled": false
+      },
+      "required_linear_history": {
+        "enabled": true
+      },
+      "allow_force_pushes": {
+        "enabled": false
+      },
+      "allow_deletions": {
+        "enabled": false
+      },
+      "block_creations": {
+        "enabled": false
+      },
+      "required_conversation_resolution": {
+        "enabled": true
+      },
+      "lock_branch": {
+        "enabled": false
+      },
+      "allow_fork_syncing": {
+        "enabled": false
+      }
+    }
+  },
+  {
+    "repo": "ProjectCharybdis",
+    "protection": {
+      "url": "https://api.github.com/repos/HomericIntelligence/ProjectCharybdis/branches/main/protection",
+      "required_status_checks": {
+        "url": "https://api.github.com/repos/HomericIntelligence/ProjectCharybdis/branches/main/protection/required_status_checks",
+        "strict": false,
+        "contexts": [
+          "All Build/Test Checks",
+          "All Static Analysis Checks",
+          "All Coverage Checks"
+        ],
+        "contexts_url": "https://api.github.com/repos/HomericIntelligence/ProjectCharybdis/branches/main/protection/required_status_checks/contexts",
+        "checks": [
+          {
+            "context": "All Build/Test Checks",
+            "app_id": 15368
+          },
+          {
+            "context": "All Static Analysis Checks",
+            "app_id": 15368
+          },
+          {
+            "context": "All Coverage Checks",
+            "app_id": 15368
+          }
+        ]
+      },
+      "required_pull_request_reviews": {
+        "url": "https://api.github.com/repos/HomericIntelligence/ProjectCharybdis/branches/main/protection/required_pull_request_reviews",
+        "dismiss_stale_reviews": false,
+        "require_code_owner_reviews": false,
+        "require_last_push_approval": false,
+        "required_approving_review_count": 0
+      },
+      "required_signatures": {
+        "url": "https://api.github.com/repos/HomericIntelligence/ProjectCharybdis/branches/main/protection/required_signatures",
+        "enabled": false
+      },
+      "enforce_admins": {
+        "url": "https://api.github.com/repos/HomericIntelligence/ProjectCharybdis/branches/main/protection/enforce_admins",
+        "enabled": false
+      },
+      "required_linear_history": {
+        "enabled": true
+      },
+      "allow_force_pushes": {
+        "enabled": false
+      },
+      "allow_deletions": {
+        "enabled": false
+      },
+      "block_creations": {
+        "enabled": false
+      },
+      "required_conversation_resolution": {
+        "enabled": true
+      },
+      "lock_branch": {
+        "enabled": false
+      },
+      "allow_fork_syncing": {
+        "enabled": false
+      }
+    }
+  }
+]

--- a/configs/github/canonical-checks.md
+++ b/configs/github/canonical-checks.md
@@ -1,0 +1,56 @@
+# HomericIntelligence — Canonical Required CI Check Names
+
+All 15 repos must emit these exact GitHub Actions status check names.
+Each check must run a **real validator** — no echo-true placeholders.
+
+## Required checks (block merge if failing)
+
+| Context name | Category | Validator examples |
+|---|---|---|
+| `lint` | Linting | pre-commit, ruff, shellcheck, yamllint, clang-format |
+| `unit-tests` | Testing | pytest, ctest, mojo test, bats |
+| `integration-tests` | Testing | network integration run; schema-validation for no-network repos |
+| `security/dependency-scan` | Security | pip-audit, conan audit, trivy fs, npm audit |
+| `security/secrets-scan` | Security | gitleaks |
+| `build` | Build | pixi run build, cmake --build, docker build |
+| `typecheck` | Linting | mypy, pyright, clang-tidy |
+| `schema-validation` | Validation | check-jsonschema against workflow YAMLs / pixi.toml / NATS schemas |
+| `deps/version-sync` | Validation | verify VERSION/pyproject.toml/pixi.toml/Conanfile parity |
+
+## Informational checks (report but do not block merge)
+
+| Context name | Category | Validator |
+|---|---|---|
+| `docs/link-check` | Documentation | markdown-link-check |
+| `ci/action-pinning` | CI hygiene | zizmor or pinact |
+
+## Naming convention
+
+All canonical jobs MUST be defined in `.github/workflows/_required.yml` in each repo.
+The GitHub status check name is `<workflow.name> / <job.name>`.
+The `_required.yml` workflow is named `Required Checks` and each job's `name:` field
+is set to the canonical context string exactly (e.g. `name: lint`).
+
+This means each context in the org ruleset resolves to:
+`Required Checks / lint`, `Required Checks / unit-tests`, etc.
+
+**Wait** — this means the required_status_checks contexts in org-ruleset.json must be
+updated to include the workflow prefix. Check the GitHub docs: org ruleset
+`required_status_checks` entries use the full check name as GitHub reports it, which
+for Actions is `<workflow name> / <job name>`.
+
+Actually, re-check: for GitHub rulesets (not classic branch protection), the
+`required_status_checks` `context` field matches the check name exactly as it appears
+in the PR checks list. For GitHub Actions, that is `<workflow-name> / <job-name>` when
+the job has a `name:` field, or just `<job-id>` when it doesn't. So if the workflow
+`name:` is `Required Checks` and the job `name:` is `lint`, the context is
+`Required Checks / lint`.
+
+The `org-ruleset.json` contexts above assume the job names are used directly as contexts.
+If the workflow adds a prefix, update the JSON accordingly. Verify by opening one test PR
+after the first `_required.yml` lands and reading `gh pr checks` output to see the exact
+strings GitHub reports.
+
+For now, write the JSON with bare names (`lint`, `unit-tests`, etc.) as placeholders.
+After Wave 1 PRs merge and a test PR is opened, the exact context strings will be
+confirmed and the JSON updated if needed before the ruleset is applied in Phase 3.

--- a/configs/github/org-ruleset-active.json
+++ b/configs/github/org-ruleset-active.json
@@ -1,0 +1,46 @@
+{
+  "name": "homeric-main-baseline",
+  "target": "branch",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": { "include": ["refs/heads/main"], "exclude": [] },
+    "repository_name": { "include": ["~ALL"], "exclude": [], "protected": true }
+  },
+  "bypass_actors": [
+    { "actor_id": 1, "actor_type": "OrganizationAdmin", "bypass_mode": "pull_request" },
+    { "actor_id": 49699333, "actor_type": "Integration", "bypass_mode": "pull_request" }
+  ],
+  "rules": [
+    { "type": "deletion" },
+    { "type": "non_fast_forward" },
+    { "type": "required_linear_history" },
+    { "type": "required_signatures" },
+    {
+      "type": "pull_request",
+      "parameters": {
+        "required_approving_review_count": 0,
+        "dismiss_stale_reviews_on_push": false,
+        "require_code_owner_review": false,
+        "require_last_push_approval": false,
+        "required_review_thread_resolution": true
+      }
+    },
+    {
+      "type": "required_status_checks",
+      "parameters": {
+        "strict_required_status_checks_policy": false,
+        "required_status_checks": [
+          { "context": "lint" },
+          { "context": "unit-tests" },
+          { "context": "integration-tests" },
+          { "context": "security/dependency-scan" },
+          { "context": "security/secrets-scan" },
+          { "context": "build" },
+          { "context": "typecheck" },
+          { "context": "schema-validation" },
+          { "context": "deps/version-sync" }
+        ]
+      }
+    }
+  ]
+}

--- a/configs/github/org-ruleset.json
+++ b/configs/github/org-ruleset.json
@@ -1,0 +1,46 @@
+{
+  "name": "homeric-main-baseline",
+  "target": "branch",
+  "enforcement": "evaluate",
+  "conditions": {
+    "ref_name": { "include": ["refs/heads/main"], "exclude": [] },
+    "repository_name": { "include": ["~ALL"], "exclude": [], "protected": true }
+  },
+  "bypass_actors": [
+    { "actor_id": 1, "actor_type": "OrganizationAdmin", "bypass_mode": "pull_request" },
+    { "actor_id": 49699333, "actor_type": "Integration", "bypass_mode": "pull_request" }
+  ],
+  "rules": [
+    { "type": "deletion" },
+    { "type": "non_fast_forward" },
+    { "type": "required_linear_history" },
+    { "type": "required_signatures" },
+    {
+      "type": "pull_request",
+      "parameters": {
+        "required_approving_review_count": 0,
+        "dismiss_stale_reviews_on_push": false,
+        "require_code_owner_review": false,
+        "require_last_push_approval": false,
+        "required_review_thread_resolution": true
+      }
+    },
+    {
+      "type": "required_status_checks",
+      "parameters": {
+        "strict_required_status_checks_policy": false,
+        "required_status_checks": [
+          { "context": "lint" },
+          { "context": "unit-tests" },
+          { "context": "integration-tests" },
+          { "context": "security/dependency-scan" },
+          { "context": "security/secrets-scan" },
+          { "context": "build" },
+          { "context": "typecheck" },
+          { "context": "schema-validation" },
+          { "context": "deps/version-sync" }
+        ]
+      }
+    }
+  ]
+}

--- a/justfile
+++ b/justfile
@@ -561,3 +561,44 @@ hermes-hub-down:
 # Stream logs from hermes compose stack (optional: pass service name, e.g. just hermes-hub-logs agamemnon)
 hermes-hub-logs SERVICE="":
     ssh hermes "cd Odysseus && podman compose -f docker-compose.e2e.yml -f e2e/docker-compose.hermes-hub.yml logs --tail=100 {{ SERVICE }}"
+
+# ===========================================================================
+# GitHub Org Ruleset Management
+# ===========================================================================
+
+# Snapshot all 15 repos' current classic branch protection to a timestamped backup file
+ruleset-backup:
+    mkdir -p configs/github/backups
+    ./tools/github/snapshot-protection.sh > "configs/github/backups/rulesets-$(date +%Y%m%d-%H%M%S).json"
+    @echo "Backup written."
+
+# Snapshot all 15 repos' classic branch protection to the canonical pre-ruleset backup file
+protection-snapshot:
+    mkdir -p configs/github/backups
+    ./tools/github/snapshot-protection.sh > configs/github/backups/branch-protection-pre-ruleset.json
+    @echo "Snapshot written to configs/github/backups/branch-protection-pre-ruleset.json"
+
+# Create or update the org-level ruleset (default: evaluate mode JSON)
+ruleset-apply FILE="configs/github/org-ruleset.json":
+    ./tools/github/apply-org-ruleset.sh "{{FILE}}"
+
+# Validate the live org ruleset against the canonical JSON and print current enforcement + checks
+ruleset-validate:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    ORG=HomericIntelligence
+    NAME=homeric-main-baseline
+    live=$(gh api "orgs/$ORG/rulesets" --paginate --jq ".[] | select(.name == \"$NAME\")" 2>/dev/null || echo "null")
+    if [[ "$live" == "null" ]]; then
+      echo "ERROR: Ruleset '$NAME' not found in org." >&2
+      exit 1
+    fi
+    echo "Live ruleset enforcement: $(echo "$live" | jq -r '.enforcement')"
+    echo "Live required checks:"
+    echo "$live" | jq -r '.rules[] | select(.type == "required_status_checks") | .parameters.required_status_checks[].context' 2>/dev/null || echo "  (none)"
+    echo "Canonical required checks (from file):"
+    jq -r '.rules[] | select(.type == "required_status_checks") | .parameters.required_status_checks[].context' configs/github/org-ruleset.json
+
+# Remove classic branch protection from ALL 15 repos (requires confirmation; run after ruleset is active)
+protection-remove-all:
+    ./tools/github/remove-classic-protection.sh --all

--- a/tools/github/apply-org-ruleset.sh
+++ b/tools/github/apply-org-ruleset.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# apply-org-ruleset.sh <ruleset-json-file>
+# Creates the org ruleset if it doesn't exist; updates it if it does.
+# Requires: gh with admin:org scope, jq
+
+ORG="HomericIntelligence"
+RULESET_NAME="homeric-main-baseline"
+JSON_FILE="${1:-configs/github/org-ruleset.json}"
+
+if [[ ! -f "$JSON_FILE" ]]; then
+  echo "ERROR: $JSON_FILE not found" >&2
+  exit 1
+fi
+
+# Check for existing ruleset with this name
+existing_id=$(gh api "orgs/$ORG/rulesets" --paginate \
+  --jq ".[] | select(.name == \"$RULESET_NAME\") | .id" 2>/dev/null || echo "")
+
+if [[ -z "$existing_id" ]]; then
+  echo "Creating new org ruleset '$RULESET_NAME'..."
+  gh api -X POST "orgs/$ORG/rulesets" --input "$JSON_FILE"
+  echo "Created."
+else
+  echo "Updating existing org ruleset '$RULESET_NAME' (id: $existing_id)..."
+  gh api -X PUT "orgs/$ORG/rulesets/$existing_id" --input "$JSON_FILE"
+  echo "Updated."
+fi

--- a/tools/github/remove-classic-protection.sh
+++ b/tools/github/remove-classic-protection.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# remove-classic-protection.sh [--repo REPO | --all]
+# Removes classic branch protection from one or all repos.
+# Requires confirmation before --all.
+
+ORG="HomericIntelligence"
+ALL_REPOS=(Odysseus AchaeanFleet ProjectArgus ProjectHermes ProjectTelemachy ProjectKeystone Myrmidons ProjectProteus ProjectOdyssey ProjectScylla ProjectMnemosyne ProjectHephaestus ProjectAgamemnon ProjectNestor ProjectCharybdis)
+
+if [[ "${1:-}" == "--repo" && -n "${2:-}" ]]; then
+  repo="$2"
+  echo "Removing classic branch protection from $ORG/$repo/branches/main..."
+  gh api -X DELETE "repos/$ORG/$repo/branches/main/protection"
+  echo "Done: $repo"
+elif [[ "${1:-}" == "--all" ]]; then
+  echo "WARNING: This will remove classic branch protection from ALL 15 repos."
+  echo "The org-level ruleset must already be active before running this."
+  read -r -p "Type 'yes' to confirm: " confirm
+  if [[ "$confirm" != "yes" ]]; then
+    echo "Aborted."
+    exit 1
+  fi
+  for repo in "${ALL_REPOS[@]}"; do
+    echo "Removing $repo..."
+    gh api -X DELETE "repos/$ORG/$repo/branches/main/protection" 2>/dev/null && echo "  Done." || echo "  Already removed or 404."
+  done
+else
+  echo "Usage: $0 --repo REPO | --all"
+  exit 1
+fi

--- a/tools/github/snapshot-protection.sh
+++ b/tools/github/snapshot-protection.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# snapshot-protection.sh
+# Snapshots classic branch protection from all 15 repos to stdout as JSON array.
+# Usage: ./tools/github/snapshot-protection.sh > configs/github/backups/branch-protection-$(date +%Y%m%d).json
+
+ORG="HomericIntelligence"
+REPOS=(Odysseus AchaeanFleet ProjectArgus ProjectHermes ProjectTelemachy ProjectKeystone Myrmidons ProjectProteus ProjectOdyssey ProjectScylla ProjectMnemosyne ProjectHephaestus ProjectAgamemnon ProjectNestor ProjectCharybdis)
+
+result="[]"
+for repo in "${REPOS[@]}"; do
+  echo "Snapshotting $repo..." >&2
+  protection=$(gh api "repos/$ORG/$repo/branches/main/protection" 2>/dev/null || echo "null")
+  result=$(echo "$result" | jq --arg r "$repo" --argjson p "$protection" '. + [{repo: $r, protection: $p}]')
+done
+echo "$result"


### PR DESCRIPTION
## Summary

- Adds `configs/github/org-ruleset.json` as the canonical source of truth for the `homeric-main-baseline` org-level ruleset
- Adds `configs/github/org-ruleset-active.json` (enforcement=active variant, applied after 48h evaluate soak)
- Adds `configs/github/canonical-checks.md` documenting all 9 required CI check names by category
- Snapshots all 15 repos' current classic branch protection to `configs/github/backups/branch-protection-pre-ruleset.json` for rollback
- Adds `tools/github/` helper scripts for applying, snapshotting, and removing org ruleset + classic protection
- Extends `justfile` with `ruleset-apply`, `ruleset-validate`, `ruleset-backup`, `protection-snapshot`, `protection-remove-all` recipes

## Test plan

- [ ] `just ruleset-validate` succeeds once the org ruleset is applied
- [ ] `just protection-snapshot` writes a valid JSON array to backups/
- [ ] `./tools/github/apply-org-ruleset.sh` creates or updates the ruleset idempotently

🤖 Generated with Claude Code