### PR TITLE
docs(conventions): add developer tooling standards; bump ProjectHephaestus pin (#42)

### DIFF
--- a/docs/repo-conventions.md
+++ b/docs/repo-conventions.md
@@ -60,3 +60,59 @@ Closes #N
 ```
 
 Common types: `feat`, `fix`, `docs`, `config`, `build`, `ci`, `refactor`, `test`, `chore`
+
+## Developer Tooling Standards
+
+These requirements apply to **every** HomericIntelligence repository. They were
+formalised as ecosystem conventions following the cross-repo audit (Odysseus
+[#42](https://github.com/HomericIntelligence/Odysseus/issues/42)).
+
+### Justfile (all repos)
+
+Every repository **must** have a `justfile` at the repo root that provides a
+consistent developer experience regardless of the underlying build system. The
+`justfile` wraps all tasks that an engineer needs:
+
+| Recipe | Description |
+|--------|-------------|
+| `default` | Lists available recipes (`@just --list`) |
+| `bootstrap` | Installs all dependencies (e.g. `pixi install`) |
+| `test` | Runs the full test suite |
+| `lint` | Runs linters (ruff, clang-tidy, etc.) |
+| `format` | Auto-formats source code |
+| `build` | Builds the package or binary |
+
+Additional repo-specific recipes are allowed and encouraged. Use `pixi run
+<task>` inside recipes rather than direct tool invocations so that toolchain
+versions are governed by `pixi.toml`.
+
+**Rationale:** Before this standard, each repo had different entry points
+(`make`, `pixi run`, bare scripts). The unified `just` interface means any
+engineer can run `just test` in any repo without reading the README.
+
+### pixi.toml (all repos)
+
+Every repository **must** have a `pixi.toml` at the repo root using the
+`[dependencies]` key (not `[workspace.dependencies]`). At minimum:
+
+```toml
+[dependencies]
+# runtime tools the justfile recipes need
+
+[tasks]
+# optional: delegate pixi tasks to just for users who prefer pixi run
+test = "just test"
+lint = "just lint"
+```
+
+Include `just = ">=1.13"` in `[dependencies]` if the repo's CI environment
+does not already provide `just` via the system.
+
+### Python Repo Layout
+
+Python repositories use **flat layout** by default — the package directory
+sits directly at the repo root (e.g. `hephaestus/`, not `src/hephaestus/`).
+This is intentional: src-layout was evaluated and reverted in ProjectHephaestus
+because it conflicted with hatchling VCS versioning and editable-install
+expectations in the pixi environment. Do **not** migrate Python repos to
+src-layout without a new ADR.


### PR DESCRIPTION
## Summary

- Adds **Developer Tooling Standards** section to `docs/repo-conventions.md`, formally documenting the ecosystem requirements surfaced by the cross-repo audit (issue #42):
  - Every repo must have a `justfile` with standard recipes (`default`, `bootstrap`, `test`, `lint`, `format`, `build`)
  - Every repo must have a `pixi.toml` using `[dependencies]` (not `[workspace.dependencies]`)
  - Clarifies that **flat layout** is canonical for Python repos — src-layout was evaluated and reverted in ProjectHephaestus, and this convention is now explicit
- Bumps `shared/ProjectHephaestus` submodule pin from `14c89e1` → `28941a0` (current main tip, v0.7.x), which includes the justfile added in ProjectHephaestus #85 and all subsequent tooling work

## Divergence from Plan

The implementation plan called for migrating ProjectHephaestus to src-layout. Investigation shows this was already tried and deliberately reverted (commit `25f5bc9`: "Merge src/hephaestus functionality into main hephaestus directory — Removed redundant src/hephaestus directory"). The justfile was already added (ProjectHephaestus #85). Therefore, the Odysseus deliverable is: (1) document these conventions so they are enforceable, and (2) advance the submodule pin to a commit that satisfies the justfile requirement.

## Test plan

- [ ] `docs/repo-conventions.md` renders correctly in GitHub markdown preview
- [ ] `shared/ProjectHephaestus` submodule points to `28941a0a` (ProjectHephaestus main)
- [ ] Issue #42 is closed by this PR merge

Closes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)