### PR TITLE
Widen forbid-suppressions regex to catch `|| true)` and similar

### DIFF
--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -95,7 +95,7 @@ jobs:
             echo "No files to scan"
             exit 0
           fi
-          if grep -nE '\|\|[[:space:]]*true([[:space:]]*$|[[:space:]]+#)' "${scan_files[@]}"; then
+          if grep -nP '^(?!\s*#).*\|\|\s*true(\s*$|\s*[#);&|])' "${scan_files[@]}"; then
             echo ""
             echo '::error::Found silent-failure workarounds above. Refactor per docs/runbooks/no-silent-failures.md.'
             exit 1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,14 @@ repos:
           `if`-guard, a real conditional, or a documented `set +e`/`set -e`
           bracket. See docs/runbooks/no-silent-failures.md.
         language: pygrep
-        entry: '\|\|\s*true(\s*$|\s+#)'
+        # Matches `|| true` at a control-flow boundary: end of line, before a
+        # trailing `#` comment, or before `)` `;` `&` `|`. Documentation lines
+        # that quote the pattern inside backticks or other characters are not
+        # matched. The leading negative-lookbehind keeps the regex from firing
+        # on lines that are themselves a comment (start with optional whitespace
+        # then `#`), since the runbook quotes the idiom verbatim as a teaching
+        # example.
+        entry: '^(?!\s*#).*\|\|\s*true(\s*$|\s*[#);&|])'
         files: \.(sh|bash|yml|yaml|hcl)$|(^|/)Dockerfile[^/]*$|(^|/)[Jj]ustfile$
         types: [text]
         pass_filenames: true

--- a/docs/runbooks/no-silent-failures.md
+++ b/docs/runbooks/no-silent-failures.md
@@ -141,6 +141,19 @@ the lint guard scans only committed `*.sh`/`*.bash`/`*.yml`/`*.yaml`/`*.hcl`/
 this runbook) is not scanned. Use the runbook's quoted examples as fenced
 code in PR descriptions or issue comments when explaining the rule.
 
+Inside the scanned files, the guard recognises `|| true` at any control-flow
+boundary: end-of-line, before `#` (trailing comment), before `)` (closing
+substitution or subshell), before `;`, before `&&` or `||`. Comment lines
+(starting with optional whitespace then `#`) are exempt so that this runbook
+can quote the idiom for teaching. The regex used is:
+
+```
+^(?!\s*#).*\|\|\s*true(\s*$|\s*[#);&|])
+```
+
+If you discover a control-flow boundary not covered by this regex, file a
+follow-up and widen the pattern — the guard is meant to be inclusive.
+
 ## Adding new files
 
 When you add a new shell script, YAML workflow, or Dockerfile:

--- a/tests/install/run_install_tests.sh
+++ b/tests/install/run_install_tests.sh
@@ -16,8 +16,15 @@
 set -euo pipefail
 
 # ─── Runtime detection ────────────────────────────────────────────────────────
-RUNTIME=$(command -v podman 2>/dev/null || command -v docker 2>/dev/null || true)
-if [[ -z "$RUNTIME" ]]; then
+# `command -v` exits non-zero when the binary isn't found; under set -e we need
+# to capture both attempts without aborting. An explicit if-chain makes the
+# "missing is OK, both missing is fatal" semantics clear.
+RUNTIME=""
+if RUNTIME=$(command -v podman 2>/dev/null); then
+    :
+elif RUNTIME=$(command -v docker 2>/dev/null); then
+    :
+else
     echo "ERROR: Neither podman nor docker found on PATH." >&2
     exit 1
 fi


### PR DESCRIPTION
## Summary

Follow-up to #280. The `ProjectArgus` cleanup PR (HomericIntelligence/ProjectArgus#500) discovered that the initial guard regex `\|\|\s*true(\s*$|\s+#)` only recognised two control-flow boundaries (EOL and trailing `#`), so patterns like:

- `var=$(cmd || true)` — substitution boundary
- `cmd || true; next` — statement terminator
- `cmd || true && next` — chained command
- `cmd || true | next` — pipe

silently escaped both the pre-commit hook and the CI job.

Odysseus itself had one missed instance in `tests/install/run_install_tests.sh:19`:
```bash
RUNTIME=$(command -v podman 2>/dev/null || command -v docker 2>/dev/null || true)
```
(The `tests/install/` path wasn't in the initial Phase 2 sweep file list.)

## Changes

1. **Widen the regex** in both `.pre-commit-config.yaml` and `.github/workflows/_required.yml` to:
   ```
   ^(?!\s*#).*\|\|\s*true(\s*$|\s*[#);&|])
   ```
   Recognises `|| true` at any control-flow boundary (EOL, `#`, `)`, `;`, `&`, `|`) but exempts lines that are themselves comments (so the runbook can quote the idiom for teaching).

2. **CI step switches from `grep -nE` to `grep -nP`** to use PCRE's negative-lookbehind for the comment skip. PCRE is available in standard GNU grep on `ubuntu-latest`.

3. **Refactor the missed `tests/install/run_install_tests.sh` instance** using a chained `if/elif` over `command -v`, which is the clean alternative to the `cmd || cmd || true` triple-fallback idiom under `set -e`.

4. **Document the regex** in `docs/runbooks/no-silent-failures.md` so future contributors know which control-flow boundaries the guard recognises (and can widen further if they find a new boundary).

## Test plan

- [x] `pre-commit run --all-files` -> both hooks pass locally.
- [x] Manually constructed test file with 5 control-flow forms (`||true$`, `||true #cmt`, `$(||true)`, `||true&&`, `||true;`) -> regex matched all 5.
- [x] Manually constructed comment line `# Documents the || true rule` -> regex correctly did NOT match.
- [ ] CI `forbid-suppressions` job passes (will run on this PR).

## Notes

Submodule cleanup PRs across the ecosystem use the original (narrower) regex pattern from #280. Once those land, this widening will retroactively apply to them via standard CI on subsequent PRs. Existing submodule clean state is unaffected — the wider regex is a strict superset of the narrow one and existing submodule code is already clean of the narrow pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)