### PR TITLE
fix(install): extend PATH before Phase 1 detect

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -116,6 +116,21 @@ _should_run_phase() {
 STATE_FILE="${TMPDIR:-/tmp}/odysseus-install-state-$$.env"
 trap 'rm -f "$STATE_FILE"' EXIT
 
+# ─── Extend PATH for previously-installed tools ──────────────────────────────
+# Tools installed by prior runs (pixi, just, brew, go) write to user-local dirs
+# that are added to PATH via ~/.bashrc — but install.sh runs in a non-interactive
+# bash that doesn't source .bashrc. Without this, Phase 1 detect falsely reports
+# already-installed tools as missing on every re-run.
+for _p in \
+    "$HOME/.pixi/bin" \
+    "$HOME/.local/bin" \
+    "/home/linuxbrew/.linuxbrew/bin" \
+    "/usr/local/go/bin"
+do
+    [[ -d "$_p" ]] && [[ ":$PATH:" != *":$_p:"* ]] && export PATH="$_p:$PATH"
+done
+unset _p
+
 # ─── Phase 1: Detect ─────────────────────────────────────────────────────────
 echo ""
 echo -e "${BOLD}${CYAN}━━━ Phase 1: Detect ━━━${NC}"

--- a/install_dev.sh
+++ b/install_dev.sh
@@ -53,6 +53,19 @@ if ! ODYSSEUS_ROOT="$(_find_odysseus_root)"; then
 fi
 export ODYSSEUS_ROOT
 
+# ─── Extend PATH for tools installed by install.sh ───────────────────────────
+# install.sh writes pixi/just/brew binaries to user-local dirs added to ~/.bashrc.
+# This non-interactive shell doesn't source .bashrc, so add them explicitly.
+for _p in \
+    "$HOME/.pixi/bin" \
+    "$HOME/.local/bin" \
+    "/home/linuxbrew/.linuxbrew/bin" \
+    "/usr/local/go/bin"
+do
+    [[ -d "$_p" ]] && [[ ":$PATH:" != *":$_p:"* ]] && export PATH="$_p:$PATH"
+done
+unset _p
+
 # ─── Prerequisite check ───────────────────────────────────────────────────────
 PREREQ_ERRORS=()
 


### PR DESCRIPTION
## Summary

`install.sh --check` was falsely reporting tools as missing immediately after a successful `--install` on the same machine.

**Root cause:** `install.sh` runs in non-interactive bash, which does NOT source `~/.bashrc`. Tools installed by previous runs (pixi → `~/.pixi/bin`, just → `~/.local/bin`, brew → `/home/linuxbrew/.linuxbrew/bin`, go → `/usr/local/go/bin`) become invisible to Phase 1 detection because the PATH extension lives in `~/.bashrc`.

The script already had a PATH-extension block AFTER Phase 2, but that runs too late — Phase 1 detect has already concluded everything is missing.

## Fix

Add the same PATH-extension block at the top of `install.sh` (before Phase 1) and at the top of `install_dev.sh` (before its prerequisite check). The post-Phase-2 block stays because it's still useful within a single run for tools that get installed during that run.

## Validation

End-to-end container validation found this bug. After fix, `bash install.sh --install && bash install.sh --install && bash install.sh --check` all exit 0 in a fresh Debian 12 container.

## Test plan

- [ ] Container validation: install → re-install (idempotency) → --check all exit 0
- [ ] Required CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)