### PR TITLE
chore: bump ProjectArgus submodule pin to Atlas v0.2.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ node_modules/
 
 # Temporary files
 .claude/worktrees/
+.claude/scheduled_tasks.lock
 .issue_implementer/
 *.tmp
 


### PR DESCRIPTION
## Summary

- Advances ProjectArgus pin from `e804520` (Atlas M6) to `7b2c8c7` (Atlas v0.2.0 release)
- Adds `.claude/scheduled_tasks.lock` to `.gitignore` (per-session runtime lockfile)

## What's in Atlas v0.2.0

Cherry-picked highlights since M6:
- `feat(atlas)`: Dockerfile + GHCR release pipeline + supply-chain hardening (#448)
- `feat(atlas)`: live metrics + real `/readyz` aggregator (#446)
- `feat(atlas)`: wire NATS subscriber into events.Bus + integration test (#445)
- `test(atlas)`: store, mnemosyne XSS, middleware, e2e refresh (#447)
- `fix(atlas)`: tier-1 security + missing review charter (#444)
- `docs(changelog)`: lock v0.2.0 release notes for tag (#456)

## Test plan

- [ ] All 8 required CI checks pass
- [ ] No regressions in `just status` / submodule init paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)