### PR TITLE
chore: bump ProjectArgus to v0.2.0 security patch + Odysseus v0.1.1

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -1,6 +1,6 @@
 [workspace]
 name = "odysseus"
-version = "0.1.0"
+version = "0.1.1"
 description = "Meta-repo and unified architecture hub for the HomericIntelligence distributed agent mesh"
 channels = ["conda-forge"]
 platforms = ["linux-64"]


### PR DESCRIPTION
## Summary
- Bumps `infrastructure/ProjectArgus` submodule pin `7b2c8c7` → `f4ab0a1`
  - `fix(security): close v0.2.0 auth-bypass + SSE token-leak regressions`
  - `docs: close audit doc-drift findings and add operational runbook`
- Bumps Odysseus workspace version in `pixi.toml` `0.1.0` → `0.1.1` to mark this cross-repo integration point.

## Test plan
- [ ] CI: submodule pin resolves and clones cleanly
- [ ] CI: pixi workspace metadata still parses
- [ ] No other submodule pins changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)