### PR TITLE
fix(validate-configs): guard server.hcl NOMAD_ADVERTISE_ADDR placeholder

### DIFF
--- a/justfile
+++ b/justfile
@@ -267,6 +267,11 @@ validate-configs:
     else
         echo "Note: install nomad to validate HCL syntax (skipping HCL check)"
     fi
+    # Anti-re-hardcoding guard (issue #320, regression from #181): server.hcl must
+    # keep its ${NOMAD_ADVERTISE_ADDR} placeholder, never a literal Tailscale IP.
+    grep -qF '${NOMAD_ADVERTISE_ADDR}' configs/nomad/server.hcl || {
+        echo "configs/nomad/server.hcl lost its \${NOMAD_ADVERTISE_ADDR} placeholder (hardcoded IP re-introduced — see #181)"; exit 1;
+    }
     yamllint -c .yamllint.yml configs/
     bash tools/validate-nats-auth.sh
 


### PR DESCRIPTION
## Summary
Add validation check for NOMAD_ADVERTISE_ADDR placeholder in server.hcl to prevent silent re-introduction of hardcoded IPs, matching the existing guard on client.hcl's NOMAD_SERVER_IP.

## Changes
- Added grep guard in justfile to verify server.hcl contains ${NOMAD_ADVERTISE_ADDR} placeholder
- Prevents accidental hardcoding of Tailscale IPs in server.hcl (regression of issue #181)

## Testing
- Verify `just validate-configs` passes with placeholders intact
- Confirm `just validate-configs` fails if ${NOMAD_ADVERTISE_ADDR} is replaced with literal IP in server.hcl

## Closes
Closes #320

Generated by Claude Code via ProjectHephaestus automation.
