### PR TITLE
fix(myrmidon): require explicit issue_number, reject magic default

### DIFF
--- a/e2e/claude-myrmidon.py
+++ b/e2e/claude-myrmidon.py
@@ -20,6 +20,10 @@ Environment:
     REPO            GitHub repo (default: HomericIntelligence/Odysseus)
     WORKING_DIR     Working directory for claude invocations (default: cwd)
     MAX_ITERATIONS  Max review loop iterations (default: 5)
+    ISSUE_NUMBER    Target GitHub issue number used when the task message omits
+                    issue_number. If neither the message nor this var supplies a
+                    positive integer, the stage fails loudly — no default issue
+                    is ever assumed (issue #187).
 """
 
 import asyncio
@@ -98,6 +102,31 @@ def prune_task_data(task_data: dict, keep_extra: tuple = ()) -> dict:
     """Strip accumulated stage outputs, keeping only core identity + specified extras."""
     allowed = _CORE_KEYS | set(keep_extra)
     return {k: v for k, v in task_data.items() if k in allowed}
+
+
+def resolve_issue_number(task_data: dict) -> int:
+    """Resolve the target GitHub issue number, failing loudly when absent.
+
+    Resolution order: the task message's ``issue_number`` field, then the
+    ``ISSUE_NUMBER`` env var. There is NO silent default — a missing or invalid
+    value raises ValueError so a malformed task never targets an unrelated
+    issue (see issue #187, POLA).
+    """
+    for source in (task_data.get("issue_number"), ISSUE_NUMBER or None):
+        if source is None or source == "":
+            continue
+        try:
+            value = int(source)
+        except (TypeError, ValueError):
+            raise ValueError(
+                f"issue_number is not a valid integer: {source!r}"
+            ) from None
+        if value > 0:
+            return value
+    raise ValueError(
+        "issue_number missing: provide it in the task message or set the "
+        "ISSUE_NUMBER environment variable (no default is assumed)"
+    )
 
 
 def mock_claude_response(stage: str, iteration: int) -> str:
@@ -422,7 +451,7 @@ async def stage_plan(task_data: dict, js) -> dict:
     team_id = task_data.get("team_id", "unknown")
     subject = task_data.get("subject", "unknown task")
     description = task_data.get("description", "")
-    issue_number = task_data.get("issue_number", ISSUE_NUMBER or 7)
+    issue_number = resolve_issue_number(task_data)
 
     log("plan", f"Planning task: {subject}")
     log_memory("plan")
@@ -470,7 +499,7 @@ async def stage_test(task_data: dict, js) -> dict:
     plan = task_data.get("plan", "")
     iteration = task_data.get("iteration", 1)
     feedback = task_data.get("feedback", "")
-    issue_number = task_data.get("issue_number", ISSUE_NUMBER or 7)
+    issue_number = resolve_issue_number(task_data)
 
     log("test", f"Writing tests (iteration {iteration})")
     log_memory("test")
@@ -529,7 +558,7 @@ async def stage_implement(task_data: dict, js) -> dict:
     iteration = task_data.get("iteration", 1)
     feedback = task_data.get("feedback", "")
     concerns = task_data.get("concerns", "")
-    issue_number = task_data.get("issue_number", ISSUE_NUMBER or 7)
+    issue_number = resolve_issue_number(task_data)
 
     log("implement", f"Implementing (iteration {iteration})")
     log_memory("implement")
@@ -582,7 +611,7 @@ async def stage_review(task_data: dict, js) -> dict:
     test_script = task_data.get("test_script", "")
     iteration = task_data.get("iteration", 1)
     previous_concerns = task_data.get("concerns", "")
-    issue_number = task_data.get("issue_number", ISSUE_NUMBER or 7)
+    issue_number = resolve_issue_number(task_data)
 
     log("review", f"Reviewing (iteration {iteration})")
     log_memory("review")
@@ -675,7 +704,7 @@ async def stage_ship(task_data: dict, js) -> dict:
     task_id = task_data.get("task_id", "unknown")
     team_id = task_data.get("team_id", "unknown")
     subject = task_data.get("subject", "implement task")
-    issue_number = task_data.get("issue_number", ISSUE_NUMBER or 7)
+    issue_number = resolve_issue_number(task_data)
 
     log("ship", "Shipping approved implementation")
     log_memory("ship")

--- a/e2e/test-myrmidon-issue-number.sh
+++ b/e2e/test-myrmidon-issue-number.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# E2E regression test for issue #187 — Myrmidon must NOT default issue_number to #7.
+# Drives resolve_issue_number() in e2e/claude-myrmidon.py via system python3
+# (the e2e tree is bash-only; there is no pytest harness — see pixi.toml).
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SRC="$SCRIPT_DIR/claude-myrmidon.py"
+
+RED='\033[0;31m'; GREEN='\033[0;32m'; NC='\033[0m'
+fails=0
+pass() { echo -e "  ${GREEN}✓ PASS${NC}: $1"; }
+fail() { echo -e "  ${RED}✗ FAIL${NC}: $1"; fails=$((fails + 1)); }
+
+# Run resolve_issue_number with a given task_data JSON and ISSUE_NUMBER env.
+# Prints the resolved int on success; prints "RAISED" (exit 0) when it raises.
+run_resolver() {
+  local issue_env="$1" task_json="$2"
+  ISSUE_NUMBER="$issue_env" SRC="$SRC" TASK_JSON="$task_json" python3 - <<'PY'
+import importlib.util, json, os
+spec = importlib.util.spec_from_file_location("cm", os.environ["SRC"])
+mod = importlib.util.module_from_spec(spec); spec.loader.exec_module(mod)
+task = json.loads(os.environ["TASK_JSON"])
+try:
+    print(mod.resolve_issue_number(task))
+except ValueError:
+    print("RAISED")
+PY
+}
+
+expect() {  # expect <description> <expected> <actual>
+  if [ "$2" = "$3" ]; then pass "$1 (got $3)"; else fail "$1 (expected $2, got $3)"; fi
+}
+
+echo ""
+echo "╔══════════════════════════════════════════════════════╗"
+echo "║  Myrmidon issue-number resolver checks (issue #187)  ║"
+echo "╚══════════════════════════════════════════════════════╝"
+echo ""
+
+# 1. message issue_number wins, ignores env
+expect "message issue_number used" "187" "$(run_resolver 0 '{"issue_number": 187}')"
+# 2. numeric string coerced
+expect "numeric string coerced" "42" "$(run_resolver 0 '{"issue_number": "42"}')"
+# 3. CORE #187 regression: both absent -> RAISED, never 7
+out="$(run_resolver 0 '{}')"
+expect "missing both raises (not #7)" "RAISED" "$out"
+[ "$out" != "7" ] || fail "resolver returned the forbidden magic number 7"
+# 4. env fallback used when message omits it
+expect "env ISSUE_NUMBER fallback" "99" "$(run_resolver 99 '{}')"
+# 5. invalid/zero/null/non-numeric message values raise
+expect "issue_number 0 raises"           "RAISED" "$(run_resolver 0 '{"issue_number": 0}')"
+expect "issue_number null raises"        "RAISED" "$(run_resolver 0 '{"issue_number": null}')"
+expect "issue_number empty raises"       "RAISED" "$(run_resolver 0 '{"issue_number": ""}')"
+expect "issue_number non-numeric raises" "RAISED" "$(run_resolver 0 '{"issue_number": "abc"}')"
+expect "issue_number negative raises"    "RAISED" "$(run_resolver 0 '{"issue_number": -3}')"
+
+echo ""
+if [ "$fails" -eq 0 ]; then
+  echo -e "${GREEN}All issue-number resolver checks passed.${NC}"; exit 0
+else
+  echo -e "${RED}$fails check(s) failed.${NC}"; exit 1
+fi

--- a/justfile
+++ b/justfile
@@ -508,6 +508,10 @@ start-claude-myrmidon-multi NATS_URL="nats://localhost:4222":
 e2e-multi-dry-run NATS_URL="nats://localhost:4222":
     DRY_RUN=1 NO_GITHUB=1 NATS_URL={{ NATS_URL }} python3 e2e/claude-myrmidon-multi.py
 
+# Run the issue-number resolver regression test (issue #187, no stack needed)
+e2e-test-myrmidon-issue-number:
+    bash e2e/test-myrmidon-issue-number.sh
+
 # Build E2E container images
 e2e-build:
     podman compose -f docker-compose.e2e.yml build


### PR DESCRIPTION
## Summary
Replaced silent magic-number fallback (issue #7) in Myrmidon pipeline with explicit error. The `resolve_issue_number()` function now fails loudly if issue_number is absent from both the NATS message and the ISSUE_NUMBER environment variable, preventing production tasks from silently targeting unrelated historical issues.

## Changes
- Added `resolve_issue_number()` function to enforce explicit issue_number — raises ValueError with clear message if neither task message nor ISSUE_NUMBER env var provides a valid positive integer
- Replaced all task data.get("issue_number", ISSUE_NUMBER or 7) patterns with call to resolve_issue_number()
- Updated module docstring to document ISSUE_NUMBER env var behavior and clarify that no default is ever assumed (POLA)
- Added e2e/test-myrmidon-issue-number.sh regression test with 8 cases covering message field resolution, env fallback, zero/null/invalid rejection, and the specific case from issue #187

## Testing
- Run e2e/test-myrmidon-issue-number.sh — tests resolve_issue_number() with message fields, env fallbacks, and all invalid cases (zero, null, empty, non-numeric, negative)
- Regression: confirm resolver never returns #7 when both message and env are absent (now raises instead)
- Verify all 5 pipeline stages (plan, test, implement, review, ship) call resolve_issue_number() to validate task_data before use

## Closes
Closes #187

Generated by Claude Code via ProjectHephaestus automation.
