### PR TITLE
fix(configs): replace hardcoded Tailscale IPs with env-var placeholders

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,19 +24,18 @@ AGAMEMNON_URL=http://100.92.173.32:8080
 # This is the client port (4222), not the leafnode port (7422)
 NATS_URL=nats://100.92.173.32:4222
 
-# Primary NATS server Tailscale IP (used in configs/nats/leaf.conf)
-# Set this to the Tailscale IP of the host running the primary NATS server
-# Get with: tailscale ip -4 (run on the NATS server host)
-NATS_SERVER_IP=100.92.173.32
+# Full leafnode URL of the primary NATS server (used in configs/nats/leaf.conf)
+# Must be the WHOLE URL — NATS expands $NATS_LEAF_URL as a single value.
+# Build with: echo "nats+tls://$(tailscale ip -4):7422" (run on the NATS server host)
+NATS_LEAF_URL=nats+tls://<your-nats-server-tailscale-ip>:7422
 
-# Primary Nomad server Tailscale IP (used in configs/nomad/client.hcl)
-# Set this to the Tailscale IP of the host running the primary Nomad server
+# Primary Nomad server Tailscale IP (rendered into client.hcl by just render-nomad-configs)
 # Get with: tailscale ip -4 (run on the Nomad server host)
-NOMAD_SERVER_IP=100.92.173.32
+NOMAD_SERVER_IP=<your-nomad-server-tailscale-ip>
 
-# This host's Tailscale IP (used by Nomad clients to advertise themselves)
+# This host's Tailscale IP (rendered into server.hcl advertise)
 # Get with: tailscale ip -4 (run on this host)
-NOMAD_ADVERTISE_ADDR=100.92.173.32
+NOMAD_ADVERTISE_ADDR=<your-this-host-tailscale-ip>
 
 # ── Compose Build Contexts ──────────────────────────────────────
 # These resolve symlinks for podman build contexts.

--- a/configs/nats/leaf.conf
+++ b/configs/nats/leaf.conf
@@ -1,12 +1,9 @@
 # NATS Leaf Node — Secondary Hosts
 # Deploy on any host that needs to participate in the HomericIntelligence event mesh.
 #
-# Before deploying, update the remotes URL to your primary NATS server's Tailscale IP.
-# The port MUST be 7422 (leafnode TLS port), NOT 4222 (client port).
-#
-# Example:
-#   Primary host (epimetheus):  100.92.173.32
-#   Control host:               100.73.61.56
+# Before deploying, export NATS_LEAF_URL = the FULL leafnode URL of the
+# primary NATS server, e.g. nats+tls://<tailscale-ip>:7422 (port MUST be 7422).
+# Tailscale IPs are ephemeral — derive from `tailscale ip -4`, never hardcode.
 #
 # TLS certificates must be provisioned before starting this node (see ADR 008 / ADR 010).
 # Place certs in /etc/nats/certs/ with permissions: chmod 600 key, chmod 644 cert/ca
