### PR TITLE
chore: easy-issue sweep — refs #207 #205 #204 #203 #202

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,32 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Added
+- `install.sh` and `install_dev.sh` bootstrap scripts with container-based CI
+  validation (#260, #265).
+- E2E CI harden-job verification script (#276).
+- Unified org ruleset source-of-truth, tooling, and per-repo ruleset configs.
+- Unified required-checks workflow at the meta-repo level.
+- `.gitignore` entry for `scheduled_tasks.lock`.
+
+### Changed
+- Bumped `ProjectArgus` submodule pin through Atlas M2/M3/M4/M5/M6 and
+  v0.2.0 security patch (#266, #268, #269, #272, #273, #275).
+- Refreshed submodule pins to latest `main` SHAs on 2026-05-03, 2026-05-06,
+  and 2026-05-09 (#259, #274, #277).
+- Extended CI workflow with markdownlint, pixi, justfile, and symlink checks
+  (#22, #256).
+- Reformatted ADRs to 80-char line limit and replaced markdownlint config.
+
+### Fixed
+- `install.sh` now extends `PATH` before Phase 1 detection so prior-installed
+  tools are found (#271).
+- CI: skip `ProjectOdyssey` in idempotent-build when Podman is unavailable
+  (#262).
+- CI: install `just` in build, update trivy, replace gitleaks-action (#254).
+- CI: harden Odysseus workflow and split harden checks into a dedicated job
+  per issue #22 spec.
+
 ---
 
 ## [0.4.0] - 2026-03-29

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (c) 2025, HomericIntelligence Contributors
+Copyright (c) 2025-2026, HomericIntelligence Contributors
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/e2e/claude-myrmidon.py
+++ b/e2e/claude-myrmidon.py
@@ -23,10 +23,12 @@ Environment:
 """
 
 import asyncio
+import glob
 import json
 import os
 import resource
 import signal
+import stat
 import subprocess
 import sys
 import time
@@ -202,13 +204,11 @@ def _build_container_cmd(claude_args: list[str], cwd: str = WORKING_DIR) -> list
     # Ensure .claude directory files are readable by the container's agent user.
     # Podman rootless maps the host user to root in the container namespace,
     # making o+r required for the agent user (uid=1000 in container) to read creds.
-    import glob as _glob
-    import stat as _stat
-    for _path in _glob.glob(f"{home}/.claude/**", recursive=True) + [f"{home}/.claude.json"]:
+    for _path in glob.glob(f"{home}/.claude/**", recursive=True) + [f"{home}/.claude.json"]:
         try:
             _st = os.stat(_path)
-            if not (_st.st_mode & _stat.S_IROTH):
-                os.chmod(_path, _st.st_mode | _stat.S_IROTH)
+            if not (_st.st_mode & stat.S_IROTH):
+                os.chmod(_path, _st.st_mode | stat.S_IROTH)
         except OSError:
             pass
 
@@ -217,8 +217,7 @@ def _build_container_cmd(claude_args: list[str], cwd: str = WORKING_DIR) -> list
     standalone = os.path.join(home, ".local/share/claude/versions/2.1.120")
     if not os.path.exists(standalone):
         # Fallback: find any available standalone version
-        import glob as _g
-        versions = sorted(_g.glob(os.path.join(home, ".local/share/claude/versions/*")))
+        versions = sorted(glob.glob(os.path.join(home, ".local/share/claude/versions/*")))
         standalone = versions[-1] if versions else ""
 
     cmd = [
@@ -280,8 +279,8 @@ def invoke_claude(prompt: str, cwd: str = WORKING_DIR, stage: str = "",
             return "ERROR: Claude returned empty output"
         return output
     except subprocess.TimeoutExpired:
-        log("claude", f"{RED}Timed out after 600s{NC}")
-        return "ERROR: Claude invocation timed out after 10 minutes"
+        log("claude", f"{RED}Timed out after 1800s{NC}")
+        return "ERROR: Claude invocation timed out after 30 minutes"
     except FileNotFoundError:
         log("claude", f"{RED}{CONTAINER_RUNTIME} not found in PATH{NC}")
         return f"ERROR: {CONTAINER_RUNTIME} not found"

--- a/renovate.json
+++ b/renovate.json
@@ -11,10 +11,20 @@
     "shared/**",
     "ci-cd/**"
   ],
+  "git-submodules": {
+    "enabled": true,
+    "schedule": ["before 5am on Monday"]
+  },
   "packageRules": [
     {
       "matchManagers": ["github-actions"],
       "automerge": true
+    },
+    {
+      "matchManagers": ["git-submodules"],
+      "groupName": "submodule pins",
+      "commitMessageTopic": "submodule {{depName}}",
+      "automerge": false
     }
   ]
 }


### PR DESCRIPTION
Multi-issue sweep of severity:minor audit findings.

## Changes
- **#207** — LICENSE copyright bumped to `2025-2026`.
- **#205** — `[Unreleased]` section of CHANGELOG.md populated from `git log --since=2026-04-01` (feat/fix/chore commits since 0.4.0).
- **#204** — `glob`/`stat` deferred imports inside `_build_container_cmd` hoisted to module top-level in `e2e/claude-myrmidon.py`. (The `nats` import inside `main()` is intentionally guarded with try/except for graceful failure when the optional dep is missing — left in place.)
- **#203** — `TimeoutExpired` log in `e2e/claude-myrmidon.py` claimed "Timed out after 600s … 10 minutes" while the actual `timeout=1800` is 30 min. Aligned the log message with the code (code is authoritative — pipeline relies on the 30-min budget).
- **#202** — `renovate.json` extended with `git-submodules` manager + a packageRule that groups submodule SHA bumps under `submodule pins` and disables auto-merge so pins stay gated by review.

## Scope
4 commits, +45 / -10 LOC across 4 files. No submodule SHAs touched. No ADRs touched.

Refs #207
Refs #205
Refs #204
Refs #203
Refs #202

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>