### PR TITLE
fix(github): activate ruleset enforcement, align org contexts, preserve rollback (#177)

### DIFF
--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -322,13 +322,18 @@ jobs:
       - name: Assert each ruleset config holds its intended enforcement value
         run: |
           set -euo pipefail
-          # The two-form split follows the base/active filename convention:
-          # base *-ruleset.json are "evaluate"; *-active.json are "active".
+          # Enforcement-value contract (issue #177): the canonical bare
+          # *-ruleset.json files are the live/enforcing default and must be
+          # "active" so an idempotent re-apply never silently downgrades the
+          # live ruleset back to shadow mode. *-active.json are also "active".
+          # The explicit *-evaluate.json files carry the "evaluate" (shadow)
+          # form for the deliberate rollback/shadow path (--evaluate flag).
           # Catches silent drift in BOTH directions (downgrade and upgrade).
           declare -A expected=(
-            [configs/github/repo-ruleset.json]=evaluate
+            [configs/github/repo-ruleset.json]=active
             [configs/github/repo-ruleset-active.json]=active
-            [configs/github/org-ruleset.json]=evaluate
+            [configs/github/repo-ruleset-evaluate.json]=evaluate
+            [configs/github/org-ruleset.json]=active
             [configs/github/org-ruleset-active.json]=active
           )
           fail=0
@@ -342,7 +347,7 @@ jobs:
             fi
           done
           [ "$fail" -eq 0 ] || { echo "FAILED: ruleset enforcement drift detected" >&2; exit 1; }
-          echo "PASSED: all 4 ruleset configs hold their intended enforcement"
+          echo "PASSED: all ruleset configs hold their intended enforcement"
 
   deps-version-sync:
     name: deps/version-sync

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,12 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Branch protection: require 1 approving review on `main` across all four canonical rulesets (closes #178).
 
 ### Fixed
+- GitHub ruleset configs now match the enforcing live state: `repo-ruleset.json`
+  and `org-ruleset.json` set `"enforcement": "active"` (#177), preventing an
+  idempotent re-apply from downgrading the live repo ruleset back to `evaluate`.
+  Corrected `org-ruleset.json` contexts to the canonical bare-name +
+  `integration_id` form. Added `repo-ruleset-evaluate.json` + `--evaluate`
+  apply flag so the evaluate-mode rollback path is preserved.
 - `install.sh` now extends `PATH` before Phase 1 detection so prior-installed
   tools are found (#271).
 - CI: skip `ProjectOdyssey` in idempotent-build when Podman is unavailable

--- a/configs/github/org-ruleset.json
+++ b/configs/github/org-ruleset.json
@@ -1,7 +1,7 @@
 {
   "name": "homeric-main-baseline",
   "target": "branch",
-  "enforcement": "evaluate",
+  "enforcement": "active",
   "conditions": {
     "ref_name": { "include": ["refs/heads/main"], "exclude": [] },
     "repository_name": { "include": ["~ALL"], "exclude": [], "protected": true }
@@ -30,15 +30,14 @@
       "parameters": {
         "strict_required_status_checks_policy": false,
         "required_status_checks": [
-          { "context": "Required Checks / lint" },
-          { "context": "Required Checks / unit-tests" },
-          { "context": "Required Checks / integration-tests" },
-          { "context": "Required Checks / security/dependency-scan" },
-          { "context": "Required Checks / security/secrets-scan" },
-          { "context": "Required Checks / build" },
-          { "context": "Required Checks / typecheck" },
-          { "context": "Required Checks / schema-validation" },
-          { "context": "Required Checks / deps/version-sync" }
+          { "context": "lint",                    "integration_id": 15368 },
+          { "context": "unit-tests",              "integration_id": 15368 },
+          { "context": "integration-tests",       "integration_id": 15368 },
+          { "context": "security/dependency-scan","integration_id": 15368 },
+          { "context": "security/secrets-scan",   "integration_id": 15368 },
+          { "context": "build",                   "integration_id": 15368 },
+          { "context": "schema-validation",       "integration_id": 15368 },
+          { "context": "deps/version-sync",       "integration_id": 15368 }
         ]
       }
     }

--- a/configs/github/repo-ruleset-evaluate.json
+++ b/configs/github/repo-ruleset-evaluate.json
@@ -1,24 +1,20 @@
 {
   "name": "homeric-main-baseline",
   "target": "branch",
-  "enforcement": "active",
+  "enforcement": "evaluate",
   "conditions": {
-    "ref_name": { "include": ["refs/heads/main"], "exclude": [] },
-    "repository_name": { "include": ["~ALL"], "exclude": [], "protected": true }
+    "ref_name": { "include": ["refs/heads/main"], "exclude": [] }
   },
   "bypass_actors": [
-    { "actor_id": 1, "actor_type": "OrganizationAdmin", "bypass_mode": "pull_request" },
-    { "actor_id": 49699333, "actor_type": "Integration", "bypass_mode": "pull_request" }
+    { "actor_id": 5, "actor_type": "RepositoryRole", "bypass_mode": "pull_request" }
   ],
   "rules": [
     { "type": "deletion" },
-    { "type": "non_fast_forward" },
-    { "type": "required_linear_history" },
     { "type": "required_signatures" },
     {
       "type": "pull_request",
       "parameters": {
-        "required_approving_review_count": 1,
+        "required_approving_review_count": 0,
         "dismiss_stale_reviews_on_push": false,
         "require_code_owner_review": false,
         "require_last_push_approval": false,

--- a/configs/github/repo-ruleset.json
+++ b/configs/github/repo-ruleset.json
@@ -1,7 +1,7 @@
 {
   "name": "homeric-main-baseline",
   "target": "branch",
-  "enforcement": "evaluate",
+  "enforcement": "active",
   "conditions": {
     "ref_name": { "include": ["refs/heads/main"], "exclude": [] }
   },

--- a/docs/runbooks/branch-protection-rollout.md
+++ b/docs/runbooks/branch-protection-rollout.md
@@ -12,17 +12,21 @@ ruleset after a change.
 
 1. In the new repo, create `.github/workflows/_required.yml` using
    `research/ProjectScylla/.github/workflows/_required.yml` as the reference.
-   The workflow must be named `Required Checks` and have exactly 9 jobs whose
-   `name:` fields match the contexts in `configs/github/canonical-checks.md`.
+   The workflow must be named `Required Checks` and have `name:` fields that
+   match the contexts in `configs/github/canonical-checks.md`. There are
+   **8 required contexts**; `_required.yml` also defines a 9th job
+   (`forbid-suppressions`) that is intentionally NOT a required context.
    Each job must invoke a real validator for that repo's stack.
 
-2. Open a PR, verify all 9 contexts appear in the PR checks UI once CI runs,
-   then merge.
+2. Open a PR, verify all 8 required contexts appear in the PR checks UI once CI
+   runs, then merge.
 
-3. Apply the ruleset to the new repo:
+3. Apply the ruleset to the new repo in shadow (evaluate) mode first:
    ```bash
-   ./tools/github/apply-repo-rulesets.sh --repos <NewRepo>
+   ./tools/github/apply-repo-rulesets.sh --evaluate --repos <NewRepo>
    ```
+   (The bare invocation now applies the canonical `repo-ruleset.json`, which is
+   `active`; pass `--evaluate` for the shadow pass.)
 
 4. Observe evaluate mode for one PR cycle, then flip to active:
    ```bash
@@ -32,8 +36,10 @@ ruleset after a change.
 ## Re-applying the ruleset to all repos
 
 ```bash
-# Evaluate mode first (shadow enforcement — reports but doesn't block)
-./tools/github/apply-repo-rulesets.sh
+# Evaluate mode first (shadow enforcement — reports but doesn't block).
+# NOTE: the bare invocation applies the canonical repo-ruleset.json, which is
+# now "active"; use --evaluate explicitly for the shadow pass.
+./tools/github/apply-repo-rulesets.sh --evaluate
 
 # Check evaluate results
 gh api "repos/HomericIntelligence/<repo>/rulesets/rule-suites?ref=refs/heads/main" \
@@ -66,8 +72,12 @@ by the old context list during a ruleset migration. Use sparingly.
 
 Re-applying evaluate mode is instant and safe:
 ```bash
-./tools/github/apply-repo-rulesets.sh   # reverts to evaluate
+./tools/github/apply-repo-rulesets.sh --evaluate   # or: --repos <repo>
 ```
+
+> Note: `org-ruleset.json` is not applied on the current GitHub plan —
+> `gh api orgs/HomericIntelligence/rulesets` returns 404 / requires `admin:org`.
+> Per-repo rulesets (`repos/<org>/<repo>/rulesets`) are the enforcing path.
 
 To remove the ruleset entirely from a single repo:
 ```bash

--- a/tools/github/apply-repo-rulesets.sh
+++ b/tools/github/apply-repo-rulesets.sh
@@ -1,24 +1,26 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# apply-repo-rulesets.sh [--active] [--repos repo1,repo2,...]
+# apply-repo-rulesets.sh [--active|--evaluate] [--repos repo1,repo2,...]
 # Creates or updates the homeric-main-baseline branch ruleset on every repo.
 # Usage:
-#   ./tools/github/apply-repo-rulesets.sh                    # evaluate mode, all repos
+#   ./tools/github/apply-repo-rulesets.sh                    # canonical (active) mode, all repos
 #   ./tools/github/apply-repo-rulesets.sh --active           # active (enforcing) mode, all repos
-#   ./tools/github/apply-repo-rulesets.sh --repos Foo,Bar    # evaluate mode, specific repos only
+#   ./tools/github/apply-repo-rulesets.sh --evaluate         # evaluate (shadow) mode, all repos
+#   ./tools/github/apply-repo-rulesets.sh --repos Foo,Bar    # canonical mode, specific repos only
 
 ORG="HomericIntelligence"
 RULESET_NAME="homeric-main-baseline"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 
-ENFORCEMENT="evaluate"
+ENFORCEMENT=""
 REPOS_OVERRIDE=""
 
 while [[ $# -gt 0 ]]; do
   case "${1:-}" in
     --active)        ENFORCEMENT="active"; shift ;;
+    --evaluate)      ENFORCEMENT="evaluate"; shift ;;
     --repos)         REPOS_OVERRIDE="$2"; shift 2 ;;
     --repos=*)       REPOS_OVERRIDE="${1#--repos=}"; shift ;;
     *) echo "Unknown argument: $1" >&2; exit 2 ;;
@@ -28,9 +30,12 @@ done
 if [[ "$ENFORCEMENT" == "active" ]]; then
   JSON_FILE="$REPO_ROOT/configs/github/repo-ruleset-active.json"
   echo "Applying in ACTIVE (enforcing) mode"
+elif [[ "$ENFORCEMENT" == "evaluate" ]]; then
+  JSON_FILE="$REPO_ROOT/configs/github/repo-ruleset-evaluate.json"
+  echo "Applying in EVALUATE (shadow) mode"
 else
   JSON_FILE="$REPO_ROOT/configs/github/repo-ruleset.json"
-  echo "Applying in EVALUATE mode"
+  echo "Applying canonical ruleset ($(jq -r .enforcement "$JSON_FILE") mode)"
 fi
 
 if [[ -n "$REPOS_OVERRIDE" ]]; then


### PR DESCRIPTION
## Summary

- Flips `"enforcement"` from `"evaluate"` to `"active"` in both `configs/github/repo-ruleset.json` and `configs/github/org-ruleset.json`, closing the drift window where an idempotent re-apply would silently downgrade the live (already-active) repo ruleset back to evaluate mode.
- Replaces the 9 stale prefixed `Required Checks / *` contexts in `org-ruleset.json` with the canonical 8 bare-name + `integration_id: 15368` entries that match the live enforcing repo ruleset (id 15556483).
- Adds `configs/github/repo-ruleset-evaluate.json` so the evaluate shadow-test rollback path survives the base file flipping to active.
- Adds `--evaluate` flag to `tools/github/apply-repo-rulesets.sh`; default (no flag) now applies the canonical `repo-ruleset.json`.
- Corrects runbook wording: "9 jobs / 9 contexts" → "8 required contexts (9 jobs, `forbid-suppressions` intentionally non-required)"; points Rollback at `--evaluate`; adds org-endpoint 404 caveat.

## Test plan

- [x] `jq -e '.enforcement == "active"'` passes on both ruleset files
- [x] `org-ruleset.json` contexts are exactly the canonical 8 bare-name + `integration_id: 15368` entries
- [x] `repo-ruleset.json` has exactly 8 required contexts; `forbid-suppressions` is absent
- [x] `repo-ruleset-evaluate.json` exists and has `"enforcement": "evaluate"`
- [x] `apply-repo-rulesets.sh` has `--evaluate` flag; `repo-ruleset-active.json` intact
- [x] All JSON files valid (`jq empty`)
- [x] Runbook contains "8 required contexts" and `--evaluate` references
- [x] Commit is GPG-signed (Good signature verified)

Closes #177

🤖 Generated with [Claude Code](https://claude.com/claude-code)