@@ -81,15 +78,20 @@ leafnodes {
   # upstream (e.g. AGENTS would silently fail to deliver hi.agents.> events to the hub).
   # SYS is internal and does NOT get a user-facing remote.
   #
-  # Primary NATS server's Tailscale IP — TLS on leafnode port (7422).
-  # Set NATS_SERVER_IP environment variable or update the IP below.
-  # To find your primary NATS server's Tailscale IP, run on that host: tailscale ip -4
-  # Default below is epimetheus (100.92.173.32) — update for your network.
+  # All remotes point at the primary NATS server's leafnode port (7422) via the
+  # whole-value $NATS_LEAF_URL variable — export it before launching (Tailscale
+  # IPs are ephemeral, never hardcode): on the NATS server host run `tailscale ip -4`
+  #   export NATS_LEAF_URL="nats+tls://<that-ip>:7422"
   # The leaf presents its own cert (one TLS identity) so the hub can authenticate it
   # (ADR-010 §1); every remote reuses the same cert/key/CA.
   remotes = [
     {
-      url     = "nats+tls://100.92.173.32:7422"
+      # Primary NATS server endpoint — TLS on leafnode port (7422).
+      # NATS expands a WHOLE-VALUE $VAR (NOT a substring), so the full URL
+      # must live in one variable. Export it before launching:
+      #   export NATS_LEAF_URL="nats+tls://$(tailscale ip -4):7422"  # run on the NATS server host for its IP
+      # nats-server -c configs/nats/leaf.conf
+      url     = $NATS_LEAF_URL
       account = "HERMES"
       tls {
         # Leaf presents its own cert so the hub can authenticate it (ADR-010 §1).
@@ -103,7 +105,7 @@ leafnodes {
       token = "$NATS_LEAF_TOKEN"
     }
     {
-      url     = "nats+tls://100.92.173.32:7422"
+      url     = $NATS_LEAF_URL
       account = "AGENTS"
       tls {
         cert_file = "/etc/nats/certs/server-cert.pem"
@@ -113,7 +115,7 @@ leafnodes {
       token = "$NATS_LEAF_TOKEN"
     }
     {
-      url     = "nats+tls://100.92.173.32:7422"
+      url     = $NATS_LEAF_URL
       account = "KEYSTONE"
       tls {
         cert_file = "/etc/nats/certs/server-cert.pem"
@@ -123,7 +125,7 @@ leafnodes {
       token = "$NATS_LEAF_TOKEN"
     }
     {
-      url     = "nats+tls://100.92.173.32:7422"
+      url     = $NATS_LEAF_URL
       account = "TELEMACHY"
       tls {
         cert_file = "/etc/nats/certs/server-cert.pem"

--- a/configs/nomad/client.hcl
+++ b/configs/nomad/client.hcl
@@ -4,11 +4,10 @@ data_dir   = "/var/lib/nomad"
 client {
   enabled = true
 
-  # Nomad server addresses — Tailscale IP of the primary Nomad server
-  # Set NOMAD_SERVER_IP environment variable to override the hardcoded IP below.
-  # To find your Nomad server's Tailscale IP, run on that host: tailscale ip -4
-  # Default below is epimetheus (100.92.173.32) — update for your network.
-  servers = ["100.92.173.32:4647"]
+  # GENERATED — render before use. Nomad agent HCL does NOT expand OS env vars,
+  # so this file MUST be rendered with envsubst (NOMAD_SERVER_IP set) before
+  # `nomad agent -config`. Run: just render-nomad-configs  (writes to /etc/nomad.d/).
+  servers = ["${NOMAD_SERVER_IP}:4647"]
 }
 
 # ACL enforcement on the client HTTP API (issue #196). Required so the client

--- a/configs/nomad/server.hcl
+++ b/configs/nomad/server.hcl
@@ -7,9 +7,9 @@ data_dir   = "/var/lib/nomad"
 # below adds workload-layer least privilege (issue #196). Both are required.
 bind_addr = "0.0.0.0"
 
-# Advertise the Tailscale IP address so clients and peers discover this server
-# via the Tailscale mesh. Set NOMAD_ADVERTISE_ADDR before starting Nomad:
-#   export NOMAD_ADVERTISE_ADDR=$(tailscale ip -4)
+# Advertise the Tailscale IP. GENERATED — render before use: Nomad does NOT
+# expand ${NOMAD_ADVERTISE_ADDR} itself; `just render-nomad-configs` must run
+# envsubst over this file (writes to /etc/nomad.d/) before `nomad agent -config`.
 advertise {
   http = "${NOMAD_ADVERTISE_ADDR}"
   rpc  = "${NOMAD_ADVERTISE_ADDR}"

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -220,7 +220,14 @@ You should see: `Server is ready for connections on 0.0.0.0:4222`
 
 ### 4d. Configure Leaf Nodes (Multi-Host Only)
 
-If deploying across multiple hosts, configure leaf node connections in `configs/nats/leaf.conf` to federate the NATS clusters over Tailscale. See `docs/runbooks/add-new-host.md` for details.
+If deploying across multiple hosts, configure leaf node connections in `configs/nats/leaf.conf` to federate the NATS clusters over Tailscale. Export `NATS_LEAF_URL` before starting the leaf node:
+
+```bash
+export NATS_LEAF_URL="nats+tls://$(tailscale ip -4):7422"   # run on the primary NATS server host for its IP
+nats-server -c configs/nats/leaf.conf
+```
+
+See `docs/runbooks/add-new-host.md` for details.
 
 ---
 
@@ -237,6 +244,17 @@ The canonical Nomad configs are at:
 
 For a single-host setup, run both server and client on the same host.
 
+### 5a-bis. Render the Nomad configs (required)
+
+Nomad does not expand environment variables in its config files, so render the
+canonical placeholders to a deploy-local path first:
+
+```bash
+export NOMAD_SERVER_IP=$(tailscale ip -4)
+export NOMAD_ADVERTISE_ADDR=$(tailscale ip -4)
+just render-nomad-configs            # writes /etc/nomad.d/{server,client}.hcl
+```
+
 ### 5b. Start Nomad Server
 
 ```bash
@@ -250,7 +268,7 @@ podman run -d \
   -p 4647:4647 \
   -p 4648:4648/udp \
   -v /var/nomad:/nomad/data \
-  -v $(pwd)/configs/nomad/server.hcl:/etc/nomad/server.hcl:ro \
+  -v /etc/nomad.d/server.hcl:/etc/nomad/server.hcl:ro \
   hashicorp/nomad:1.6 agent -config /etc/nomad/server.hcl
 ```
 
@@ -277,7 +295,7 @@ podman run -d \
   --name nomad-client \
   --network homeric-mesh \
   -v /var/nomad:/nomad/data \
-  -v $(pwd)/configs/nomad/client.hcl:/etc/nomad/client.hcl:ro \
+  -v /etc/nomad.d/client.hcl:/etc/nomad/client.hcl:ro \
   -v /var/run/podman:/var/run/podman:ro \
   hashicorp/nomad:1.6 agent -config /etc/nomad/client.hcl
 ```

--- a/docs/runbooks/add-new-host.md
+++ b/docs/runbooks/add-new-host.md
@@ -93,15 +93,14 @@ chmod 600 /etc/nats/certs/leaf.creds
 
 Copy the leaf node config from this repo:
 
+Copy the leaf config and start the NATS leaf node (export `NATS_LEAF_URL` — the full URL of the primary NATS server):
+
 ```bash
 cp configs/nats/leaf.conf /etc/nats/leaf.conf
-# Edit leaf.conf: set the remotes.url to the primary NATS server's Tailscale IP,
-# and confirm the credential (credentials=... or token=$NATS_LEAF_TOKEN) matches the hub.
-```
-
-Start the NATS leaf node:
-
-```bash
+# Edit leaf.conf: set the remotes.url to the primary NATS server's Tailscale IP
+# (via $NATS_LEAF_URL below), and confirm the credential
+# (credentials=... or token=$NATS_LEAF_TOKEN) matches the hub.
+export NATS_LEAF_URL="nats+tls://<primary-nats-tailscale-ip>:7422"
 nats-server -c /etc/nats/leaf.conf &
 ```
 
@@ -116,9 +115,15 @@ nats --server nats://localhost:4222 sub "hi.>" &
 
 Copy the client config and start Nomad:
 
+Render the client config (resolves the `${NOMAD_SERVER_IP}` placeholder) then start Nomad:
+
 ```bash
-cp configs/nomad/client.hcl /etc/nomad.d/client.hcl
-# Edit client.hcl: set client.servers to the primary Nomad server's Tailscale IP
+export NOMAD_SERVER_IP=<primary-nomad-server-tailscale-ip>   # tailscale ip -4 on the Nomad server host
+# NOMAD_ADVERTISE_ADDR is only needed to satisfy the shared render recipe (which
+# renders both client.hcl and server.hcl); a Nomad client never uses the
+# advertise{} block, so the rendered /etc/nomad.d/server.hcl is unused here.
+export NOMAD_ADVERTISE_ADDR=$(tailscale ip -4)
+just render-nomad-configs                   # writes /etc/nomad.d/client.hcl (resolved, no ${...})
 
 # ACLs are enabled (issue #196): the client needs a token to register.
 # Obtain one from the server operator (a node-policy token, or the bootstrap

--- a/docs/runbooks/disaster-recovery.md
+++ b/docs/runbooks/disaster-recovery.md
@@ -162,8 +162,10 @@ just bootstrap
 # 5. Install and start NATS with server config
 nats-server -c configs/nats/server.conf &
 
-# 6. Install and start Nomad server
-nomad agent -config configs/nomad/server.hcl &
+# 6. Render and start Nomad server
+export NOMAD_ADVERTISE_ADDR=$(tailscale ip -4); export NOMAD_SERVER_IP=$NOMAD_ADVERTISE_ADDR
+just render-nomad-configs
+nomad agent -config /etc/nomad.d/server.hcl &
 
 # 7. Apply desired state from Myrmidons
 just apply-all

--- a/justfile
+++ b/justfile
@@ -262,6 +262,7 @@ clean:
 validate-configs:
     #!/usr/bin/env bash
     set -euo pipefail
+    grep -q '${NOMAD_SERVER_IP}' configs/nomad/client.hcl || { echo "client.hcl lost its placeholder"; exit 1; }
     if command -v nomad >/dev/null 2>&1; then
         nomad fmt -check configs/nomad/client.hcl configs/nomad/server.hcl
     else
@@ -275,6 +276,22 @@ validate-configs:
     yamllint -c .yamllint.yml configs/
     bash tools/validate-nats-auth.sh
     bash tools/tests/test-validate-nats-auth.sh
+
+# Render Nomad config placeholders to a deploy-local dir (default /etc/nomad.d).
+# Nomad agent HCL does NOT expand OS env vars, so render before `nomad agent -config`.
+# Requires NOMAD_SERVER_IP and NOMAD_ADVERTISE_ADDR (e.g. export NOMAD_SERVER_IP=$(tailscale ip -4)).
+render-nomad-configs OUT_DIR="/etc/nomad.d":
+    #!/usr/bin/env bash
+    set -euo pipefail
+    : "${NOMAD_SERVER_IP:?set NOMAD_SERVER_IP (e.g. export NOMAD_SERVER_IP=$(tailscale ip -4))}"
+    : "${NOMAD_ADVERTISE_ADDR:?set NOMAD_ADVERTISE_ADDR (e.g. export NOMAD_ADVERTISE_ADDR=$(tailscale ip -4))}"
+    mkdir -p "{{ OUT_DIR }}"
+    for f in client server; do
+      envsubst '${NOMAD_SERVER_IP} ${NOMAD_ADVERTISE_ADDR}' \
+        < "configs/nomad/${f}.hcl" > "{{ OUT_DIR }}/${f}.hcl"
+      echo "rendered {{ OUT_DIR }}/${f}.hcl"
+    done
+    if command -v nomad >/dev/null 2>&1; then nomad fmt -check "{{ OUT_DIR }}"/*.hcl; fi
 
 # Run all CI checks locally
 ci: lint validate-configs check-doc-field-drift


### PR DESCRIPTION
## Summary

- **`configs/nats/leaf.conf`**: replace hardcoded `url = "nats+tls://100.92.173.32:7422"` with `url = $NATS_LEAF_URL` (whole-value var — NATS substring expansion is broken and dials the literal string); update header and inline comments
- **`configs/nomad/client.hcl`**: replace hardcoded `servers = ["100.92.173.32:4647"]` with `${NOMAD_SERVER_IP}` placeholder + `GENERATED — render before use` header (Nomad agent HCL has no native OS env-var expansion)
- **`configs/nomad/server.hcl`**: add `GENERATED` header to the existing `${NOMAD_ADVERTISE_ADDR}` advertise block (same latent class of defect in a sibling canonical file; disclosed scope)
- **`justfile`**: add `render-nomad-configs OUT_DIR` recipe that runs `envsubst` with an explicit var allow-list to `/etc/nomad.d/` (deploy-local, never back into `configs/` — no `.gitignore` change needed); extend `validate-configs` with a placeholder-present guard
- **`.env.example`**: rename `NATS_SERVER_IP` to `NATS_LEAF_URL` (full URL value); neutralize `NOMAD_SERVER_IP` and `NOMAD_ADVERTISE_ADDR` defaults to placeholder strings
- **`docs/`**: add `render-nomad-configs` steps to `deployment.md` (step 5a-bis + rendered volume mounts + `NATS_LEAF_URL` note), `add-new-host.md` (render instead of raw copy), and `disaster-recovery.md` (render before launch)

## Test plan

- [x] `just render-nomad-configs /tmp/nomadout` with `NOMAD_SERVER_IP=10.11.12.13 NOMAD_ADVERTISE_ADDR=10.11.12.13` produces resolved files with zero residual `${` tokens
- [x] `just validate-configs` passes (placeholder guard + yamllint)
- [x] No hardcoded dev IPs remain in any fixed canonical config or doc file
- [x] All three docs reference `render-nomad-configs`; no runbook mounts raw `configs/nomad/*.hcl` directly

Closes #181

🤖 Generated with [Claude Code](https://claude.com/claude-code)
