### PR TITLE
ci: unify job naming to canonical 8-category scheme + wire install/release

### DIFF
--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -233,6 +233,32 @@ jobs:
         run: |
           git submodule foreach 'git ls-remote --exit-code origin HEAD > /dev/null && echo "OK: $name" || echo "WARN: $name unreachable"'
 
+  test:
+    # Aggregate test gate for the canonical 8-category CI naming scheme
+    # (docs/ci-naming-convention.md). The split suites above (unit-tests,
+    # integration-tests) remain as sub-checks; this job emits the canonical
+    # `test` check-run so the Ecosystem CI Status board's **test** column can
+    # target a single name. It is a pure gate: it fans-in the two suites and
+    # fails if either failed.
+    name: test
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    needs: [unit-tests, integration-tests]
+    if: ${{ always() }}
+    steps:
+      - name: Aggregate unit-tests + integration-tests results
+        run: |
+          set -euo pipefail
+          unit="${{ needs.unit-tests.result }}"
+          integ="${{ needs.integration-tests.result }}"
+          echo "unit-tests:        $unit"
+          echo "integration-tests: $integ"
+          if [ "$unit" != "success" ] || [ "$integ" != "success" ]; then
+            echo "::error::Aggregate test gate failed (unit=$unit integration=$integ)"
+            exit 1
+          fi
+          echo "OK: all test suites passed"
+
   security-dependency-scan:
     name: security/dependency-scan
     runs-on: ubuntu-latest

--- a/.github/workflows/install-test.yml
+++ b/.github/workflows/install-test.yml
@@ -1,6 +1,10 @@
 name: Install test
 
 on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
   schedule:
     - cron: "0 6 * * 1"  # Every Monday at 06:00 UTC
   workflow_dispatch:
@@ -11,6 +15,53 @@ on:
         default: ""
 
 jobs:
+  # Canonical `install` check for the 8-category CI naming scheme
+  # (docs/ci-naming-convention.md). The full multi-OS Docker matrix below is
+  # heavy (45 min × 3 images) and stays gated to schedule / workflow_dispatch.
+  # This lightweight smoke job runs on every main push/PR so the Ecosystem CI
+  # Status board's **install** column lights up quickly: it exercises the
+  # installer's check-only detection path (no sudo, no apt, no Docker) and
+  # asserts the installer is structurally sound and produces its detection
+  # summary. Check-only mode exits 1 when components are missing on a bare
+  # runner (expected), so we assert on the produced summary, not the exit code.
+  install:
+    name: install
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+
+      - name: Installer script is valid bash
+        run: bash -n install.sh
+
+      - name: Reject unknown flags (CLI contract)
+        run: |
+          set -euo pipefail
+          if bash install.sh --definitely-not-a-flag >/tmp/badflag.log 2>&1; then
+            echo "::error::install.sh accepted an unknown flag (expected non-zero exit)"
+            cat /tmp/badflag.log
+            exit 1
+          fi
+          grep -q "Unknown option" /tmp/badflag.log \
+            || { echo "::error::install.sh did not report 'Unknown option'"; cat /tmp/badflag.log; exit 1; }
+          echo "OK: unknown flag rejected"
+
+      - name: Check-only detection produces a summary (install smoke test)
+        run: |
+          set -uo pipefail
+          # Check-only mode (no --install): probes components, never escalates.
+          # Exit code is 1 when components are missing on a bare runner — that
+          # is the expected/healthy signal, so we assert on the summary output.
+          bash install.sh >/tmp/install-check.log 2>&1
+          rc=$?
+          echo "install.sh check-only exit code: $rc"
+          cat /tmp/install-check.log
+          grep -q "Detection summary:" /tmp/install-check.log \
+            || { echo "::error::install.sh check-only did not produce a 'Detection summary'"; exit 1; }
+          grep -q "Check-only mode" /tmp/install-check.log \
+            || { echo "::error::install.sh did not run in check-only mode"; exit 1; }
+          echo "OK: installer check-only smoke test passed (exit $rc tolerated)"
+
   install-test:
     name: Install (${{ matrix.os }})
     runs-on: ubuntu-latest

--- a/.github/workflows/install-test.yml
+++ b/.github/workflows/install-test.yml
@@ -51,9 +51,14 @@ jobs:
           set -uo pipefail
           # Check-only mode (no --install): probes components, never escalates.
           # Exit code is 1 when components are missing on a bare runner — that
-          # is the expected/healthy signal, so we assert on the summary output.
-          bash install.sh >/tmp/install-check.log 2>&1
-          rc=$?
+          # is the expected/healthy signal, so we assert on the summary output,
+          # not the exit code. NOTE: GitHub runs steps with `bash -e`, so we
+          # capture the (expected non-zero) exit explicitly via `|| rc=$?`
+          # rather than letting `-e` abort the step. This is exit-code capture,
+          # not failure suppression — we still fail below if the summary is
+          # absent.
+          rc=0
+          bash install.sh >/tmp/install-check.log 2>&1 || rc=$?
           echo "install.sh check-only exit code: $rc"
           cat /tmp/install-check.log
           grep -q "Detection summary:" /tmp/install-check.log \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,15 +2,62 @@ name: Release
 
 on:
   push:
