### PR TITLE
feat(ci): scheduled submodule drift check + just recipe (#46)

### DIFF
--- a/.github/workflows/submodule-update-check.yml
+++ b/.github/workflows/submodule-update-check.yml
@@ -1,0 +1,86 @@
+name: Submodule Update Check
+
+on:
+  schedule:
+    - cron: '0 9 * * 1'  # Monday 09:00 UTC — weekly drift check
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check-drift:
+    name: check submodule drift
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    outputs:
+      has_drift: ${{ steps.drift.outputs.has_drift }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - name: Run drift check
+        id: drift
+        run: bash scripts/check-submodule-drift.sh --ci
+
+      - name: Upload drift report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: submodule-drift-report
+          path: drift-report.json
+          retention-days: 30
+
+  create-update-pr:
+    name: open draft submodule-bump PR
+    needs: check-drift
+    if: needs.check-drift.outputs.has_drift == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - name: Bump stale submodule pins
+        run: |
+          set -uo pipefail
+          BRANCH="chore/submodule-updates-$(date +%Y-%m-%d)"
+          # Skip if a branch for today's run already exists (idempotency).
+          if git ls-remote --exit-code --heads origin "$BRANCH" >/dev/null 2>&1; then
+            echo "Branch $BRANCH already exists — skipping."
+            echo "skip=true" >> "$GITHUB_ENV"
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$BRANCH"
+          git submodule update --remote
+          echo "branch=$BRANCH" >> "$GITHUB_ENV"
+
+      - name: Open draft PR
+        if: env.skip != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -uo pipefail
+          if git diff --quiet; then
+            echo "No submodule pin changes after update --remote — nothing to PR."
+            exit 0
+          fi
+          DATESTR="$(date +%Y-%m-%d)"
+          git add -A
+          git commit -m "chore(submodules): bump stale submodule pins (${DATESTR})"
+          git push -u origin "$branch"
+          gh pr create \
+            --draft \
+            --title "chore(submodules): bump stale submodule pins (${DATESTR})" \
+            --body "Automated draft PR opened by the Submodule Update Check workflow. One or more submodule pins were behind their upstream default branch. Review the changes and the attached drift report before merging. This PR is **not** auto-merged."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Unified org ruleset source-of-truth, tooling, and per-repo ruleset configs.
 - Unified required-checks workflow at the meta-repo level.
 - `.gitignore` entry for `scheduled_tasks.lock`.
+- Scheduled submodule-drift detection: `.github/workflows/submodule-update-check.yml`
+  (weekly + manual), `scripts/check-submodule-drift.sh`, and the
+  `just check-submodule-drift` recipe. Detects stale submodule pins and opens a
+  draft (never auto-merged) bump PR (#46).
 
 ### Changed
 - Bumped `ProjectArgus` submodule pin through Atlas M2/M3/M4/M5/M6 and

--- a/justfile
+++ b/justfile
@@ -40,6 +40,10 @@ status:
     @echo "=== Submodule status ==="
     @git submodule foreach --recursive 'echo "--- $name ---" && git status --short && echo ""'
 
+# Check whether any submodule pins are behind their upstream default branch
+check-submodule-drift:
+    bash scripts/check-submodule-drift.sh
+
 # ===========================================================================
 # Build
 # ===========================================================================

--- a/pixi.toml
+++ b/pixi.toml
@@ -17,6 +17,7 @@ shellcheck = ">=0.9,<1"
 [tasks]
 bootstrap = "just bootstrap"
 status = "just status"
+check-submodule-drift = "just check-submodule-drift"
 build = "just build"
 test = "just test"
 clean = "just clean"

--- a/scripts/check-submodule-drift.sh
+++ b/scripts/check-submodule-drift.sh
@@ -1,0 +1,165 @@
+#!/usr/bin/env bash
+#
+# check-submodule-drift.sh — Detect when Odysseus submodule pins have fallen
+# behind their upstream default branch.
+#
+# Each submodule in Odysseus is pinned to a specific SHA representing the last
+# known-good cross-repo integration point. Over time these pins go stale. This
+# script compares each pinned SHA against the upstream default-branch HEAD and
+# reports which submodules are behind.
+#
+# Usage:
+#   check-submodule-drift.sh           Print a human-readable table.
+#   check-submodule-drift.sh --ci      Also write drift-report.json and emit
+#                                      has_drift=<bool> to $GITHUB_OUTPUT.
+#
+# Exit codes:
+#   0  No drift — all submodule pins match their upstream default branch.
+#   1  Drift detected — one or more submodules are behind.
+#   2  Usage or environment error (network failure, bad arguments, etc.).
+#
+# Used by both the GitHub Actions workflow and `just check-submodule-drift`.
+
+set -uo pipefail
+
+CI_MODE=0
+case "${1:-}" in
+  "")        ;;
+  --ci)      CI_MODE=1 ;;
+  -h|--help)
+    sed -n '2,20p' "$0" | sed 's/^# \{0,1\}//'
+    exit 0
+    ;;
+  *)
+    printf 'error: unknown argument: %s\n' "$1" >&2
+    exit 2
+    ;;
+esac
+
+# Resolve the repository root so the script works from any cwd.
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)" || {
+  printf 'error: not inside a git repository\n' >&2
+  exit 2
+}
+cd "$REPO_ROOT" || exit 2
+
+GITMODULES="$REPO_ROOT/.gitmodules"
+if [ ! -f "$GITMODULES" ]; then
+  printf 'error: %s not found\n' "$GITMODULES" >&2
+  exit 2
+fi
+
+# Enumerate submodule logical names from .gitmodules.
+mapfile -t SUBMODULES < <(
+  git config --file "$GITMODULES" --get-regexp 'submodule\..*\.path' \
+    | sed -E 's/^submodule\.(.*)\.path .*/\1/'
+)
+
+if [ "${#SUBMODULES[@]}" -eq 0 ]; then
+  printf 'error: no submodules found in .gitmodules\n' >&2
+  exit 2
+fi
+
+drift_count=0
+error_count=0
+json_rows=()
+
+printf '## Submodule Drift Report\n\n'
+printf '| Submodule | Pinned SHA | Upstream SHA | Behind By | Last Updated |\n'
+printf '|-----------|-----------|--------------|-----------|--------------|\n'
+
+for name in "${SUBMODULES[@]}"; do
+  path="$(git config --file "$GITMODULES" --get "submodule.${name}.path")"
+  url="$(git config --file "$GITMODULES" --get "submodule.${name}.url")"
+
+  # Pinned SHA = the gitlink recorded in the Odysseus tree for this path.
+  pinned="$(git ls-tree HEAD "$path" 2>/dev/null | awk '{print $3}')"
+  if [ -z "$pinned" ]; then
+    printf '| %s | (unpinned) | - | - | - |\n' "$path"
+    json_rows+=("$(printf '{"submodule":"%s","status":"error","detail":"no gitlink"}' "$path")")
+    error_count=$((error_count + 1))
+    continue
+  fi
+
+  # Determine the upstream default branch HEAD via ls-remote.
+  remote_head="$(git ls-remote --symref "$url" HEAD 2>/dev/null | awk '/^ref:/ {print $2}')"
+  if [ -z "$remote_head" ]; then
+    printf '| %s | %s | (unreachable) | - | - |\n' "$path" "${pinned:0:8}"
+    json_rows+=("$(printf '{"submodule":"%s","status":"error","detail":"remote unreachable"}' "$path")")
+    error_count=$((error_count + 1))
+    continue
+  fi
+
+  upstream="$(git ls-remote "$url" "$remote_head" 2>/dev/null | awk '{print $1}')"
+  if [ -z "$upstream" ]; then
+    printf '| %s | %s | (unreachable) | - | - |\n' "$path" "${pinned:0:8}"
+    json_rows+=("$(printf '{"submodule":"%s","status":"error","detail":"remote unreachable"}' "$path")")
+    error_count=$((error_count + 1))
+    continue
+  fi
+
+  if [ "$pinned" = "$upstream" ]; then
+    printf '| %s | %s | %s | up to date | - |\n' "$path" "${pinned:0:8}" "${upstream:0:8}"
+    json_rows+=("$(printf '{"submodule":"%s","status":"current","pinned":"%s","upstream":"%s"}' "$path" "$pinned" "$upstream")")
+    continue
+  fi
+
+  # Drift detected. Try to count commits behind and the upstream commit date by
+  # fetching into the local submodule clone if present; otherwise report unknown.
+  behind="?"
+  last_updated="unknown"
+  if [ -d "$path/.git" ] || [ -f "$path/.git" ]; then
+    git -C "$path" fetch --quiet "$url" "$remote_head" 2>/dev/null || true
+    count="$(git -C "$path" rev-list --count "${pinned}..${upstream}" 2>/dev/null || echo "")"
+    [ -n "$count" ] && behind="$count"
+    date_str="$(git -C "$path" show -s --format=%cs "$upstream" 2>/dev/null || echo "")"
+    [ -n "$date_str" ] && last_updated="$date_str"
+  fi
+
+  printf '| %s | %s | %s | %s commits | %s |\n' \
+    "$path" "${pinned:0:8}" "${upstream:0:8}" "$behind" "$last_updated"
+  json_rows+=("$(printf '{"submodule":"%s","status":"behind","pinned":"%s","upstream":"%s","behind":"%s","last_updated":"%s"}' \
+    "$path" "$pinned" "$upstream" "$behind" "$last_updated")")
+  drift_count=$((drift_count + 1))
+done
+
+printf '\n'
+if [ "$drift_count" -eq 0 ] && [ "$error_count" -eq 0 ]; then
+  printf '**All %d submodule pins are up to date.**\n' "${#SUBMODULES[@]}"
+else
+  printf '**%d submodule(s) behind upstream; %d error(s).**\n' "$drift_count" "$error_count"
+fi
+
+if [ "$CI_MODE" -eq 1 ]; then
+  {
+    printf '{\n'
+    printf '  "generated_at": "%s",\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    printf '  "drift_count": %d,\n' "$drift_count"
+    printf '  "error_count": %d,\n' "$error_count"
+    printf '  "submodules": [\n'
+    for i in "${!json_rows[@]}"; do
+      sep=","
+      [ "$i" -eq $((${#json_rows[@]} - 1)) ] && sep=""
+      printf '    %s%s\n' "${json_rows[$i]}" "$sep"
+    done
+    printf '  ]\n'
+    printf '}\n'
+  } > drift-report.json
+
+  has_drift="false"
+  [ "$drift_count" -gt 0 ] && has_drift="true"
+  if [ -n "${GITHUB_OUTPUT:-}" ]; then
+    printf 'has_drift=%s\n' "$has_drift" >> "$GITHUB_OUTPUT"
+  else
+    printf 'has_drift=%s\n' "$has_drift"
+  fi
+fi
+
+# Network errors take precedence so CI fails visibly rather than silently.
+if [ "$error_count" -gt 0 ]; then
+  exit 2
+fi
+if [ "$drift_count" -gt 0 ]; then
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
Adds automated detection of stale submodule pins.

- scripts/check-submodule-drift.sh — compares each pinned SHA against the upstream default-branch HEAD via git ls-remote; prints a Markdown table; --ci writes drift-report.json and sets has_drift; exits 0 (current) / 1 (drift) / 2 (error).
- .github/workflows/submodule-update-check.yml — weekly (Mon 09:00 UTC) + workflow_dispatch; check-drift job uploads the report; gated create-update-pr job opens a DRAFT bump PR (never auto-merged) when drift is found, idempotent per day.
- just check-submodule-drift recipe + pixi task.

Divergence from plan: ai-maestro special-casing dropped (removed per ADR-006; not in .gitmodules). 13 submodules enumerated dynamically from .gitmodules.

Closes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)