### PR TITLE
docs(readme): add CI/CD badges and ecosystem badge table

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,12 @@
 # Odysseus
 
+[![Build](https://github.com/HomericIntelligence/Odysseus/actions/workflows/build.yml/badge.svg)](https://github.com/HomericIntelligence/Odysseus/actions/workflows/build.yml)
+[![CI](https://github.com/HomericIntelligence/Odysseus/actions/workflows/ci.yml/badge.svg)](https://github.com/HomericIntelligence/Odysseus/actions/workflows/ci.yml)
+[![Ecosystem Health](https://github.com/HomericIntelligence/Odysseus/actions/workflows/ecosystem-health.yml/badge.svg)](https://github.com/HomericIntelligence/Odysseus/actions/workflows/ecosystem-health.yml)
+[![Install Test](https://github.com/HomericIntelligence/Odysseus/actions/workflows/install-test.yml/badge.svg)](https://github.com/HomericIntelligence/Odysseus/actions/workflows/install-test.yml)
+[![Release](https://github.com/HomericIntelligence/Odysseus/actions/workflows/release.yml/badge.svg)](https://github.com/HomericIntelligence/Odysseus/actions/workflows/release.yml)
+[![Submodule Update Check](https://github.com/HomericIntelligence/Odysseus/actions/workflows/submodule-update-check.yml/badge.svg)](https://github.com/HomericIntelligence/Odysseus/actions/workflows/submodule-update-check.yml)
+
 Odysseus is the meta-repo and unified architecture hub for the HomericIntelligence distributed agent mesh. It contains documentation, Architecture Decision Records (ADRs), shared configurations, runbooks, and all other HomericIntelligence repositories as git submodules.
 
 ## Purpose
@@ -55,6 +62,26 @@ Odysseus/
 ├── justfile
 └── pixi.toml
 ```
+
+### Ecosystem CI Status
+
+| Repository | CI Status |
+|---|---|
+| [Odysseus](https://github.com/HomericIntelligence/Odysseus) | [![CI](https://github.com/HomericIntelligence/Odysseus/actions/workflows/ci.yml/badge.svg)](https://github.com/HomericIntelligence/Odysseus/actions/workflows/ci.yml) |
+| [AchaeanFleet](https://github.com/HomericIntelligence/AchaeanFleet) | [![CI](https://github.com/HomericIntelligence/AchaeanFleet/actions/workflows/ci.yml/badge.svg)](https://github.com/HomericIntelligence/AchaeanFleet/actions/workflows/ci.yml) |
+| [ProjectArgus](https://github.com/HomericIntelligence/ProjectArgus) | [![CI](https://github.com/HomericIntelligence/ProjectArgus/actions/workflows/ci.yml/badge.svg)](https://github.com/HomericIntelligence/ProjectArgus/actions/workflows/ci.yml) |
+| [ProjectHermes](https://github.com/HomericIntelligence/ProjectHermes) | [![CI](https://github.com/HomericIntelligence/ProjectHermes/actions/workflows/ci.yml/badge.svg)](https://github.com/HomericIntelligence/ProjectHermes/actions/workflows/ci.yml) |
+| [ProjectAgamemnon](https://github.com/HomericIntelligence/ProjectAgamemnon) | [![Build & Test](https://github.com/HomericIntelligence/ProjectAgamemnon/actions/workflows/build-test.yml/badge.svg)](https://github.com/HomericIntelligence/ProjectAgamemnon/actions/workflows/build-test.yml) |
+| [ProjectNestor](https://github.com/HomericIntelligence/ProjectNestor) | [![Build & Test](https://github.com/HomericIntelligence/ProjectNestor/actions/workflows/build-test.yml/badge.svg)](https://github.com/HomericIntelligence/ProjectNestor/actions/workflows/build-test.yml) |
+| [ProjectTelemachy](https://github.com/HomericIntelligence/ProjectTelemachy) | [![CI](https://github.com/HomericIntelligence/ProjectTelemachy/actions/workflows/ci.yml/badge.svg)](https://github.com/HomericIntelligence/ProjectTelemachy/actions/workflows/ci.yml) |
+| [ProjectKeystone](https://github.com/HomericIntelligence/ProjectKeystone) | [![Release Please](https://github.com/HomericIntelligence/ProjectKeystone/actions/workflows/release-please.yml/badge.svg)](https://github.com/HomericIntelligence/ProjectKeystone/actions/workflows/release-please.yml) |
+| [Myrmidons](https://github.com/HomericIntelligence/Myrmidons) | [![Test](https://github.com/HomericIntelligence/Myrmidons/actions/workflows/test.yml/badge.svg)](https://github.com/HomericIntelligence/Myrmidons/actions/workflows/test.yml) |
+| [ProjectProteus](https://github.com/HomericIntelligence/ProjectProteus) | [![CI](https://github.com/HomericIntelligence/ProjectProteus/actions/workflows/ci.yml/badge.svg)](https://github.com/HomericIntelligence/ProjectProteus/actions/workflows/ci.yml) |
+| [ProjectOdyssey](https://github.com/HomericIntelligence/ProjectOdyssey) | [![CI](https://github.com/HomericIntelligence/ProjectOdyssey/actions/workflows/ci.yml/badge.svg)](https://github.com/HomericIntelligence/ProjectOdyssey/actions/workflows/ci.yml) |
+| [ProjectScylla](https://github.com/HomericIntelligence/ProjectScylla) | [![Test](https://github.com/HomericIntelligence/ProjectScylla/actions/workflows/test.yml/badge.svg)](https://github.com/HomericIntelligence/ProjectScylla/actions/workflows/test.yml) |
+| [ProjectMnemosyne](https://github.com/HomericIntelligence/ProjectMnemosyne) | [![Validate Plugins](https://github.com/HomericIntelligence/ProjectMnemosyne/actions/workflows/validate-plugins.yml/badge.svg)](https://github.com/HomericIntelligence/ProjectMnemosyne/actions/workflows/validate-plugins.yml) |
+| [ProjectHephaestus](https://github.com/HomericIntelligence/ProjectHephaestus) | [![Test](https://github.com/HomericIntelligence/ProjectHephaestus/actions/workflows/test.yml/badge.svg)](https://github.com/HomericIntelligence/ProjectHephaestus/actions/workflows/test.yml) |
+| [ProjectCharybdis](https://github.com/HomericIntelligence/ProjectCharybdis) | [![Build & Test](https://github.com/HomericIntelligence/ProjectCharybdis/actions/workflows/build-test.yml/badge.svg)](https://github.com/HomericIntelligence/ProjectCharybdis/actions/workflows/build-test.yml) |
 
 ## Common Commands
 


### PR DESCRIPTION
Closes #352

## Summary
- Add CI/CD workflow status badges under the Odysseus README H1 title for all six real workflows (build, ci, ecosystem-health, install-test, release, submodule-update-check)
- Add a consolidated **Ecosystem CI Status** table in the Repository Layout section showing primary CI badge for all 15 HomericIntelligence repos
- Bump `provisioning/ProjectKeystone` submodule pin to latest `origin/main`

## Per-repo PRs
- **ProjectKeystone**: https://github.com/HomericIntelligence/ProjectKeystone/pull/594
  - Added `Profiling Tests (Weekly)` and `Release Please` CI/CD badges to match actual workflows
  - Replaced hardcoded `86.2%` line coverage with `See CI` in the quality metrics table
  - Removed stale `- 86.2% coverage, 481 tests` from the footer status line

## Test plan
- [ ] Verify all badge URLs resolve (no 404s) and point at `HomericIntelligence/<Repo>` workflows
- [ ] Verify ProjectKeystone submodule pin matches latest `origin/main`
- [ ] Confirm badge table renders correctly in GitHub markdown preview

Generated with [Claude Code](https://claude.com/claude-code)