+    branches: [main]
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+'
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
 
 permissions:
   contents: write
 
 jobs:
+  # Canonical `release` check for the 8-category CI naming scheme
+  # (docs/ci-naming-convention.md). Actual publishing is tag-gated (the
+  # validate/publish jobs below run only on a vX.Y.Z tag push). This
+  # lightweight dry-run runs on every main push/PR so the Ecosystem CI Status
+  # board's **release** column lights up: it exercises the same release-gating
+  # logic (CHANGELOG shape + release-contract regression tests + release-notes
+  # extraction) WITHOUT creating a GitHub Release, so release regressions are
+  # caught on `main` before a tag is ever cut.
+  release:
+    name: release
+    # Skip on tag pushes — the real validate/publish jobs handle tags.
+    if: ${{ !startsWith(github.ref, 'refs/tags/') }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+        with:
+          fetch-depth: 0
+
+      - name: CHANGELOG has an Unreleased section
+        run: |
+          set -euo pipefail
+          if ! grep -q "^## \[Unreleased\]$" CHANGELOG.md; then
+            echo "::error::CHANGELOG.md missing '## [Unreleased]' section"
+            exit 1
+          fi
+          echo "OK: CHANGELOG has an Unreleased section"
+
+      - name: Release-contract regression tests (dry-run)
+        run: bash tests/release/release.test.sh
+
+      - name: Release-notes extraction is wired (dry-run, no publish)
+        run: |
+          set -euo pipefail
+          # Verify the release-notes extractor exists and is valid; do not
+          # publish anything. The full extraction runs only on a real tag.
+          test -f scripts/extract_release_notes.py
+          python3 -c "import py_compile; py_compile.compile('scripts/extract_release_notes.py', doraise=True)"
+          echo "OK: release notes extractor is present and importable"
+
   validate:
     name: validate-release-assets
+    # Tag-only: real release validation runs only when a vX.Y.Z tag is pushed.
+    # On main push/PR the lightweight `release` dry-run above stands in.
+    if: ${{ startsWith(github.ref, 'refs/tags/') }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -57,6 +104,8 @@ jobs:
 
   publish:
     name: publish-release
+    # Tag-only: never publishes a GitHub Release on main push/PR.
+    if: ${{ startsWith(github.ref, 'refs/tags/') }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     needs: validate


### PR DESCRIPTION
Aligns Odysseus CI with the canonical 8-category naming scheme defined in `docs/ci-naming-convention.md` (PR #365), so the [Ecosystem CI Status board](../README.md#ecosystem-ci-status) can target one canonical check-run name per category. **Odysseus is the pilot repo** for this rollout.

## What changed

| Category | Before | After |
|----------|--------|-------|
| **test** | only `unit-tests` + `integration-tests` | added aggregate `test` job (needs both, emits `test`); sub-checks kept |
| **install** | `install-test.yml` was **schedule-only** — emitted no check on main | added `main` push/PR triggers + a lightweight non-Docker `install` smoke job emitting `install`; heavy 3-OS Docker matrix stays schedule-gated |
| **release** | `release.yml` was **tag-only** — emitted no check on main | added a lightweight `release` dry-run job on main push/PR emitting `release` (no publish); real validate/publish jobs now explicitly tag-gated |
| build, lint, security/* | already canonical | unchanged |
| **package** | meta-repo, no artifact | tracked in #366 (document N/A vs add real package check) |

### Wiring the silent workflows (the key pilot case)

- **install** — `install-test.yml` now runs on main push/PR. The new `install` job is deliberately lightweight (no sudo/apt/Docker): it runs `bash -n install.sh`, asserts the CLI rejects unknown flags, and exercises the installer's **check-only** detection path, asserting it produces a "Detection summary". Verified locally: all three assertions pass.
- **release** — `release.yml` now runs a `release` dry-run on main push/PR: CHANGELOG `[Unreleased]` shape, the full `tests/release/release.test.sh` regression suite (13/13 pass locally), and a release-notes-extractor importability check — **without** creating a GitHub Release. The tag-gated `validate-release-assets` / `publish-release` jobs are now guarded with `if: startsWith(github.ref, 'refs/tags/')` so they never run on main push.

## Categories now emitting on main (after this merges)

`build`, `test`, `lint`, `install`, `release`, `security/dependency-scan`, `security/secrets-scan`, plus custom (`deps/version-sync`, `schema-validation`, `validate configs`, `idempotent-build`, `forbid-suppressions`, `verify-scripts`).

Only **package** remains a gap — N/A for a meta-repo, tracked in #366.

## Verification done locally

- `yamllint -d relaxed .github/workflows/` → rc=0 (warnings are pre-existing line-length only)
- `check-jsonschema` against the github-workflow schema → ok
- install smoke logic + release dry-run logic both exercised and pass

The wired checks must actually emit on this branch before they're made required — CI on this PR is the verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)