### PR TITLE
feat(nats): add mTLS auth and subject-scoped accounts (ADR-009)

### DIFF
--- a/configs/nats/leaf.conf
+++ b/configs/nats/leaf.conf
@@ -46,10 +46,7 @@ accounts {
       user = "agent.homeric"                         # SAN-DNS=agent.homeric
       permissions {
         publish   { allow = ["hi.agents.>", "hi.tasks.>"] }
-        subscribe {
-          allow = ["hi.agents.>", "_INBOX.>"]
-          deny  = ["hi.research.>"]
-        }
+        subscribe { allow = ["hi.agents.>", "_INBOX.>"] }
       }
     } ]
   }
@@ -76,13 +73,24 @@ accounts {
 system_account = SYS
 
 leafnodes {
+  # MULTI-ACCOUNT LEAF BRIDGING (ADR-010): once named accounts{} + system_account are
+  # defined, the implicit global account no longer exists, so a leafnode remote bridges
+  # EXACTLY ONE account to the hub. Each non-SYS account that needs hub connectivity
+  # therefore requires its own remote entry with an explicit `account:` binding. Without
+  # it, leaf-local clients authenticate locally but their hi.* traffic never propagates
+  # upstream (e.g. AGENTS would silently fail to deliver hi.agents.> events to the hub).
+  # SYS is internal and does NOT get a user-facing remote.
+  #
+  # Primary NATS server's Tailscale IP — TLS on leafnode port (7422).
+  # Set NATS_SERVER_IP environment variable or update the IP below.
+  # To find your primary NATS server's Tailscale IP, run on that host: tailscale ip -4
+  # Default below is epimetheus (100.92.173.32) — update for your network.
+  # The leaf presents its own cert (one TLS identity) so the hub can authenticate it
+  # (ADR-010 §1); every remote reuses the same cert/key/CA.
   remotes = [
     {
-      # Primary NATS server's Tailscale IP — TLS on leafnode port (7422)
-      # Set NATS_SERVER_IP environment variable or update the IP below.
-      # To find your primary NATS server's Tailscale IP, run on that host: tailscale ip -4
-      # Default below is epimetheus (100.92.173.32) — update for your network.
-      url = "nats+tls://100.92.173.32:7422"
+      url     = "nats+tls://100.92.173.32:7422"
+      account = "HERMES"
       tls {
         # Leaf presents its own cert so the hub can authenticate it (ADR-010 §1).
         cert_file = "/etc/nats/certs/server-cert.pem"
@@ -94,6 +102,37 @@ leafnodes {
       # BOOTSTRAP fallback: shared token via env substitution (must match hub).
       token = "$NATS_LEAF_TOKEN"
     }
+    {
+      url     = "nats+tls://100.92.173.32:7422"
+      account = "AGENTS"
+      tls {
+        cert_file = "/etc/nats/certs/server-cert.pem"
+        key_file  = "/etc/nats/certs/server-key.pem"
+        ca_file   = "/etc/nats/certs/ca.pem"
+      }
+      token = "$NATS_LEAF_TOKEN"
+    }
+    {
+      url     = "nats+tls://100.92.173.32:7422"
+      account = "KEYSTONE"
+      tls {
+        cert_file = "/etc/nats/certs/server-cert.pem"
+        key_file  = "/etc/nats/certs/server-key.pem"
+        ca_file   = "/etc/nats/certs/ca.pem"
+      }
+      token = "$NATS_LEAF_TOKEN"
+    }
+    {
+      url     = "nats+tls://100.92.173.32:7422"
+      account = "TELEMACHY"
+      tls {
+        cert_file = "/etc/nats/certs/server-cert.pem"
+        key_file  = "/etc/nats/certs/server-key.pem"
+        ca_file   = "/etc/nats/certs/ca.pem"
+      }
+      token = "$NATS_LEAF_TOKEN"
+    }
+    # SYS account intentionally omitted — internal NATS system account, not user-facing.
   ]
 }
 

--- a/configs/nats/leaf.conf
+++ b/configs/nats/leaf.conf
@@ -8,21 +8,72 @@
 #   Primary host (epimetheus):  100.92.173.32
 #   Control host:               100.73.61.56
 #
-# TLS certificates must be provisioned before starting this node (see ADR 008).
+# TLS certificates must be provisioned before starting this node (see ADR 008 / ADR 010).
 # Place certs in /etc/nats/certs/ with permissions: chmod 600 key, chmod 644 cert/ca
 
 port = 4222
 
-# TLS for local client connections on this leaf node
+# TLS for local client connections on this leaf node — mutual TLS; maps SAN-DNS to account user
 tls {
-  cert_file = "/etc/nats/certs/server-cert.pem"
-  key_file  = "/etc/nats/certs/server-key.pem"
-  ca_file   = "/etc/nats/certs/ca.pem"
+  cert_file      = "/etc/nats/certs/server-cert.pem"
+  key_file       = "/etc/nats/certs/server-key.pem"
+  ca_file        = "/etc/nats/certs/ca.pem"
+  verify_and_map = true
 }
 
 jetstream {
   store_dir = "/var/lib/nats/jetstream"
 }
+
+# Subject-scoped accounts (ADR-010) — identical to server.conf so leaf-local clients are
+# authenticated and authorized with the same least-privilege policy.
+# Every client cert MUST carry CN=<role>.homeric AND a DNS SAN equal to <role>.homeric.
+accounts {
+  SYS {
+    users = [ { user = "sys.homeric" } ]            # SAN-DNS=sys.homeric — system account
+  }
+  HERMES {
+    users = [ {
+      user = "hermes.homeric"                        # SAN-DNS=hermes.homeric
+      permissions {
+        publish   { allow = ["hi.>", "$JS.API.>"] }
+        subscribe { allow = ["hi.>", "_INBOX.>"] }
+      }
+    } ]
+  }
+  AGENTS {
+    users = [ {
+      user = "agent.homeric"                         # SAN-DNS=agent.homeric
+      permissions {
+        publish   { allow = ["hi.agents.>", "hi.tasks.>"] }
+        subscribe {
+          allow = ["hi.agents.>", "_INBOX.>"]
+          deny  = ["hi.research.>"]
+        }
+      }
+    } ]
+  }
+  KEYSTONE {
+    users = [ {
+      user = "keystone.homeric"                      # SAN-DNS=keystone.homeric
+      permissions {
+        publish   { allow = ["$JS.API.CONSUMER.>", "$JS.API.STREAM.INFO.>", "$JS.ACK.>"] }
+        subscribe { allow = ["hi.tasks.>", "_INBOX.>"] }
+      }
+    } ]
+  }
+  TELEMACHY {
+    users = [ {
+      user = "telemachy.homeric"                     # SAN-DNS=telemachy.homeric
+      permissions {
+        publish   { allow = ["hi.tasks.>", "$JS.API.>"] }
+        subscribe { allow = ["hi.tasks.>", "_INBOX.>"] }
+      }
+    } ]
+  }
+}
+
+system_account = SYS
 
 leafnodes {
   remotes = [
@@ -33,7 +84,10 @@ leafnodes {
       # Default below is epimetheus (100.92.173.32) — update for your network.
       url = "nats+tls://100.92.173.32:7422"
       tls {
-        ca_file = "/etc/nats/certs/ca.pem"
+        # Leaf presents its own cert so the hub can authenticate it (ADR-010 §1).
+        cert_file = "/etc/nats/certs/server-cert.pem"
+        key_file  = "/etc/nats/certs/server-key.pem"
+        ca_file   = "/etc/nats/certs/ca.pem"
       }
       # Authenticate to the hub (issue #176). RECOMMENDED: per-leaf NKey/JWT:
       #   credentials = "/etc/nats/certs/leaf.creds"

--- a/configs/nats/server.conf
+++ b/configs/nats/server.conf
@@ -46,10 +46,7 @@ accounts {
       user = "agent.homeric"                         # SAN-DNS=agent.homeric
       permissions {
         publish   { allow = ["hi.agents.>", "hi.tasks.>"] }
-        subscribe {
-          allow = ["hi.agents.>", "_INBOX.>"]
-          deny  = ["hi.research.>"]
-        }
+        subscribe { allow = ["hi.agents.>", "_INBOX.>"] }
       }
     } ]
   }

--- a/configs/nats/server.conf
+++ b/configs/nats/server.conf
@@ -12,30 +12,79 @@
 
 port = 4222
 
-# TLS for client connections
+# TLS for client connections — mutual TLS; maps client cert SAN-DNS to an account user (ADR-010)
 tls {
-  cert_file = "/etc/nats/certs/server-cert.pem"
-  key_file  = "/etc/nats/certs/server-key.pem"
-  ca_file   = "/etc/nats/certs/ca.pem"
+  cert_file      = "/etc/nats/certs/server-cert.pem"
+  key_file       = "/etc/nats/certs/server-key.pem"
+  ca_file        = "/etc/nats/certs/ca.pem"
+  verify_and_map = true
 }
 
 jetstream {
   store_dir = "/var/lib/nats/jetstream"
 }
 
-# Client authentication — token (bootstrap) or accounts/operator (decentralized).
-# Set $NATS_CLIENT_TOKEN in deployment secrets. Fail-closed: no token = rejected.
-authorization {
-  token = "$NATS_CLIENT_TOKEN"
+# Subject-scoped accounts (ADR-010). NATS maps the client cert's SAN-DNS value to user.
+# Permissions mirror the hi.* subject schema (ADR-005).
+# Every client cert MUST carry CN=<role>.homeric AND a DNS SAN equal to <role>.homeric.
+accounts {
+  SYS {
+    users = [ { user = "sys.homeric" } ]            # SAN-DNS=sys.homeric — system account
+  }
+  HERMES {
+    # Event bridge: creates JetStream streams, publishes all hi.* events (ADR-005).
+    users = [ {
+      user = "hermes.homeric"                        # SAN-DNS=hermes.homeric
+      permissions {
+        publish   { allow = ["hi.>", "$JS.API.>"] }
+        subscribe { allow = ["hi.>", "_INBOX.>"] }
+      }
+    } ]
+  }
+  AGENTS {
+    users = [ {
+      user = "agent.homeric"                         # SAN-DNS=agent.homeric
+      permissions {
+        publish   { allow = ["hi.agents.>", "hi.tasks.>"] }
+        subscribe {
+          allow = ["hi.agents.>", "_INBOX.>"]
+          deny  = ["hi.research.>"]
+        }
+      }
+    } ]
+  }
+  KEYSTONE {
+    # Durable consumer keystone-dag over homeric-tasks (ADR-005).
+    users = [ {
+      user = "keystone.homeric"                      # SAN-DNS=keystone.homeric
+      permissions {
+        publish   { allow = ["$JS.API.CONSUMER.>", "$JS.API.STREAM.INFO.>", "$JS.ACK.>"] }
+        subscribe { allow = ["hi.tasks.>", "_INBOX.>"] }
+      }
+    } ]
+  }
+  TELEMACHY {
+    users = [ {
+      user = "telemachy.homeric"                     # SAN-DNS=telemachy.homeric
+      permissions {
+        publish   { allow = ["hi.tasks.>", "$JS.API.>"] }
+        subscribe { allow = ["hi.tasks.>", "_INBOX.>"] }
+      }
+    } ]
+  }
 }
 
-# Leaf node listener — TLS on standard leafnode port (7422), authenticated.
+system_account = SYS
+
+# Leaf node listener — TLS with peer verification on standard leafnode port (7422),
+# authenticated. The leafnodes{} listener carries its own auth (issue #176).
 leafnodes {
   port = 7422
   tls {
     cert_file = "/etc/nats/certs/server-cert.pem"
     key_file  = "/etc/nats/certs/server-key.pem"
     ca_file   = "/etc/nats/certs/ca.pem"
+    verify    = true
   }
   # Leaf nodes MUST authenticate (issue #176) — this block is separate from the
   # client authorization above; a leafnode listener without it stays open.
@@ -58,6 +107,7 @@ cluster {
     cert_file = "/etc/nats/certs/server-cert.pem"
     key_file  = "/etc/nats/certs/server-key.pem"
     ca_file   = "/etc/nats/certs/ca.pem"
+    verify    = true
   }
   # Cluster route authorization (issue #306, ADR-009): TLS alone only verifies
   # the CA — any host with the mesh CA cert could join as a full cluster peer.

--- a/docs/adr/010-nats-mtls-subject-scoped-auth.md
+++ b/docs/adr/010-nats-mtls-subject-scoped-auth.md
@@ -1,0 +1,147 @@
+# ADR 010: NATS Mutual-TLS Authentication and Subject-Scoped Authorization
+
+**Status:** Proposed
+
+---
+
+## Context
+
+ADR-008 added TLS encryption to all NATS listeners (`server.conf` and `leaf.conf`), protecting
+message payloads in transit. However, both configs omit `verify` / `verify_and_map` on every TLS
+block, and neither config includes an `accounts {}` or `authorization {}` block. As a result:
+
+- Any process that can reach port 4222 over Tailscale can connect and pub/sub all `hi.*` subjects,
+  including agent commands and research results.
+- Any peer that can reach port 6222 can join the NATS cluster (`0.0.0.0:6222`, no auth).
+- Leaf nodes present no client certificate to the hub; any TLS connection from port 7422 is
+  accepted.
+
+Tailscale provides host-level isolation but is not a substitute for application-layer authentication
+— a single compromised host exposes the full mesh. Issue #175 identifies this as CRITICAL.
+
+No operator, NKey, or JWT scaffolding exists in the repository. ADR-008 already established a
+mutual-cert PKI under `/etc/nats/certs/` with `ca.pem` as the trust anchor. This ADR extends that
+PKI to enforce identity and least-privilege authorization using NATS's built-in `verify_and_map`
+mechanism. AID v0.2.0 (Ed25519 + scoped JWT) is the documented future path and is deferred to a
+subsequent ADR.
+
+## Decision
+
+### 1. Mutual TLS on every listener
+
+- **Client listener (port 4222):** `verify_and_map = true` — clients must present a CA-signed
+  certificate; the cert's SAN-DNS value is mapped to an account user identity.
+- **Leafnode listener (port 7422):** `verify = true` — leaf nodes must present a CA-signed cert.
+- **Cluster listener (port 6222):** `verify = true` — cluster peers must present a CA-signed cert.
+- **Leaf remote (outbound):** leaf nodes present a client cert+key when connecting to the hub, so
+  the hub can authenticate the leaf.
+
+### 2. Cert identity convention (binding contract for `verify_and_map`)
+
+Every client and leaf node certificate **MUST** carry:
+
+1. A Common Name of the form `CN=<role>.homeric`
+2. A DNS Subject Alternative Name equal to `<role>.homeric`
+
+NATS `verify_and_map` matches identities in the following precedence order:
+SAN email → **SAN DNS** → RFC-2253 Subject DN.
+The `accounts {}` `user` field is therefore set to the **SAN-DNS string** (e.g. `hermes.homeric`),
+not a bare CN substring. A bare CN is never a match key.
+
+Defined roles and their SAN-DNS values:
+
+| Role | SAN-DNS | Purpose |
+|------|---------|---------|
+| `sys.homeric` | `sys.homeric` | NATS system account |
+| `hermes.homeric` | `hermes.homeric` | Event bridge; creates JetStream streams |
+| `agent.homeric` | `agent.homeric` | Myrmidon worker agents |
+| `keystone.homeric` | `keystone.homeric` | DAG consumer (homeric-tasks) |
+| `telemachy.homeric` | `telemachy.homeric` | Workflow runner |
+
+**Issuing a role cert (using `step` CLI):**
+
+```bash
+# Example: hermes identity cert with required DNS SAN
+step ca certificate hermes.homeric hermes-cert.pem hermes-key.pem \
+  --san hermes.homeric
+```
+
+The `--san` flag sets the DNS SAN that `verify_and_map` matches. The CN is set automatically to
+`hermes.homeric` when the first positional argument equals the SAN value.
+
+**Fallback (discouraged):** If a SAN cannot be added, the `accounts {}` `user` field may instead
+be set to the full RFC-2253 Subject DN (e.g. `CN=hermes.homeric,O=HomericIntelligence`). DN-order
+fragility makes this error-prone; the SAN-DNS convention is strongly preferred.
+
+### 3. Subject-scoped `accounts {}`
+
+Five accounts are defined, each scoped to the `hi.*` subtree relevant to its role (ADR-005):
+
+| Account | User (SAN-DNS) | Publish | Subscribe |
+|---------|----------------|---------|-----------|
+| `SYS` | `sys.homeric` | — | — |
+| `HERMES` | `hermes.homeric` | `hi.>`, `$JS.API.>` | `hi.>`, `_INBOX.>` |
+| `AGENTS` | `agent.homeric` | `hi.agents.>`, `hi.tasks.>` | `hi.agents.>`, `_INBOX.>` (deny `hi.research.>`) |
+| `KEYSTONE` | `keystone.homeric` | `$JS.API.CONSUMER.>`, `$JS.API.STREAM.INFO.>`, `$JS.ACK.>` | `hi.tasks.>`, `_INBOX.>` |
+| `TELEMACHY` | `telemachy.homeric` | `hi.tasks.>`, `$JS.API.>` | `hi.tasks.>`, `_INBOX.>` |
+
+`system_account = SYS` designates the NATS internal system account.
+
+### 4. Future path: AID v0.2.0 (NKey + scoped JWT)
+
+Decentralized identity using Ed25519 operator/account/user NKeys and NATS JWT is the intended
+long-term auth mechanism (referenced in the ecosystem audit as AID v0.2.0). It supersedes
+cert-mapped accounts when an operator key and resolver are provisioned. That transition is deferred
+to a subsequent ADR and tracked in the HomericIntelligence roadmap.
+
+## Consequences
+
+**Positive:**
+- Closes #175: anonymous connections to port 4222 are rejected fail-closed.
+- Cluster port 6222 now requires a CA-signed peer cert; arbitrary peers cannot join.
+- Leaf remotes authenticate to the hub; unauthenticated leaf connections are rejected.
+- Least-privilege subject scoping: AGENTS cannot read `hi.research.>`; KEYSTONE cannot publish
+  arbitrary `hi.*` subjects.
+- `AuthorizationError` is already classified as non-retryable in the Hermes publish retry loop, so
+  auth failures surface immediately rather than burning retry budget.
+- The SAN-DNS convention is a hard, testable contract: `step ca certificate` enforces it at
+  issuance time.
+
+**Negative:**
+- Every client and leaf must present a valid role cert before enforcement is enabled. Enforcement is
+  fail-closed: plain `nats://` connections are rejected once `verify_and_map` is active.
+- Three downstream clients default to plain `nats://` today and must be reconfigured before NATS
+  is restarted with the new config:
+  - `ProjectHermes` (`infrastructure/ProjectHermes/src/hermes/config.py:34`) — already mTLS-capable
+    via `TLS_CERT_FILE`/`TLS_KEY_FILE`/`TLS_CA_BUNDLE` env vars; needs configuration only.
+  - `ProjectTelemachy` (`provisioning/ProjectTelemachy/src/telemachy/config.py:21`) — has a
+    `require_tls` gate but no client-cert wiring; tracked in follow-up issue
+    "ProjectTelemachy: add NATS client-cert (mTLS) wiring".
+  - `docker-compose.crosshost.yml:45` — `NATS_URL: nats://nats:4222`; must be updated and a client
+    cert mounted before enforcement is enabled.
+- Cert provisioning and distribution adds operational overhead. See
+  `docs/runbooks/enable-nats-auth.md` for the step-by-step procedure.
+
+**Neutral:**
+- The HTTP monitoring endpoint (`127.0.0.1:8222`) is unchanged; it remains plain HTTP on loopback.
+- Cert issuance stays out-of-band (ProjectKeystone / Myrmidons), consistent with ADR-008.
+- Cert rotation (NATS `nats-server --signal reload`) is standard TLS operational overhead,
+  unchanged from ADR-008.
+
+## References
+
+- [ADR 008](008-nats-tls-encryption.md) — TLS encryption for all NATS listeners (this ADR
+  extends its PKI)
+- [ADR 009](009-nats-authentication.md) — Token-based authentication on every NATS listener
+  (issue #176). This ADR strengthens that baseline: cert-mapped subject-scoped accounts replace
+  the client token, while the leafnode and cluster listeners retain their `authorization {}`
+  blocks for fail-closed bootstrap.
+- [ADR 005](005-nats-subject-schema.md) — `hi.*` subject schema that the account permissions
+  mirror
+- [ADR 002](002-nats-event-bridge.md) — Decision to use NATS JetStream as the event bridge
+- [Issue #175](https://github.com/HomericIntelligence/Odysseus/issues/175) — CRITICAL: NATS
+  server has no TLS and no authentication
+- [Issue #174](https://github.com/HomericIntelligence/Odysseus/issues/174) — Parent audit issue
+- [NATS `verify_and_map` documentation](https://docs.nats.io/running-a-nats-service/configuration/securing_nats/auth_intro/tls_mutual_auth)
+- [NATS accounts configuration](https://docs.nats.io/running-a-nats-service/configuration/securing_nats/accounts)
+- [Smallstep `step` CLI](https://smallstep.com/docs/step-cli/) — Recommended cert issuance tool

--- a/docs/adr/010-nats-mtls-subject-scoped-auth.md
+++ b/docs/adr/010-nats-mtls-subject-scoped-auth.md
@@ -81,7 +81,7 @@ Five accounts are defined, each scoped to the `hi.*` subtree relevant to its rol
 |---------|----------------|---------|-----------|
 | `SYS` | `sys.homeric` | — | — |
 | `HERMES` | `hermes.homeric` | `hi.>`, `$JS.API.>` | `hi.>`, `_INBOX.>` |
-| `AGENTS` | `agent.homeric` | `hi.agents.>`, `hi.tasks.>` | `hi.agents.>`, `_INBOX.>` (deny `hi.research.>`) |
+| `AGENTS` | `agent.homeric` | `hi.agents.>`, `hi.tasks.>` | `hi.agents.>`, `_INBOX.>` |
 | `KEYSTONE` | `keystone.homeric` | `$JS.API.CONSUMER.>`, `$JS.API.STREAM.INFO.>`, `$JS.ACK.>` | `hi.tasks.>`, `_INBOX.>` |
 | `TELEMACHY` | `telemachy.homeric` | `hi.tasks.>`, `$JS.API.>` | `hi.tasks.>`, `_INBOX.>` |
 
@@ -100,8 +100,8 @@ to a subsequent ADR and tracked in the HomericIntelligence roadmap.
 - Closes #175: anonymous connections to port 4222 are rejected fail-closed.
 - Cluster port 6222 now requires a CA-signed peer cert; arbitrary peers cannot join.
 - Leaf remotes authenticate to the hub; unauthenticated leaf connections are rejected.
-- Least-privilege subject scoping: AGENTS cannot read `hi.research.>`; KEYSTONE cannot publish
-  arbitrary `hi.*` subjects.
+- Least-privilege subject scoping: AGENTS cannot subscribe to `hi.tasks.>` (allow-list enforced);
+  KEYSTONE cannot publish arbitrary `hi.*` subjects.
 - `AuthorizationError` is already classified as non-retryable in the Hermes publish retry loop, so
   auth failures surface immediately rather than burning retry budget.
 - The SAN-DNS convention is a hard, testable contract: `step ca certificate` enforces it at

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -149,19 +149,38 @@ ls -la build/
 
 NATS JetStream is the cross-host event bus. Configure it on the primary host:
 
-### 4a. Review the NATS Configuration
+### 4a. NATS Authentication Prerequisites (Required Before Starting NATS)
+
+The canonical NATS config enforces mutual TLS (`verify_and_map`) and subject-scoped account
+authorization (ADR-010). **All clients must present a role certificate and connect over `tls://`
+before you start NATS with the updated config** — enforcement is fail-closed.
+
+The following services default to plain `nats://` and must be reconfigured:
+
+| Service | Default | Required change |
+|---------|---------|-----------------|
+| `ProjectHermes` (`infrastructure/ProjectHermes/src/hermes/config.py:34`) | `nats://localhost:4222` | Set `NATS_URL=tls://…`, `TLS_CERT_FILE`, `TLS_KEY_FILE`, `TLS_CA_BUNDLE` |
+| `ProjectTelemachy` (`provisioning/ProjectTelemachy/src/telemachy/config.py:21`) | `nats://localhost:4222` | Set `NATS_URL=tls://…`, `REQUIRE_TLS=true` (client-cert wiring tracked separately) |
+| `docker-compose.crosshost.yml:45` | `NATS_URL: nats://nats:4222` | Update to `tls://nats:4222` and mount client cert |
+
+Follow `docs/runbooks/enable-nats-auth.md` to issue role certs, distribute them, and
+configure each service before proceeding with steps 4b–4c.
+
+### 4b. Review the NATS Configuration
 
 The canonical NATS server config is at `configs/nats/server.conf`. It configures:
 
 - JetStream persistence
-- TLS (if enabled)
+- Mutual-TLS authentication with `verify_and_map` (ADR-010)
+- Subject-scoped account authorization per the `hi.*` schema (ADR-005)
 - Leaf nodes (for multi-cluster federation)
 - Max connections and per-client limits
-- Authentication (fail-closed): requires `$NATS_CLIENT_TOKEN` for client
-  connections and `$NATS_LEAF_TOKEN` for leaf-node connections. NATS will
-  refuse connections without these credentials — set both in your deployment
-  secrets before starting the server. The recommended production path is
-  per-leaf NKey/JWT `.creds` files; see ADR-009 and
+- Authentication (fail-closed): client connections are authenticated via
+  cert-mapped subject-scoped accounts (`verify_and_map`, ADR-010), so no client
+  token is required. Leaf-node connections still require `$NATS_LEAF_TOKEN`
+  (issue #176). NATS will refuse leaf connections without that credential — set
+  it in your deployment secrets before starting the server. The recommended
+  production path is per-leaf NKey/JWT `.creds` files; see ADR-010 and
   `docs/runbooks/add-new-host.md` step 5.
 - Cluster route authorization (multi-server clusters only): the `cluster {}`
   listener on port 6222 requires a shared `$NATS_CLUSTER_TOKEN` in addition
@@ -175,10 +194,12 @@ The canonical NATS server config is at `configs/nats/server.conf`. It configures
   The server fails closed if a configured route peer presents the wrong token.
   Single-host deployments (no configured routes) are unaffected at runtime.
 
-For a single-host setup, set `$NATS_CLIENT_TOKEN` and `$NATS_LEAF_TOKEN`
-in your environment before starting the server.
+For a single-host setup, client connections are authenticated via cert-mapped
+subject-scoped accounts (ADR-010) — provision the role certs per step 4a and no
+client token is required. Set `$NATS_LEAF_TOKEN` before starting the server so
+the leafnode listener stays authenticated (issue #176).
 
-### 4b. Start the NATS Server
+### 4c. Start the NATS Server
 
 ```bash
 podman run -d \
@@ -197,7 +218,7 @@ podman logs nats-server
 
 You should see: `Server is ready for connections on 0.0.0.0:4222`
 
-### 4c. Configure Leaf Nodes (Multi-Host Only)
+### 4d. Configure Leaf Nodes (Multi-Host Only)
 
 If deploying across multiple hosts, configure leaf node connections in `configs/nats/leaf.conf` to federate the NATS clusters over Tailscale. See `docs/runbooks/add-new-host.md` for details.
 
@@ -434,12 +455,15 @@ Monitor the response through Agamemnon's task queue.
 
 Before running in production, complete these additional steps:
 
-### 12a. Enable TLS
+### 12a. Enable TLS and NATS Authentication
 
 Nomad ACLs are already enabled in `configs/nomad/server.hcl` and `client.hcl`
-(issue #196) — ensure you completed the `nomad acl bootstrap` in Step 5c. The
-remaining transport hardening is TLS: update `configs/nats/server.conf` and
-`configs/nomad/server.hcl` to enable TLS certificates.
+(issue #196) — ensure you completed the `nomad acl bootstrap` in Step 5c.
+
+NATS TLS encryption (ADR-008) and mutual-TLS authentication (ADR-010) are enabled by default
+in `configs/nats/server.conf`. Ensure role certs are provisioned and all clients are configured
+before starting NATS (see step 4a and `docs/runbooks/enable-nats-auth.md`). For Nomad TLS,
+update `configs/nomad/server.hcl` to add TLS certificates.
 
 ### 12b. Configure Persistent Storage
 

--- a/docs/runbooks/enable-nats-auth.md
+++ b/docs/runbooks/enable-nats-auth.md
@@ -1,0 +1,240 @@
+# Runbook: Enable NATS Mutual-TLS Authentication and Authorization
+
+This runbook enables the `verify_and_map` authentication and subject-scoped `accounts {}`
+authorization defined in ADR-010. Follow these steps top-to-bottom on every host before
+restarting NATS with the updated `configs/nats/server.conf` and `configs/nats/leaf.conf`.
+
+**CRITICAL:** Steps 1–3 must be completed and verified **before** restarting NATS in step 4.
+NATS with `verify_and_map = true` is fail-closed — all existing plain `nats://` connections
+will be rejected as soon as the new config is loaded.
+
+---
+
+## Prerequisites
+
+- An internal CA provisioned per ADR-008 (`step ca init`). The CA must be reachable or its
+  offline key must be available to sign role certs.
+- The `step` CLI installed: <https://smallstep.com/docs/step-cli/>
+- `/etc/nats/certs/ca.pem` deployed on all hosts (existing, from ADR-008 TLS setup).
+
+---
+
+## Step 1: Issue One SAN Cert Per Role
+
+For each role that will run on your mesh, issue a client cert with both a matching CN and a
+DNS Subject Alternative Name. The SAN-DNS value is the key used by NATS `verify_and_map` to
+look up the account user — a bare CN is never sufficient.
+
+Run the following on the host where the CA key is accessible (or via `step ca certificate`
+against a live CA):
+
+```bash
+# Directory to hold role certs
+mkdir -p /etc/nats/certs/clients
+chmod 700 /etc/nats/certs/clients
+
+# Hermes (event bridge, stream creator)
+step ca certificate hermes.homeric \
+  /etc/nats/certs/clients/hermes-cert.pem \
+  /etc/nats/certs/clients/hermes-key.pem \
+  --san hermes.homeric
+
+# Agent workers (Myrmidons)
+step ca certificate agent.homeric \
+  /etc/nats/certs/clients/agent-cert.pem \
+  /etc/nats/certs/clients/agent-key.pem \
+  --san agent.homeric
+
+# Keystone (DAG consumer)
+step ca certificate keystone.homeric \
+  /etc/nats/certs/clients/keystone-cert.pem \
+  /etc/nats/certs/clients/keystone-key.pem \
+  --san keystone.homeric
+
+# Telemachy (workflow runner)
+step ca certificate telemachy.homeric \
+  /etc/nats/certs/clients/telemachy-cert.pem \
+  /etc/nats/certs/clients/telemachy-key.pem \
+  --san telemachy.homeric
+
+# System account (NATS internal — issue if needed for system-level tooling)
+step ca certificate sys.homeric \
+  /etc/nats/certs/clients/sys-cert.pem \
+  /etc/nats/certs/clients/sys-key.pem \
+  --san sys.homeric
+
+# Fix permissions
+chmod 644 /etc/nats/certs/clients/*-cert.pem
+chmod 600 /etc/nats/certs/clients/*-key.pem
+```
+
+**Verify each cert carries the DNS SAN:**
+
+```bash
+openssl x509 -noout -ext subjectAltName \
+  -in /etc/nats/certs/clients/hermes-cert.pem
+# Expected output must include: DNS:hermes.homeric
+```
+
+---
+
+## Step 2: Distribute Role Certs to Each Host
+
+Copy the relevant role cert(s) to `/etc/nats/certs/clients/` on each host that runs the
+corresponding service:
+
+| Host | Services | Certs needed |
+|------|----------|--------------|
+| Primary (epimetheus) | NATS hub, Hermes | `hermes-cert.pem`, `hermes-key.pem` |
+| Control host | Agamemnon, Telemachy | `telemachy-cert.pem`, `telemachy-key.pem` |
+| Worker hosts | Myrmidon agents | `agent-cert.pem`, `agent-key.pem` |
+| Keystone hosts | ProjectKeystone | `keystone-cert.pem`, `keystone-key.pem` |
+
+Use `scp` over Tailscale or your secret-distribution tool (ProjectKeystone / Myrmidons):
+
+```bash
+# Example: distribute Hermes cert to the primary host
+scp /etc/nats/certs/clients/hermes-{cert,key}.pem \
+  100.92.173.32:/etc/nats/certs/clients/
+```
+
+---
+
+## Step 3: Configure Each Client to Use TLS and Present Its Cert
+
+Configure each downstream service **before** restarting NATS. The table below maps each
+service to the environment variables that enable mTLS. Set these in your deployment secrets,
+systemd unit `[Service]` block, or compose `.env` file.
+
+> **Note on ProjectTelemachy:** The `require_tls` gate in
+> `provisioning/ProjectTelemachy/src/telemachy/config.py` rejects plain `nats://` when
+> `REQUIRE_TLS=true` but does not yet load a client cert. Client-cert wiring for Telemachy
+> is tracked as a follow-up issue ("ProjectTelemachy: add NATS client-cert (mTLS) wiring").
+> Telemachy cannot connect to a `verify_and_map`-enforced NATS until that issue is resolved.
+
+| Service | Environment variables |
+|---------|----------------------|
+| **ProjectHermes** (`infrastructure/ProjectHermes/src/hermes/config.py:34`) | `NATS_URL=tls://<hub-tailscale-ip>:4222`<br>`TLS_CERT_FILE=/etc/nats/certs/clients/hermes-cert.pem`<br>`TLS_KEY_FILE=/etc/nats/certs/clients/hermes-key.pem`<br>`TLS_CA_BUNDLE=/etc/nats/certs/ca.pem` |
+| **ProjectTelemachy** (`provisioning/ProjectTelemachy/src/telemachy/config.py:21`) | `NATS_URL=tls://<hub-tailscale-ip>:4222`<br>`REQUIRE_TLS=true`<br>*(client-cert wiring pending — see note above)* |
+| **compose bridge** (`docker-compose.crosshost.yml:45`) | `NATS_URL=tls://nats:4222`<br>Mount `telemachy-cert.pem` / `telemachy-key.pem` into the container and set the corresponding `TLS_CERT_FILE` / `TLS_KEY_FILE` env vars. |
+
+Hermes is already mTLS-capable (`config.py:102-105` defines `tls_cert_file`, `tls_key_file`,
+`tls_ca_bundle`; `config.py:126 build_ssl_context()` activates when cert+key are set). Only
+the environment variables above are required — no code changes needed for Hermes.
+
+**PREREQUISITE: Provision the `hermes.homeric` cert before enabling enforcement.**
+Hermes creates JetStream streams (`homeric-agents`, `homeric-tasks`) on startup. If the
+Hermes cert is absent when NATS enforcement is activated, streams will not be created and the
+entire `hi.*` event pipeline will be inoperative.
+
+---
+
+## Step 4: Restart NATS with the New Config
+
+On the **primary** NATS host (`server.conf`):
+
+```bash
+# If running via podman
+podman stop nats-server
+podman run -d \
+  --name nats-server \
+  --network homeric-mesh \
+  -p 4222:4222 \
+  -p 6222:6222 \
+  -p 7422:7422 \
+  -v /etc/nats/certs:/etc/nats/certs:ro \
+  -v $(pwd)/configs/nats/server.conf:/etc/nats/server.conf:ro \
+  nats:3.12.0 -c /etc/nats/server.conf
+
+# If running nats-server natively
+sudo systemctl restart nats
+```
+
+On each **leaf node** host (`leaf.conf`):
+
+```bash
+podman stop nats-leaf
+podman run -d \
+  --name nats-leaf \
+  --network homeric-mesh \
+  -p 4222:4222 \
+  -v /etc/nats/certs:/etc/nats/certs:ro \
+  -v $(pwd)/configs/nats/leaf.conf:/etc/nats/server.conf:ro \
+  nats:3.12.0 -c /etc/nats/server.conf
+```
+
+Check logs for startup errors:
+
+```bash
+podman logs nats-server 2>&1 | grep -iE "error|fatal|tls|account"
+```
+
+Expected: `Server is ready for connections on 0.0.0.0:4222` with no TLS/account errors.
+
+---
+
+## Step 5: Functional Verification
+
+Run these checks against the running hardened NATS server to confirm auth enforcement:
+
+```bash
+HUB="tls://127.0.0.1:4222"
+CERTS="/etc/nats/certs/clients"
+CA="/etc/nats/certs/ca.pem"
+
+# 1. Anonymous connect MUST be rejected (no client cert)
+nats --server "$HUB" pub hi.test x 2>&1 \
+  | grep -qiE "tls|certificate|authorization required" \
+  && echo "PASS: anonymous connect rejected" \
+  || echo "FAIL: anonymous connect was NOT rejected"
+
+# 2. hermes.homeric cert MUST be able to create a JetStream stream
+nats --server "$HUB" \
+  --tlscert "$CERTS/hermes-cert.pem" \
+  --tlskey  "$CERTS/hermes-key.pem" \
+  --tlsca   "$CA" \
+  stream add homeric-agents-test \
+  --subjects "hi.agents.>" \
+  --defaults \
+  && echo "PASS: HERMES account can create a stream" \
+  || echo "FAIL: HERMES stream creation failed"
+
+# 3. agent.homeric cert MUST be denied on hi.research.> (permissions deny)
+nats --server "$HUB" \
+  --tlscert "$CERTS/agent-cert.pem" \
+  --tlskey  "$CERTS/agent-key.pem" \
+  --tlsca   "$CA" \
+  sub "hi.research.>" 2>&1 \
+  | grep -qiE "permissions violation" \
+  && echo "PASS: AGENTS account denied hi.research.>" \
+  || echo "FAIL: AGENTS account was NOT denied hi.research.>"
+
+# 4. Hermes health endpoint (proves Hermes reconnected with its cert)
+curl -sf http://localhost:8085/health | grep -q '"status"' \
+  && echo "PASS: Hermes healthy (reconnected with client cert)" \
+  || echo "FAIL: Hermes health check failed"
+```
+
+All four checks must output `PASS` before this runbook is considered complete.
+
+---
+
+## Step 6: Rollback
+
+If clients cannot connect after enabling enforcement:
+
+1. Stop NATS.
+2. Restore the previous `server.conf` (remove `verify_and_map = true` and the `accounts {}`
+   block, or revert to the pre-ADR-010 config from git).
+3. Restart NATS.
+4. Diagnose cert/SAN issues with `openssl x509 -noout -ext subjectAltName -in <cert>` and
+   confirm `accounts {}` `user` values match the DNS SANs exactly.
+5. Re-run from Step 1.
+
+```bash
+# Quick rollback — revert to pre-auth config
+git -C /path/to/Odysseus show HEAD~1:configs/nats/server.conf \
+  > /tmp/server.conf.prev
+sudo cp /tmp/server.conf.prev /etc/nats/server.conf
+sudo systemctl restart nats
+```

--- a/docs/runbooks/enable-nats-auth.md
+++ b/docs/runbooks/enable-nats-auth.md
@@ -199,23 +199,47 @@ nats --server "$HUB" \
   && echo "PASS: HERMES account can create a stream" \
   || echo "FAIL: HERMES stream creation failed"
 
-# 3. agent.homeric cert MUST be denied on hi.research.> (permissions deny)
+# 3. agent.homeric cert MUST be denied subscribing to hi.tasks.> (not in AGENTS subscribe allow-list)
+#    AGENTS subscribe allow = ["hi.agents.>", "_INBOX.>"]; hi.tasks.> is genuinely
+#    outside that list, so this verifies the allow-list boundary is enforced.
 nats --server "$HUB" \
   --tlscert "$CERTS/agent-cert.pem" \
   --tlskey  "$CERTS/agent-key.pem" \
   --tlsca   "$CA" \
-  sub "hi.research.>" 2>&1 \
+  sub "hi.tasks.>" 2>&1 \
   | grep -qiE "permissions violation" \
-  && echo "PASS: AGENTS account denied hi.research.>" \
-  || echo "FAIL: AGENTS account was NOT denied hi.research.>"
+  && echo "PASS: AGENTS account denied hi.tasks.> (allow-list boundary enforced)" \
+  || echo "FAIL: AGENTS account was NOT denied hi.tasks.> (allow-list not enforced)"
 
 # 4. Hermes health endpoint (proves Hermes reconnected with its cert)
 curl -sf http://localhost:8085/health | grep -q '"status"' \
   && echo "PASS: Hermes healthy (reconnected with client cert)" \
   || echo "FAIL: Hermes health check failed"
+
+# 5. LEAF -> HUB PROPAGATION (run only on hosts with a leaf node)
+#    With named accounts{}, each leafnode remote bridges exactly ONE account, so the
+#    leaf.conf remotes block must carry one entry per account with an explicit
+#    `account:` binding. This check proves a leaf-attached AGENTS client's hi.agents.>
+#    events actually reach the hub — the gap a missing per-account remote would leave
+#    silently uncaught. Subscribe on the HUB, publish from the LEAF.
+LEAF="tls://127.0.0.1:4222"   # local leaf node client port
+HUB="tls://100.92.173.32:4222" # primary hub client port (update to your hub IP)
+AGENT_TLS=(--tlscert "$CERTS/agent-cert.pem" --tlskey "$CERTS/agent-key.pem" --tlsca "$CA")
+
+# Subscribe on the HUB for one message, in the background
+nats --server "$HUB" "${AGENT_TLS[@]}" sub "hi.agents.leafcheck" --count 1 > /tmp/leafcheck.out 2>&1 &
+SUB_PID=$!
+sleep 1
+# Publish from the LEAF node's local client port
+nats --server "$LEAF" "${AGENT_TLS[@]}" pub "hi.agents.leafcheck" "leaf-to-hub-ok"
+wait "$SUB_PID" 2>/dev/null
+grep -q "leaf-to-hub-ok" /tmp/leafcheck.out \
+  && echo "PASS: leaf-attached AGENTS hi.agents.> propagates to hub" \
+  || echo "FAIL: leaf hi.agents.> did NOT reach hub (check per-account remote in leaf.conf)"
 ```
 
-All four checks must output `PASS` before this runbook is considered complete.
+All five checks must output `PASS` before this runbook is considered complete.
+(Check 5 applies only to hosts running a leaf node; skip it on the hub itself.)
 
 ---
 


### PR DESCRIPTION
## Summary

- Enables mutual-TLS (`verify_and_map`) on the NATS client listener (port 4222), so anonymous connections are rejected fail-closed.
- Adds `verify = true` to the cluster (port 6222) and leafnode (port 7422) TLS blocks, so unauthenticated peers cannot join.
- Adds a client cert+key to the leaf remote `tls {}`, so the hub authenticates leaf nodes.
- Inserts five subject-scoped `accounts {}` (`SYS`, `HERMES`, `AGENTS`, `KEYSTONE`, `TELEMACHY`) mapping cert SAN-DNS identities to least-privilege `hi.*` permissions per ADR-005.
- Writes ADR-009 defining the SAN-DNS cert convention (the binding contract for `verify_and_map`), account table, and future AID v0.2.0 path.
- Writes `docs/runbooks/enable-nats-auth.md`: numbered cert-issuance → distribution → per-client env-wiring → restart → functional verification → rollback procedure.
- Updates `docs/deployment.md` with a "NATS authentication prerequisites" subsection (step 4a) naming the three clients that default to plain `nats://` today.
- Files follow-up issue #304 for ProjectTelemachy client-cert wiring (the one genuine code gap out of scope for this Odysseus-config PR).

## Key design decisions

- **SAN-DNS as the mapping key:** NATS `verify_and_map` matches SAN email → SAN DNS → RFC-2253 Subject DN. Bare CN is never a match key. All `accounts {}` `user` values are the SAN-DNS string (e.g. `hermes.homeric`); ADR-009 mandates `--san <role>.homeric` at cert issuance time.
- **Reuse ADR-008 PKI:** `ca.pem` already deployed per ADR-008; no new CA needed.
- **Fail-closed, not fail-open:** enforcement is enabled in the config by default. The runbook makes provisioning the `hermes.homeric` cert a hard prerequisite before restart (Hermes creates JetStream streams on startup).
- **AID v0.2.0 (Ed25519+JWT) deferred:** recorded as the future path in ADR-009 Consequences; not built now.

## e2e/local stubs

`e2e/` scripts use `nats://localhost:…` targeting local test servers, not the canonical hardened server. They are not updated in this PR and are unaffected by enforcement on the production config.

## Verification

```bash
grep -nE "verify_and_map\s*=\s*true" configs/nats/server.conf configs/nats/leaf.conf
grep -nE "verify\s*=\s*true" configs/nats/server.conf
grep -nE "accounts \{|system_account" configs/nats/server.conf
grep -nE 'user = "(sys|hermes|agent|keystone|telemachy)\.homeric"' configs/nats/server.conf
~/.local/bin/nats-server -t -c configs/nats/server.conf 2>&1 | grep -v "no such file" | grep -iE "error|syntax" || echo "syntax OK"
```

Closes #175