### PR TITLE
docs(architecture): align ProjectMnemosyne/ProjectOdyssey scope descriptions (#3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Extended CI workflow with markdownlint, pixi, justfile, and symlink checks
   (#22, #256).
 - Reformatted ADRs to 80-char line limit and replaced markdownlint config.
+- Sharpened `docs/architecture.md` ProjectMnemosyne (skills marketplace / team-
+  knowledge store) and ProjectOdyssey (Mojo ML training framework) descriptions
+  to match their stabilized scope (#3).
 
 ### Fixed
 - `install.sh` now extends `PATH` before Phase 1 detection so prior-installed

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -39,9 +39,9 @@ a git submodule. Odysseus itself contains no application code.
 | **Myrmidons (workers)** | workers | Single-host worker pool. Pull-based, rate-limited (MaxAckPending=1). Queue subscription determines role. Multi-host clustering via Nomad is planned for a future phase. |
 | **ProjectScylla** | testing | AI agent ablation benchmarking; evaluates agent architectures across tiered configurations (T0–T6). |
 | **ProjectCharybdis** | testing | Chaos and resilience testing. Injects faults via Agamemnon `/v1/chaos/*` endpoints. |
-| **ProjectMnemosyne** | shared | Memory store for `advise` and `learn` plugins only. Not a template registry. |
+| **ProjectMnemosyne** | shared | Skills marketplace / team-knowledge memory store for the `advise` and `learn` plugins only. Not an agent-template registry. |
 | **ProjectHephaestus** | shared | Shared utilities, Claude Code plugins, and skills registry. Used across all repos. |
-| **ProjectOdyssey** | research | Mojo ML research sandbox. Stable work graduates to AchaeanFleet. |
+| **ProjectOdyssey** | research | Mojo-based ML training framework (tensor ops, training loops, optimizers, metrics) used as a research sandbox. Stable work graduates to AchaeanFleet. |
 | ~~ai-maestro~~ | removed | Removed per [ADR-006](adr/006-decouple-from-ai-maestro.md). No submodule entry and no `infrastructure/ai-maestro/` directory. Do not reintroduce. |
 
 ---
@@ -221,9 +221,9 @@ directly.
 ## Shared Infrastructure
 
 ### ProjectMnemosyne
-Memory store for the `advise` and `learn` plugins only. Mnemosyne is not a
-template registry and does not hold agent specs; those live in the Myrmidons
-repo.
+Skills marketplace and team-knowledge memory store backing the `advise` and
+`learn` plugins only. Mnemosyne is not an agent-template registry and does not
+hold agent specs; those live in the Myrmidons repo.
 
 ### ProjectHephaestus
 Shared utilities, Claude Code plugins, and the skills registry. Consumed by all
@@ -231,9 +231,10 @@ HomericIntelligence repos. Includes changelog tooling, system-info helpers, and
 markdown utilities.
 
 ### ProjectOdyssey
-Mojo ML research sandbox. Experimental work that is not production-ready lives
-here. When an experiment reaches stability it is promoted to AchaeanFleet as a
-new vessel.
+Mojo-based ML training framework — tensor operations, training loops,
+optimizers, and metrics — used as a research sandbox. Experimental work that is
+not production-ready lives here. When an experiment reaches stability it is
+promoted to AchaeanFleet as a new vessel.
 
 ---
 


### PR DESCRIPTION
Corrects the documented scope of ProjectMnemosyne and ProjectOdyssey in docs/architecture.md to match their stabilized scope, per the alignment review in #3.

- ProjectMnemosyne: described explicitly as a skills marketplace / team-knowledge memory store for the advise and learn plugins (not an agent-template registry).
- ProjectOdyssey: described as a Mojo-based ML training framework (tensor ops, training loops, optimizers, metrics) used as a research sandbox.

Divergence from plan: the plan was written against an older architecture.md (line numbers and strings like "agent marketplace"/"903 skills" no longer exist; the doc had already been partially corrected). Edits were re-derived against the current file to fulfil the issue intent. CHANGELOG updated.

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)