### PR TITLE
test(agamemnon): require tests in ProjectAgamemnon ctest

### DIFF
--- a/justfile
+++ b/justfile
@@ -172,7 +172,7 @@ test: _test-agamemnon _test-nestor _test-charybdis _test-keystone
 
 _test-agamemnon:
     @echo "--- Testing control/ProjectAgamemnon ---"
-    ctest --test-dir "{{BUILD_ROOT}}/ProjectAgamemnon" --output-on-failure
+    ctest --test-dir "{{BUILD_ROOT}}/ProjectAgamemnon" --output-on-failure --no-tests=error
 
 _test-nestor:
     @echo "--- Testing control/ProjectNestor ---"


### PR DESCRIPTION
## Summary
Make ProjectAgamemnon unit tests mandatory in CI by requiring test execution via ctest in the justfile.

## Changes
- Updated justfile to enforce test execution for ProjectAgamemnon

## Testing
- Verify `just test` runs ProjectAgamemnon ctest suite
- Confirm CI fails if ProjectAgamemnon tests do not pass

## Closes
Closes #73

Generated by Claude Code via ProjectHephaestus automation.
