### PR TITLE
docs(ci): document _required.yml canonical naming

### DIFF
--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -1,3 +1,22 @@
+# Canonical required-checks workflow for the HomericIntelligence fleet.
+#
+# The exact filename `_required.yml` is a fleet convention: the leading
+# underscore sorts it to the top of .github/workflows/ and the Actions tab,
+# and every Homeric repo uses this same path so rollout tooling and the
+# branch-protection runbook can reference one filename. The filename itself is
+# NOT an enforcement mechanism -- renaming it would only churn doc/tooling
+# references (see below), not change any required status check.
+#
+# What IS load-bearing: each job's `name:` value. GitHub emits the status-check
+# context from the job `name:`, and the branch-protection rulesets pin those
+# contexts. Keep every job `name:` byte-for-byte aligned with the contexts in
+# configs/github/canonical-checks.md and the ruleset JSON
+# (configs/github/org-ruleset*.json use "Required Checks / <name>";
+# configs/github/repo-ruleset*.json use the bare "<name>"). Do NOT rename a job
+# without updating those rulesets and re-applying them.
+#
+# References to this path: configs/github/canonical-checks.md,
+# docs/runbooks/branch-protection-rollout.md, .pre-commit-config.yaml.
 name: Required Checks
 
 on:

--- a/configs/github/canonical-checks.md
+++ b/configs/github/canonical-checks.md
@@ -37,3 +37,25 @@ with `"integration_id": 15368` (GitHub Actions app) to scope the match to Action
 the job has an explicit `name:` field — the workflow name prefix does NOT appear in
 the context string. `repo-ruleset.json` and `repo-ruleset-active.json` use bare names
 with `integration_id: 15368`.
+
+### Why the filename is `_required.yml`
+
+The leading underscore is a deliberate fleet convention, not an opaque choice —
+and the filename is organizational, not load-bearing:
+
+- **Sorts first / signals intent.** The underscore sorts ahead of letters, so the
+  required-checks workflow appears at the top of `.github/workflows/` and the
+  Actions tab — visually marking "this is the gate that blocks merges."
+- **Uniform across all repos.** Every HomericIntelligence repo uses this exact
+  path, so `tools/github/apply-repo-rulesets.sh` and
+  `docs/runbooks/branch-protection-rollout.md` can reference one filename
+  fleet-wide.
+- **The filename is NOT the enforcement contract.** Renaming the file would only
+  require updating doc/tooling references; it would not change any required
+  status check. The load-bearing artifact is each job's `name:` field — GitHub
+  derives the status-check context from it. Renaming or removing a *job* without
+  updating the ruleset contexts (and re-applying the ruleset) is what breaks
+  enforcement. Note the two ruleset forms in this repo:
+  `org-ruleset*.json` pin `"Required Checks / <job>"`, while `repo-ruleset*.json`
+  pin the bare `"<job>"` with `integration_id: 15368`. Treat the job names — not
+  the filename — as the API.


### PR DESCRIPTION
## Summary

- Add a 19-line header comment to `.github/workflows/_required.yml` explaining the `_required.yml` filename convention and explicitly stating that job `name:` values — not the filename — are the load-bearing ruleset contract
- Add a "Why the filename is `_required.yml`" subsection to `configs/github/canonical-checks.md` documenting the two ruleset context formats (`org-ruleset*.json` uses `"Required Checks / <job>"`; `repo-ruleset*.json` uses bare `"<job>"` with `integration_id: 15368`)

Addresses the NITPICK from the 2026-04-28 strict audit (issue #215) — the leading-underscore filename was non-obvious; this makes it self-documenting without renaming (which would churn fleet-wide docs/tooling for zero functional gain).

## Test plan

- [x] `yamllint -d relaxed .github/workflows/_required.yml` — passes (warnings only, pre-existing)
- [x] `name: Required Checks` remains the first YAML key at line 20
- [x] All job `name:` values unchanged — no ruleset context drift
- [x] No suppression tokens in the comment block — `forbid-suppressions` job safe
- [x] Subsection markers present in `canonical-checks.md` (`grep "Why the filename is"`, `grep "NOT the enforcement contract"`)

Closes #174

🤖 Generated with [Claude Code](https://claude.com/claude-code)