### PR TITLE
fix(governance): require 1 approving review in all four canonical rulesets

### DIFF
--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -272,8 +272,21 @@ jobs:
           find .github/workflows -name "*.yml" | xargs check-jsonschema \
             --schemafile https://json.schemastore.org/github-workflow
 
-      - name: Validate org-ruleset.json is valid JSON
-        run: jq . configs/github/org-ruleset.json > /dev/null && echo "org-ruleset.json is valid JSON"
+      - name: Validate ruleset JSON and require >=1 approving review
+        run: |
+          for f in configs/github/org-ruleset.json \
+                   configs/github/org-ruleset-active.json \
+                   configs/github/repo-ruleset.json \
+                   configs/github/repo-ruleset-active.json; do
+            jq . "$f" > /dev/null
+            count=$(jq 'first(.rules[] | select(.type=="pull_request")
+                       | .parameters.required_approving_review_count)' "$f")
+            if [ -z "$count" ] || [ "$count" -lt 1 ]; then
+              echo "ERROR: $f has required_approving_review_count=$count (must be >=1)" >&2
+              exit 1
+            fi
+            echo "$f OK (required_approving_review_count=$count)"
+          done
 
   deps-version-sync:
     name: deps/version-sync

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,9 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   knowledge store) and ProjectOdyssey (Mojo ML training framework) descriptions
   to match their stabilized scope (#3).
 
+### Security
+- Branch protection: require 1 approving review on `main` across all four canonical rulesets (closes #178).
+
 ### Fixed
 - `install.sh` now extends `PATH` before Phase 1 detection so prior-installed
   tools are found (#271).

--- a/configs/github/org-ruleset-active.json
+++ b/configs/github/org-ruleset-active.json
@@ -18,7 +18,7 @@
     {
       "type": "pull_request",
       "parameters": {
-        "required_approving_review_count": 0,
+        "required_approving_review_count": 1,
         "dismiss_stale_reviews_on_push": false,
         "require_code_owner_review": false,
         "require_last_push_approval": false,

--- a/configs/github/org-ruleset.json
+++ b/configs/github/org-ruleset.json
@@ -18,7 +18,7 @@
     {
       "type": "pull_request",
       "parameters": {
-        "required_approving_review_count": 0,
+        "required_approving_review_count": 1,
         "dismiss_stale_reviews_on_push": false,
         "require_code_owner_review": false,
         "require_last_push_approval": false,

--- a/configs/github/repo-ruleset-active.json
+++ b/configs/github/repo-ruleset-active.json
@@ -14,7 +14,7 @@
     {
       "type": "pull_request",
       "parameters": {
-        "required_approving_review_count": 0,
+        "required_approving_review_count": 1,
         "dismiss_stale_reviews_on_push": false,
         "require_code_owner_review": false,
         "require_last_push_approval": false,

--- a/configs/github/repo-ruleset.json
+++ b/configs/github/repo-ruleset.json
@@ -14,7 +14,7 @@
     {
       "type": "pull_request",
       "parameters": {
-        "required_approving_review_count": 0,
+        "required_approving_review_count": 1,
         "dismiss_stale_reviews_on_push": false,
         "require_code_owner_review": false,
         "require_last_push_approval": false,


### PR DESCRIPTION
## Summary

- Set `required_approving_review_count` from `0` to `1` in all four canonical GitHub branch-protection ruleset files (`org-ruleset.json`, `org-ruleset-active.json`, `repo-ruleset.json`, `repo-ruleset-active.json`).
- Extended the `schema-validation` CI step in `_required.yml` to assert the count is `>=1` across all four files via `jq`, preventing silent regression.
- Existing `bypass_actors` (OrganizationAdmin, Integration, RepositoryRole/admin) already provide the admin escape hatch documented in `docs/runbooks/branch-protection-rollout.md`; no new bypass actors needed.
- `enforcement` is left untouched (`evaluate` in the base files, `active` in `-active` variants); activation remains a deliberate operational step per the rollout runbook.

## Test plan

- [ ] All four ruleset files parse as valid JSON (`jq . "$f" > /dev/null`)
- [ ] All four files report `required_approving_review_count=1` via `jq '.rules[]|select(.type=="pull_request")|.parameters.required_approving_review_count'`
- [ ] `grep '"required_approving_review_count": 0'` returns no matches across all four files
- [ ] CI `schema-validation` step passes with the new `jq` guard
- [ ] (Post-merge, operational) Re-apply via `just ruleset-apply` / `just repo-rulesets-apply` to push live; activation is a separate deliberate step

Closes #178

🤖 Generated with [Claude Code](https://claude.com/claude-code)