### PR TITLE
fix(infra): throttle + memory-bound multi-agent work to stop hermes WSL OOM

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,6 +87,32 @@ Odysseus/
 - Runbooks should be written as numbered steps that can be executed top-to-bottom without prior context.
 - **ai-maestro has been fully removed per ADR-006.** ProjectAgamemnon replaces its task coordination role.
 
+## Resource limits & concurrency on the `hermes` host
+
+The dev/CI host (WSL2, hostname `hermes`) is bounded at **~16 GB RAM / 8 cores** (no `memory=`
+cap in `.wslconfig`, so WSL sees ~50% of the ~32 GB Windows host). The two heaviest operations
+here are **`pixi install`/`pixi lock`** (a conda+pypi SAT solve, ~0.5–1 GB RAM each) and
+**C++ builds** (`cmake --build`, 1.5–3 GB + multi-core each). Running many of these at once will
+exhaust RAM and the 16 GB swap, thrash, and **hang the whole WSL VM** (this has happened — a
+16-repo Myrmidon fan-out with no throttle took the host down). Observe these limits:
+
+- **≤3 concurrent heavy agents.** Do not fan out more than **3** background agents/sessions that
+  each run `pixi`/`cmake`/`podman build` simultaneously. Prefer the harness `Workflow` primitive
+  (it caps concurrency and queues the rest) or an explicit wave pattern over fire-and-forget
+  parallel `Agent(run_in_background:true)` calls. `e2e/claude-myrmidon-multi.py` enforces this via
+  `HERMES_MAX_CONCURRENT_AGENTS` (default 3).
+- **Memory-bound heavy commands** with `ulimit -v` so an over-budget process fails recoverably
+  instead of OOM-hanging the VM: `scripts/run-bounded.sh <cmd>` (default ~5 GiB cap), e.g.
+  `scripts/run-bounded.sh pixi install`. Never run a large `pixi`/build/`pytest` unbounded in
+  parallel.
+- **Cap build parallelism**, don't use `-j$(nproc)` across concurrent agents. Set
+  `ODYSSEUS_BUILD_JOBS=2` (the default in `scripts/install/50-cpp-builds.sh`) and/or
+  `export CMAKE_BUILD_PARALLEL_LEVEL=2` so each build uses ≤2 cores.
+- **Check headroom before scaling up:** run `free -h` before launching ≥4 heavy agents; if
+  `available` is under ~6 GB or swap is in use, wait or reduce concurrency.
+- Note: hephaestus' `max_workers=3` only bounds an in-process thread pool — it does **not** cap
+  concurrent Claude agent *sessions*. The limits above are what actually protect the host.
+
 ## Common Commands
 
 ```bash

--- a/e2e/claude-myrmidon-multi.py
+++ b/e2e/claude-myrmidon-multi.py
@@ -55,6 +55,13 @@ DRY_RUN = os.environ.get("DRY_RUN", "0") == "1"
 NO_GITHUB = os.environ.get("NO_GITHUB", "0") == "1"
 ISSUE_NUMBER = int(os.environ.get("ISSUE_NUMBER", "8"))
 
+# Cap concurrent HEAVY Claude agent invocations (each does clone -> pixi install
+# (a ~0.5-1 GB conda/pypi SAT solve) -> C++ build). On the 16 GB / 8-core `hermes`
+# WSL host, fanning all 16 repos out at once exhausted RAM + 16 GB swap and hung
+# the VM (see CLAUDE.md "Resource limits & concurrency"). Default 3 keeps peak at
+# ~3 x 3 GB with headroom; override with HERMES_MAX_CONCURRENT_AGENTS.
+MAX_CONCURRENT_HEAVY = int(os.environ.get("HERMES_MAX_CONCURRENT_AGENTS", "3"))
+
 # Container configuration
 CLAUDE_IMAGE = os.environ.get("CLAUDE_IMAGE", "achaean-claude:latest")
 CONTAINER_WORKSPACE = "/workspace"
@@ -388,6 +395,34 @@ def invoke_claude(
         return f"ERROR: {CONTAINER_RUNTIME} not found"
 
 
+# ─── Concurrency throttle for heavy invocations ────────────────────────────
+
+# Lazily-created so the semaphore binds to the running event loop (constructing
+# asyncio.Semaphore at import time has no loop to attach to).
+_HEAVY_SEMAPHORE: "asyncio.Semaphore | None" = None
+
+
+def _heavy_semaphore() -> "asyncio.Semaphore":
+    global _HEAVY_SEMAPHORE
+    if _HEAVY_SEMAPHORE is None:
+        _HEAVY_SEMAPHORE = asyncio.Semaphore(MAX_CONCURRENT_HEAVY)
+    return _HEAVY_SEMAPHORE
+
+
+async def bounded_invoke_claude(*args, **kwargs) -> str:
+    """Run a HEAVY ``invoke_claude`` under the global concurrency cap.
+
+    Acquires ``MAX_CONCURRENT_HEAVY`` slots so at most N container agents run
+    their clone -> pixi-solve -> build pipeline at once, and runs the blocking
+    ``invoke_claude`` in a worker thread so the cap actually throttles
+    concurrency instead of being defeated by the event loop serialising the
+    synchronous subprocess call. Prevents the all-repos-at-once OOM that hung
+    the `hermes` WSL host.
+    """
+    async with _heavy_semaphore():
+        return await asyncio.to_thread(invoke_claude, *args, **kwargs)
+
+
 # ─── Mock Responses for Dry-Run ────────────────────────────────────────────
 
 def mock_claude_response(stage: str, repo_slug: str, iteration: int) -> str:
@@ -659,8 +694,8 @@ The script should:
 
 Output ONLY the bash script. Start with #!/usr/bin/env bash."""
 
-    result = invoke_claude(prompt, scope="test", stage="test", iteration=iteration,
-                           task_id=task_id, repo_slug=repo_slug)
+    result = await bounded_invoke_claude(prompt, scope="test", stage="test", iteration=iteration,
+                                         task_id=task_id, repo_slug=repo_slug)
     post_issue_comment(issue_number, "test", iteration, f"```bash\n{result}\n```",
                        repo_slug=repo_slug)
 
@@ -739,8 +774,8 @@ Instructions:
 
 Output a brief summary of what you did (3-5 lines). Files should already be written."""
 
-    result = invoke_claude(prompt, scope="implement", stage="implement", iteration=iteration,
-                           task_id=task_id, repo_slug=repo_slug)
+    result = await bounded_invoke_claude(prompt, scope="implement", stage="implement", iteration=iteration,
+                                         task_id=task_id, repo_slug=repo_slug)
     post_issue_comment(issue_number, "implement", iteration, result, repo_slug=repo_slug)
 
     next_data = {
@@ -817,8 +852,8 @@ IMPORTANT:
 - Only GO when EVERY criterion passes.
 - Run the test script and include output."""
 
-    result = invoke_claude(prompt, scope="review", stage="review", iteration=iteration,
-                           task_id=task_id, repo_slug=repo_slug)
+    result = await bounded_invoke_claude(prompt, scope="review", stage="review", iteration=iteration,
+                                         task_id=task_id, repo_slug=repo_slug)
     post_issue_comment(issue_number, "review", iteration, result, repo_slug=repo_slug)
 
     # Parse verdict
@@ -915,7 +950,7 @@ Generated with [Claude Code](https://claude.com/claude-code)"
 
 Output the PR URL."""
 
-    result = invoke_claude(prompt, scope="ship", stage="ship", task_id=task_id, repo_slug=repo_slug)
+    result = await bounded_invoke_claude(prompt, scope="ship", stage="ship", task_id=task_id, repo_slug=repo_slug)
     post_issue_comment(issue_number, "ship", 0,
                        f"**[{repo_slug}] Shipped!**\n\n{result}", repo_slug=repo_slug)
 
@@ -998,7 +1033,7 @@ Generated with [Claude Code](https://claude.com/claude-code)"
 
 Output the PR URL."""
 
-    result = invoke_claude(prompt, scope="ship", stage="ship-final", task_id=task_id, repo_slug="odysseus")
+    result = await bounded_invoke_claude(prompt, scope="ship", stage="ship-final", task_id=task_id, repo_slug="odysseus")
     post_issue_comment(issue_number, "ship-final", 0, f"**Odysseus shipped!**\n\n{result}")
 
     # Publish completion

--- a/scripts/install/50-cpp-builds.sh
+++ b/scripts/install/50-cpp-builds.sh
@@ -29,6 +29,14 @@ CPP_REPOS=(
 
 RUNTIME_PREFIX="${ODYSSEUS_RUNTIME_PREFIX:-$HOME/.local}"
 
+# Cap build parallelism. Using -j"$(nproc)" makes every concurrent build claim
+# all cores; when several Myrmidon agents build at once on the 16 GB / 8-core
+# `hermes` WSL host this oversubscribes CPU ~2x and (with parallel pixi solves)
+# exhausts RAM + swap, hanging the VM. Default 2 cores/build; with the agent
+# concurrency cap (HERMES_MAX_CONCURRENT_AGENTS=3) that is <=6 of 8 cores.
+# Override with ODYSSEUS_BUILD_JOBS. See Odysseus CLAUDE.md "Resource limits".
+BUILD_JOBS="${ODYSSEUS_BUILD_JOBS:-2}"
+
 # Pre-create install tree so nats.c FetchContent install doesn't fail trying
 # to mkdir lib/pkgconfig inside cmake --install.
 if ! mkdir -p "$RUNTIME_PREFIX/bin" "$RUNTIME_PREFIX/lib/pkgconfig" "$RUNTIME_PREFIX/include"; then
@@ -86,6 +94,16 @@ build_cpp_repo() {
     (
         cd "$dir"
 
+        # Memory-bound this repo's conan+cmake+build pipeline. ulimit -v converts
+        # an over-budget allocation into a recoverable failure of THIS subshell
+        # instead of letting the kernel OOM-killer thrash and hang the whole WSL
+        # VM (the failure mode that took down `hermes`). Default ~6 GiB/build;
+        # override with ODYSSEUS_BUILD_VMEM_KB (0 disables the cap).
+        _vmem_kb="${ODYSSEUS_BUILD_VMEM_KB:-6291456}"
+        if [[ "$_vmem_kb" != "0" ]]; then
+            ulimit -v "$_vmem_kb" 2>/dev/null || true
+        fi
+
         # ── Step 1: Conan deps ────────────────────────────────────────────────
         # Output folder must match CMakePresets.json toolchainFile path:
         #   build/${presetName}/conan_toolchain.cmake → -of build/release
@@ -127,8 +145,8 @@ build_cpp_repo() {
             2>&1
 
         # ── Step 3: Build ─────────────────────────────────────────────────────
-        echo -e "      ${DIM}cmake --build...${NC}"
-        pixi run -- cmake --build --preset release -j"$(nproc)" 2>&1
+        echo -e "      ${DIM}cmake --build (-j$BUILD_JOBS)...${NC}"
+        pixi run -- cmake --build --preset release -j"$BUILD_JOBS" 2>&1
 
         # ── Step 4: Install ───────────────────────────────────────────────────
         echo -e "      ${DIM}cmake --install to $RUNTIME_PREFIX...${NC}"

--- a/scripts/run-bounded.sh
+++ b/scripts/run-bounded.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# run-bounded.sh — run a memory-hungry command under a virtual-memory cap.
+#
+# Wrap pixi / cmake / podman / pytest invocations so an over-budget process
+# fails as a recoverable error of ITS OWN, instead of letting the kernel
+# OOM-killer thrash swap and hang the whole WSL VM. This is the defense that
+# would have contained the `hermes` host overload (see Odysseus CLAUDE.md
+# "Resource limits & concurrency"): `ulimit -v` turns the uncatchable SIGKILL
+# into a normal non-zero exit / MemoryError that unwinds cleanly.
+#
+# Usage:
+#   scripts/run-bounded.sh pixi install
+#   scripts/run-bounded.sh cmake --build --preset release -j2
+#   RUN_BOUNDED_VMEM_KB=4194304 scripts/run-bounded.sh pytest tests/
+#
+# Env:
+#   RUN_BOUNDED_VMEM_KB   Virtual-memory cap in KiB (default 5242880 = 5 GiB).
+#                         Set to 0 to disable the cap (run unbounded).
+#
+# Sizing: on the 16 GB / 8-core host, ~5 GiB/process lets one heavy solve/build
+# run comfortably while keeping 3 concurrent bounded processes < 16 GB.
+set -euo pipefail
+
+if [[ $# -eq 0 ]]; then
+    echo "usage: $(basename "$0") <command> [args...]" >&2
+    exit 2
+fi
+
+VMEM_KB="${RUN_BOUNDED_VMEM_KB:-5242880}"
+
+if [[ "$VMEM_KB" != "0" ]]; then
+    # Best-effort: if the soft limit is already lower, ulimit -v will refuse to
+    # raise it — that is fine, we only ever want to LOWER the ceiling here.
+    ulimit -v "$VMEM_KB" 2>/dev/null || true
+fi
+
+exec "$@"


### PR DESCRIPTION
## Summary

A 16-repo Myrmidon fan-out (`e2e/claude-myrmidon-multi.py`) dispatched all per-repo agents concurrently with **no concurrency cap**. Each agent ran a `pixi` solve (~0.5–1 GB) **and** a C++ build (`cmake --build -j\$(nproc)` → all 8 cores, 1.5–3 GB), so peak demand hit **~18–40 GB on the 16 GB / 8-core `hermes` WSL host** → all 16 GB swap exhausted → swap thrash + scheduler starvation → **the WSL VM hung**.

Forensic evidence (`/var/log/syslog`): `Free swap = 0kB`, "Under memory pressure, flushing caches", `pgmajfault: 13255`, 28× "Time jumped backwards", journal corruption. Recovered only after the OOM-killer reaped agents.

`hephaestus max_workers=3` did **not** help — it bounds a ThreadPoolExecutor inside one process, not concurrent Claude agent sessions.

## Fix (orchestration + docs; no `.wslconfig` host changes)

- **`claude-myrmidon-multi.py`** — `asyncio.Semaphore(HERMES_MAX_CONCURRENT_AGENTS, default 3)` via a new `bounded_invoke_claude()` (lazy-created to bind the running loop; runs the blocking `invoke_claude` in `asyncio.to_thread` so the cap is real). Applied to every heavy stage (test/implement/review/ship); the one-shot planner stays a direct call.
- **`scripts/install/50-cpp-builds.sh`** — `-j\$(nproc)` → `-j\$BUILD_JOBS` (`ODYSSEUS_BUILD_JOBS`, default 2) + `ulimit -v` (~6 GiB) around each repo's conan+cmake+build subshell.
- **`scripts/run-bounded.sh`** (new) — `ulimit -v` wrapper (default 5 GiB) for pixi/cmake/podman/pytest so an over-budget process dies recoverably instead of OOM-hanging the VM.
- **`CLAUDE.md`** — new "Resource limits & concurrency on the `hermes` host" section (≤3 concurrent heavy agents, the wrapper, `CMAKE_BUILD_PARALLEL_LEVEL=2`, check `free -h` first).

## Verification

- **Throttle:** fired 10 concurrent `bounded_invoke_claude` calls → peak in-flight capped at exactly **3** (never exceeded).
- **Memory-bound:** `RUN_BOUNDED_VMEM_KB=65536 run-bounded.sh python3 -c '<200MB alloc>'` → clean `MemoryError`, **shell survives** (no hang).
- `python3 -m py_compile` + `bash -n` pass; `.wslconfig` untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)