### PR TITLE
fix(docs): correct nonexistent justfile recipe in onboarding.md

### DIFF
--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -230,7 +230,7 @@ just --list
 | `just setup` | One-command setup (bootstrap + build) |
 | `just update-submodules` | Pull latest from all upstream submodule remotes |
 | `just start-agamemnon` | Start ProjectAgamemnon (control plane) |
-| `just nestor-start` | Start ProjectNestor (research service) |
+| `just start-nestor` | Start ProjectNestor (research service) |
 | `just keystone-start` | Start ProjectKeystone (event bus) |
 | `just hermes-start` | Start ProjectHermes (external bridge) |
 | `just argus-start` | Start ProjectArgus (observability stack) |


### PR DESCRIPTION
## Summary

- `docs/onboarding.md:233` documented `just nestor-start` which does not exist in the justfile (613 lines, 94 recipes)
- The real recipe is `start-nestor` (`justfile:355`)
- A new engineer following the onboarding cheatsheet would hit an immediate error on their first command (POLA violation)

## Change

One-token fix: `nestor-start` → `start-nestor` at `docs/onboarding.md:233`. All other lines in the table (`start-agamemnon`, `keystone-start`, `hermes-start`, `argus-start`) are correct and left unchanged.

## Verification

```
PASS: no phantom nestor-start reference
OK  start-agamemnon
OK  start-nestor
OK  keystone-start
OK  hermes-start
OK  argus-start
```

## Test plan

- [x] `grep -n 'just nestor-start' docs/onboarding.md` returns no results
- [x] All five recipes in the table verified to exist in `justfile`
- [x] Doc-only change; no code, no markdown structure changes

Part of #174

Closes #182