### PR TITLE
fix(security): remove ANTHROPIC_API_KEY value from podman cmdline

### DIFF
--- a/e2e/claude-myrmidon-multi.py
+++ b/e2e/claude-myrmidon-multi.py
@@ -217,11 +217,17 @@ def _build_container_cmd_scoped(
     """
     home = os.path.expanduser("~")
 
-    # Common mounts: claude session data + gh CLI config
+    # Common mounts: claude session data + gh CLI config.
+    # Issue #180: pass ANTHROPIC_API_KEY by name only (no `=value`) so podman
+    # reads the value from this process's env and injects it into the container
+    # without the value ever appearing on the command line (ps/proc/cmdline).
+    # The image-baked npm `claude` still receives the key unchanged.
+    if not os.environ.get("ANTHROPIC_API_KEY"):
+        log("claude", f"{YELLOW}ANTHROPIC_API_KEY is unset — container auth may fail{NC}")
     common_mounts = [
         "-v", f"{home}/.claude:{home}/.claude",
         "-v", f"{home}/.config/gh:{home}/.config/gh:ro",
-        "-e", f"ANTHROPIC_API_KEY={os.environ.get('ANTHROPIC_API_KEY', '')}",
+        "-e", "ANTHROPIC_API_KEY",  # name-only: value pulled from host env, not on cmdline
         "-e", f"HOME={home}",
     ]
     if os.path.exists(f"{home}/.claude.json"):

--- a/e2e/claude-myrmidon.py
+++ b/e2e/claude-myrmidon.py
@@ -227,7 +227,10 @@ def _build_container_cmd(claude_args: list[str], cwd: str = WORKING_DIR) -> list
     """Build a container run command with proper volume mappings.
 
     Maps the host WORKING_DIR to /workspace inside the achaean-claude container,
-    plus the user's .claude config and ANTHROPIC_API_KEY for authentication.
+    plus the user's .claude config (OAuth credentials in ~/.claude/.credentials.json
+    and ~/.claude.json). The API key is NOT passed: command-line args are
+    world-readable via `ps`/`/proc/<pid>/cmdline` (issue #180), and the mounted
+    standalone claude-host binary authenticates via the OAuth creds, not the env var.
 
     Mounts the host's standalone claude binary to avoid npm version TLS issues
     with the oauth auth flow inside containers.
@@ -261,7 +264,6 @@ def _build_container_cmd(claude_args: list[str], cwd: str = WORKING_DIR) -> list
         "-v", f"{home}/.claude:{home}/.claude",
         "-v", f"{home}/.config/gh:{home}/.config/gh:ro",
         "-w", CONTAINER_WORKSPACE,
-        "-e", f"ANTHROPIC_API_KEY={os.environ.get('ANTHROPIC_API_KEY', '')}",
         "-e", f"HOME={home}",
         *(["-v", f"{home}/.claude.json:{home}/.claude.json"] if os.path.exists(f"{home}/.claude.json") else []),
         *(["-v", f"{standalone}:/usr/local/bin/claude-host:ro"] if standalone else []),

--- a/e2e/tests/security/_run_one_auth_probe.py
+++ b/e2e/tests/security/_run_one_auth_probe.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""Issue #180 live auth probe: build a worker's real container command and run a
+trivial prompt, asserting auth succeeds with the secret kept off the cmdline."""
+import importlib.util
+import pathlib
+import subprocess
+import sys
+
+E2E = pathlib.Path(__file__).resolve().parents[2]
+
+
+def load(fn: str) -> object:
+    """Load a module from the e2e directory by filename."""
+    spec = importlib.util.spec_from_file_location("w", E2E / fn)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+worker = sys.argv[1]
+prompt = "Reply with exactly: OK"
+
+if worker == "single":
+    m = load("claude-myrmidon.py")
+    cmd = m._build_container_cmd(
+        [
+            "claude-host",
+            "-p", prompt,
+            "--dangerously-skip-permissions",
+            "--allowedTools", "Read",
+        ],
+        cwd="/tmp",
+    )
+else:
+    m = load("claude-myrmidon-multi.py")
+    cmd = m._build_container_cmd_scoped(
+        [
+            "claude",
+            "-p", prompt,
+            "--permission-mode", "acceptEdits",
+            "--allowedTools", "Read",
+        ],
+        cwd="/tmp",
+        scope="plan",
+    )
+
+result = subprocess.run(
+    cmd,
+    capture_output=True,
+    text=True,
+    stdin=subprocess.DEVNULL,
+    timeout=120,
+)
+out = (result.stdout or "").strip()
+
+# Auth failure surfaces as non-zero exit and/or auth/credential error text.
+if (
+    result.returncode != 0
+    or not out
+    or "ERROR" in out
+    or "auth" in (result.stderr or "").lower()
+):
+    sys.stderr.write(f"rc={result.returncode} stderr={result.stderr[:300]}\n")
+    sys.exit(1)
+
+print(out[:200])
+sys.exit(0)

--- a/e2e/tests/security/_run_one_auth_probe.py
+++ b/e2e/tests/security/_run_one_auth_probe.py
@@ -52,13 +52,23 @@ result = subprocess.run(
     timeout=120,
 )
 out = (result.stdout or "").strip()
+err = (result.stderr or "").lower()
 
-# Auth failure surfaces as non-zero exit and/or auth/credential error text.
+# Auth failure surfaces as non-zero exit, empty output, or a specific
+# credential-error token in stderr. Anchor on concrete failure phrases rather
+# than the 4-char "auth" (which matches "author"/"authorized"/etc.), and rely
+# on returncode + empty-output instead of a broad "ERROR in stdout" substring.
+_AUTH_FAIL_TOKENS = (
+    "authentication",
+    "invalid api key",
+    "invalid_api_key",
+    "unauthorized",
+    "credential",
+)
 if (
     result.returncode != 0
     or not out
-    or "ERROR" in out
-    or "auth" in (result.stderr or "").lower()
+    or any(tok in err for tok in _AUTH_FAIL_TOKENS)
 ):
     sys.stderr.write(f"rc={result.returncode} stderr={result.stderr[:300]}\n")
     sys.exit(1)

--- a/e2e/tests/security/test-apikey-not-on-cmdline.sh
+++ b/e2e/tests/security/test-apikey-not-on-cmdline.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# Issue #180: the ANTHROPIC_API_KEY *value* must never appear on the container
+# command line (visible via `ps auxww` / `/proc/<pid>/cmdline`).
+set -euo pipefail
+cd "$(dirname "$0")/../../.."   # repo root
+FAIL=0
+SECRET="sk-ant-SENTINEL-must-not-leak-180"
+
+pass() { echo "PASS: $1"; }
+fail() { echo "FAIL: $1"; FAIL=1; }
+
+# ── Layer 1: built command must not contain the secret VALUE (both workers) ──
+
+# Single worker: env var dropped entirely → neither name nor value present.
+ANTHROPIC_API_KEY="$SECRET" python3 - <<'PY' && pass "single: value absent from cmdline" || fail "single: value leaked"
+import importlib.util, sys
+s = importlib.util.spec_from_file_location("m", "e2e/claude-myrmidon.py")
+m = importlib.util.module_from_spec(s)
+s.loader.exec_module(m)
+cmd = m._build_container_cmd(["claude-host", "-p", "x"], cwd="/tmp")
+joined = " ".join(cmd)
+sys.exit(0 if "sk-ant-SENTINEL-must-not-leak-180" not in joined and "ANTHROPIC_API_KEY=" not in joined else 1)
+PY
+
+# Multi worker: name-only `-e ANTHROPIC_API_KEY` allowed; the VALUE must be absent
+# and there must be NO `ANTHROPIC_API_KEY=` (the with-value leaking form).
+ANTHROPIC_API_KEY="$SECRET" python3 - <<'PY' && pass "multi: value absent from cmdline (name-only -e ok)" || fail "multi: value leaked"
+import importlib.util, sys
+s = importlib.util.spec_from_file_location("m", "e2e/claude-myrmidon-multi.py")
+m = importlib.util.module_from_spec(s)
+s.loader.exec_module(m)
+bad = False
+for scope in ("plan", "review", "test", "implement", "ship"):
+    joined = " ".join(m._build_container_cmd_scoped(["claude", "-p", "x"], cwd="/tmp", scope=scope))
+    if "sk-ant-SENTINEL-must-not-leak-180" in joined or "ANTHROPIC_API_KEY=" in joined:
+        bad = True
+sys.exit(1 if bad else 0)
+PY
+
+# Multi worker: name-only form must be present (value off cmdline, key still passed).
+ANTHROPIC_API_KEY="$SECRET" python3 - <<'PY' && pass "multi: name-only -e ANTHROPIC_API_KEY present" || fail "multi: name-only -e missing"
+import importlib.util, sys
+s = importlib.util.spec_from_file_location("m", "e2e/claude-myrmidon-multi.py")
+m = importlib.util.module_from_spec(s)
+s.loader.exec_module(m)
+cmd = m._build_container_cmd_scoped(["claude", "-p", "x"], cwd="/tmp", scope="plan")
+# Must find `-e` immediately followed by `ANTHROPIC_API_KEY` (no `=`)
+found = False
+for i, tok in enumerate(cmd):
+    if tok == "-e" and i + 1 < len(cmd) and cmd[i + 1] == "ANTHROPIC_API_KEY":
+        found = True
+        break
+sys.exit(0 if found else 1)
+PY
+
+# Single worker: key arg must be absent entirely (not just value hidden).
+ANTHROPIC_API_KEY="$SECRET" python3 - <<'PY' && pass "single: ANTHROPIC_API_KEY arg absent entirely" || fail "single: ANTHROPIC_API_KEY arg present"
+import importlib.util, sys
+s = importlib.util.spec_from_file_location("m", "e2e/claude-myrmidon.py")
+m = importlib.util.module_from_spec(s)
+s.loader.exec_module(m)
+cmd = m._build_container_cmd(["claude-host", "-p", "x"], cwd="/tmp")
+sys.exit(1 if "ANTHROPIC_API_KEY" in " ".join(cmd) else 0)
+PY
+
+# ── Layer 2: live container auth smoke check (skips if podman/image absent) ──
+IMAGE="${CLAUDE_IMAGE:-achaean-claude:latest}"
+if command -v podman >/dev/null 2>&1 && podman image exists "$IMAGE" 2>/dev/null; then
+    for W in single multi; do
+        OUT=$(ANTHROPIC_API_KEY="${ANTHROPIC_API_KEY:-}" \
+            python3 e2e/tests/security/_run_one_auth_probe.py "$W" 2>&1) \
+            && pass "$W: live container auth OK" \
+            || { echo "$OUT" | tail -5; fail "$W: live container auth FAILED"; }
+    done
+else
+    echo "SKIP: podman or image '$IMAGE' unavailable — live auth check skipped (Layer 1 still enforced)"
+fi
+
+[ "$FAIL" -eq 0 ] && { echo "ALL CHECKS PASS"; exit 0; } || { echo "CHECKS FAILED"; exit 1; }


### PR DESCRIPTION
## Summary

- **Single worker** (`e2e/claude-myrmidon.py`): remove `-e ANTHROPIC_API_KEY=<value>` entirely — `claude-host` authenticates via mounted OAuth credentials (`~/.claude/.credentials.json`), not the API key env var
- **Multi worker** (`e2e/claude-myrmidon-multi.py`): switch to podman name-only `-e ANTHROPIC_API_KEY` (no `=value`) — podman 4.9.3 reads the value from the host process env and injects it into the container without the value ever appearing on the command line; add a pre-flight warning when the key is unset so auth failures are diagnosable rather than silent
- Add `e2e/tests/security/test-apikey-not-on-cmdline.sh` with 4 Layer-1 cmdline-absence assertions (always run) and a gated Layer-2 live container auth smoke check

## Test plan

- [x] `bash e2e/tests/security/test-apikey-not-on-cmdline.sh` — all 4 Layer-1 checks pass
- [x] `grep -rn 'ANTHROPIC_API_KEY=' e2e/claude-myrmidon.py e2e/claude-myrmidon-multi.py` — zero matches
- [x] P7 asymmetry: single drops key entirely; multi uses name-only `-e ANTHROPIC_API_KEY`
- [ ] Layer-2 live container auth probe (runs when podman + `achaean-claude:latest` + host key present)

Closes #180

🤖 Generated with [Claude Code](https://claude.com/claude-code)