### PR TITLE
fix(myrmidon): defer ISSUE_NUMBER parsing to avoid import crash

### DIFF
--- a/e2e/claude-myrmidon.py
+++ b/e2e/claude-myrmidon.py
@@ -44,7 +44,11 @@ NATS_URL = os.environ.get("NATS_URL", "nats://localhost:4222")
 REPO = os.environ.get("REPO", "HomericIntelligence/Odysseus")
 WORKING_DIR = os.environ.get("WORKING_DIR", os.getcwd())
 MAX_ITERATIONS = int(os.environ.get("MAX_ITERATIONS", "5"))
-ISSUE_NUMBER = int(os.environ.get("ISSUE_NUMBER", "0"))  # 0 = read from task payload
+# Raw, un-coerced on purpose: a malformed value (e.g. "foo", "12.5") must NOT
+# crash the worker at import — coercion + validation happens lazily in
+# resolve_issue_number(), whose ValueError is acked at the consumer-loop
+# boundary rather than killing the process (issues #187, #325).
+ISSUE_NUMBER = os.environ.get("ISSUE_NUMBER", "")  # "" = read from task payload
 DRY_RUN = os.environ.get("DRY_RUN", "0") == "1"
 NO_GITHUB = os.environ.get("NO_GITHUB", "0") == "1"
 

--- a/e2e/test-myrmidon-issue-number.sh
+++ b/e2e/test-myrmidon-issue-number.sh
@@ -32,6 +32,23 @@ expect() {  # expect <description> <expected> <actual>
   if [ "$2" = "$3" ]; then pass "$1 (got $3)"; else fail "$1 (expected $2, got $3)"; fi
 }
 
+# Import the module with a given ISSUE_NUMBER env. Prints "IMPORTED" on success,
+# "CRASHED" if import raised (issue #325 — malformed ISSUE_NUMBER must not kill
+# the worker at module import, before the consumer loop can ack it).
+run_import() {
+  local issue_env="$1"
+  ISSUE_NUMBER="$issue_env" SRC="$SRC" python3 - <<'PY'
+import importlib.util, os
+spec = importlib.util.spec_from_file_location("cm", os.environ["SRC"])
+mod = importlib.util.module_from_spec(spec)
+try:
+    spec.loader.exec_module(mod)
+    print("IMPORTED")
+except Exception:
+    print("CRASHED")
+PY
+}
+
 echo ""
 echo "╔══════════════════════════════════════════════════════╗"
 echo "║  Myrmidon issue-number resolver checks (issue #187)  ║"
@@ -54,6 +71,18 @@ expect "issue_number null raises"        "RAISED" "$(run_resolver 0 '{"issue_num
 expect "issue_number empty raises"       "RAISED" "$(run_resolver 0 '{"issue_number": ""}')"
 expect "issue_number non-numeric raises" "RAISED" "$(run_resolver 0 '{"issue_number": "abc"}')"
 expect "issue_number negative raises"    "RAISED" "$(run_resolver 0 '{"issue_number": -3}')"
+
+# 6. CORE #325 regression: malformed ISSUE_NUMBER must not crash module import
+expect "import survives ISSUE_NUMBER=foo"  "IMPORTED" "$(run_import foo)"
+expect "import survives ISSUE_NUMBER=12.5" "IMPORTED" "$(run_import 12.5)"
+expect "import survives ISSUE_NUMBER unset" "IMPORTED" "$(run_import '')"
+expect "import survives ISSUE_NUMBER=42"   "IMPORTED" "$(run_import 42)"
+
+# 7. malformed env value surfaces via resolver (acked ValueError), never crashes
+expect "non-numeric env raises in resolver" "RAISED" "$(run_resolver foo '{}')"
+expect "float-string env raises in resolver" "RAISED" "$(run_resolver 12.5 '{}')"
+# message issue_number still wins even when env is garbage
+expect "message wins over garbage env" "187" "$(run_resolver foo '{"issue_number": 187}')"
 
 echo ""
 if [ "$fails" -eq 0 ]; then


### PR DESCRIPTION
## Summary
Move ISSUE_NUMBER environment variable parsing from module import time to lazy evaluation inside resolve_issue_number(). Prevents ValueError crashes during worker startup when ISSUE_NUMBER contains non-numeric values (e.g., ISSUE_NUMBER=foo), ensuring graceful handling via the existing error-acking boundary.

## Changes
- Deferred ISSUE_NUMBER parsing from module-level to resolve_issue_number() to avoid import-time crashes
- Maintains int-coercion validation inside resolve_issue_number() with proper error handling
- Added e2e/test-myrmidon-issue-number.sh test to verify graceful handling of malformed ISSUE_NUMBER values

## Testing
- e2e/test-myrmidon-issue-number.sh verifies worker handles non-numeric ISSUE_NUMBER without crashing at import
- Confirm ISSUE_NUMBER=foo python3 e2e/claude-myrmidon.py reaches consumer loop and logs/acks error instead of crashing

## Closes
Closes #325

Generated by Claude Code via ProjectHephaestus automation.
