### PR TITLE
feat(hmas): ADR-013 mesh wire contracts + architecture rewrite + console submit/interview

### DIFF
--- a/docs/adr/013-hmas-mesh-wire-contracts.md
+++ b/docs/adr/013-hmas-mesh-wire-contracts.md
@@ -1,0 +1,275 @@
+# ADR 013: HMAS Mesh Wire Contracts — Role-Addressed Dispatch, State Events, and Task Sizing
+
+**Status:** Proposed
+
+**Extends:** [ADR 005](005-nats-subject-schema.md)
+
+---
+
+## Context
+
+The HMAS primitives exist in isolation — Agamemnon's TaskStateMachine and
+`/v1/briefs` ingestion, Hephaestus' planner/implementer/reviewer product layer
+and `state:*` labels, Nestor's research intake, Telemachy's workflow engine —
+but the connective wire contracts between them were never defined:
+
+- Agamemnon dispatches on two-token `hi.myrmidon.{type}.{task_id}` subjects
+  that no worker consumes, and `hi.myrmidon.*` is absent from ADR-005 entirely
+  (the Odysseus console removed its subscription for exactly this reason,
+  issue #211).
+- Agamemnon subscribes only to `hi.tasks.*.*.completed`; workers have no way
+  to signal start or failure, so assignment is never recorded.
+- There is no defined interview channel, no epic-registration trigger, no
+  research dispatch queue, and no lease/heartbeat/idempotency contract for
+  workers.
+
+This ADR defines the authoritative wire contracts for the HMAS mesh pipeline:
+subject grammar, JetStream consumer configuration, payload envelopes, task
+sizing and overrun re-adjustment, event-vs-store ownership, the interview
+relay, and epic conventions.
+
+## Decision
+
+### 1. Role-addressed dispatch subjects (pull work queues)
+
+```
+hi.myrmidon.{domain}.{role}.task.{task_id}
+```
+
+- **domain** ∈ `research`, `pipeline` (extensible: any slugified domain).
+- **role** is an HMAS role NAME, never a level number: `chief-architect`,
+  `component-lead`, `module-lead`, `task-agent`, and deeper roles as the
+  hierarchy grows (`specialist`, `engineer`, `junior`, …).
+- The literal `task` token separates new subjects from legacy two-token
+  publishes so new consumers never receive legacy messages.
+
+**Role taxonomy.** Myrmidon roles ARE the HMAS agentic roles at every level of
+the hierarchy, crossed with domain — a `research.chief-architect` myrmidon and
+a `pipeline.chief-architect` myrmidon are distinct pool queues. The hierarchy
+is extensible beyond four levels: ProjectAgamemnon's AGENTS.md 4-level
+instantiation (L0 chief-architect → L3 task-agent) and ProjectOdyssey's
+`agents/hierarchy.md` 6-level/30-agent instantiation are both valid. Model
+tiers map to role depth: opus for architect-level roles, sonnet for
+mid-hierarchy and task agents, **haiku for junior roles**. The wire contract
+never encodes the level number — only the role name — so deeper hierarchies
+require no subject changes.
+
+**Consumers.** One durable pull consumer per (domain, role):
+
+| Setting | Value |
+|---|---|
+| Durable name | `myrmidon-{domain}-{role}` |
+| Stream | `homeric-myrmidon` |
+| Filter subject | `hi.myrmidon.{domain}.{role}.task.>` |
+| Ack policy | `AckExplicit` |
+| AckWait | 900 s (15 min) |
+| MaxDeliver | 3 |
+| MaxAckPending | pool concurrency cap (initial: 3 = host heavy-agent budget) |
+
+Each worker fetches one message at a time (`fetch(1)`) — one task per
+myrmidon. Workers heartbeat with `msg.in_progress()` every 5 minutes; three
+missed heartbeats (AckWait expiry) mean the worker is dead and the task is
+redelivered. Ack happens only after completion.
+
+**Migration.** Legacy two-token subjects (`hi.myrmidon.{type}.{task_id}`) are
+dual-published for one release, then removed. Operators must purge the stale
+`homeric-myrmidon` backlog before bringing up role-addressed consumers.
+
+### 2. Task state events (facts, fan-out)
+
+```
+hi.tasks.{team_id}.{task_id}.{verb}    verb ∈ started | updated | completed | failed
+```
+
+This adds the `started` verb to ADR-005's list. Workers publish `started`
+immediately after claiming (payload carries `agent_id` and `exec_host` — this
+IS the assignment record; assignment happens at claim, not at dispatch).
+
+**Ownership rule (normative):**
+
+- **Workers publish events.** They never write Agamemnon's store directly.
+- **Only Agamemnon writes its backing store** (GitHub Issues/Projects).
+- **Only Hephaestus automation writes `state:*` labels** (`state:needs-plan`,
+  `state:plan-go/-no-go`, `state:implementation-go/-no-go`, `state:skip`).
+
+Code truth lives in the git branch; state truth lives in GitHub labels plus
+Agamemnon's store. NATS messages are pointers and facts, never the state
+itself.
+
+### 3. Payload envelope
+
+Every payload is JSON with envelope fields:
+
+```json
+{"schema": "hi/v1", "ts": "<ISO-8601>", "msg_id": "<uuid>"}
+```
+
+Dispatch payloads carry pointers, not content: `task_id`, `team_id`, `role`,
+`domain`, `repo`, `issue`, `epic {repo, issue, key}`, `branch`,
+`base_branch`, `blocked_by[]`, `intake_id`, `attempt`. Research dispatch
+additionally carries `idea`/`context` inline (no issue exists yet). State
+events add `agent_id`, `exec_host`, `pr {number, url, merged}`,
+`error {kind, message, retryable}`.
+
+### 4. Task sizing and overrun re-adjustment
+
+- **Planner acceptance criterion:** leaf tasks are sized to ≲1 hour of active
+  work.
+- **No hard time limit.** A task exceeding ~1 hour of ACTIVE work triggers
+  re-adjustment, not failure: based on its current state and plan it is broken
+  into multiple smaller tasks — progress preserved, remainder re-planned.
+- **Worker overrun handler:** at ~1 h active the worker
+  1. checkpoints — commits and pushes its branch, posts a progress comment
+     with marker `<!-- hi:checkpoint {task_id} -->`;
+  2. derives the remainder from its current plan/state;
+  3. registers the remainder as sub-tasks via Agamemnon REST
+     (`POST /v1/tasks/:id/split`) with `blocked_by` chaining and the
+     checkpoint branch as `base_branch`;
+  4. publishes `completed` for the current task (it becomes the first slice
+     of the split) and acks.
+- **Leases detect death, not length.** The 5-minute heartbeat keeps a healthy
+  long-running task alive indefinitely; AckWait expiry only fires on worker
+  death. Sizing overruns are handled by the split mechanism above.
+- **Idempotency preamble.** On redelivery (attempt > 1) the worker first
+  checks for an existing branch, PR, labels, and Agamemnon task state, then
+  resumes from the last checkpoint or no-ops. Workers post a GitHub progress
+  comment at every major step or at least hourly — this is the resume anchor.
+- **Wall-clock-long work is event-driven, never held.** A multi-epic
+  orchestration node sleeps inside Agamemnon between child completions
+  (`blocked_by` graph); each child completion wakes it and dispatches a
+  bounded burst of newly unblocked work to the role queues. A worker never
+  holds a lease while waiting on another task.
+
+### 5. Interview relay
+
+```
+hi.pipeline.interview.{intake_id}.question.{q_id}   worker → console
+hi.pipeline.interview.{intake_id}.answer.{q_id}     console → worker
+```
+
+The interviewing worker is a research-pool myrmidon (LLM work never runs
+inside the C++ services — Nestor stays a thin intake/status/dispatch service,
+the same principle as Agamemnon).
+
+Fallback ladder:
+
+1. Question published on NATS; console prompts the user live.
+2. Unanswered after 15 min → worker posts the question to the intake issue
+   with marker `<!-- hi:question {intake_id}/{q_id} -->` and polls comments
+   every 60 s for up to 24 h.
+3. A late console answer wins over a pending GitHub poll. GitHub answers are
+   re-published on the answer subject with `"channel": "github"` so NATS
+   carries the full transcript.
+4. Both channels time out → the worker proceeds with stated assumptions and
+   re-publishes the question with `"status": "assumed"`.
+
+All Q&A is mirrored to the intake issue for audit.
+
+### 6. Epic registration trigger
+
+```
+hi.pipeline.epic.{epic_key}.registered      epic_key = {repo_slug}-{issue_number}
+```
+
+Telemachy creates the epic issue (label `agamemnon-epic`) and its child
+issues, then publishes this subject. Agamemnon consumes it with durable
+`agamemnon-epics` and submits the HMAS root (Pending → Decomposing).
+
+**Epic body convention** (parseable task list, precedent:
+ProjectOdyssey `scripts/implement_issues.py`):
+
+```markdown
+- [ ] #123 (depends on: #456)
+- [ ] #124
+```
+
+Child issues carry label `state:needs-plan` at creation.
+
+### 7. Research dispatch
+
+`POST /v1/research` on Nestor publishes
+`hi.myrmidon.research.chief-architect.task.{research_id}` (the research pool
+queue). `hi.research.{id}` is retained as a status/compat subject; externally
+published completion status on `hi.research.>` closes Nestor's store item.
+
+### 8. Logs
+
+```
+hi.logs.myrmidon.{domain}.{role}.{agent_id}
+```
+
+Every payload carries `exec_host`.
+
+### 9. Streams
+
+| Stream | Subjects | Notes |
+|---|---|---|
+| `homeric-myrmidon` | `hi.myrmidon.>` | exists; work queues |
+| `homeric-tasks` | `hi.tasks.>` | exists; state events |
+| `homeric-agents` | `hi.agents.>` | exists |
+| `homeric-logs` | `hi.logs.>` | exists |
+| `homeric-pipeline` | `hi.pipeline.>` | made authoritative; limits-based retention (multiple readers) |
+
+### 10. State machine mapping
+
+One row per pipeline phase — owner / storage / trigger:
+
+| Phase | HMAS state | Trigger | Storage |
+|---|---|---|---|
+| Intake | — | console `submit` → `POST /v1/research` | Nestor store (pending); worker creates intake issue (label `intake`) |
+| Research + interview | flat task InProgress | worker `started` event | intake issue transcript |
+| Epic registered | Pending → Decomposing | `hi.pipeline.epic.*.registered` → Submit | epic + child issues (`state:needs-plan`) |
+| Decomposing | Decomposing | planner burst → `pipeline.chief-architect` queue | — |
+| Planned / Delegated | Decomposing → Delegated | planner `completed` → brief ingested (`POST /v1/briefs`, L0–L3 tree, child-issue refs on L3 nodes) | Agamemnon store; `state:plan-go/-no-go` per child issue |
+| Executing | Delegated → InProgress | worker `started` (records `agent_id`/`exec_host`) | branch + progress comments |
+| Review gate | InProgress | PR review inside worker | `state:implementation-go/-no-go` on PR |
+| Done | InProgress → Completed | worker `completed`; PR auto-merge (squash) armed only after `state:implementation-go`; body `Closes #N`; signed commits | merged PR |
+| Split (overrun) | Completed + new Pending children | `POST /v1/tasks/:id/split` then normal `completed` | checkpoint branch is children's `base_branch` |
+| Failed / Escalated | InProgress → Failed / Escalated | `failed` event → Fail; MaxDeliver exhaustion → Escalated (bottom-up delegation) | `state:skip` on exhaustion |
+| Blocked / parent nodes | Delegated (parked) | child completion → `delegate_unblocked_children` → next burst | Agamemnon `blocked_by` graph — never held by a worker |
+
+## Consequences
+
+**Positive:**
+
+- Every existing HMAS primitive (state machine, briefs, labels, advise/learn)
+  is connected by an explicit, versioned wire contract.
+- Role-addressed queues make the worker pool horizontally scalable per
+  (domain, role) without touching the subject grammar, including hierarchy
+  levels and model tiers that do not exist yet.
+- Leases + idempotency preamble give at-least-once execution with safe resume
+  after worker death; the split mechanism keeps task sizing honest without
+  hard-killing long work.
+- The console's `hi.myrmidon.>` subscription can return (issue #211 is
+  resolved by this ADR documenting the namespace).
+
+**Negative:**
+
+- Dual-publish migration window doubles dispatch traffic for one release.
+  Mitigation: the `.task.` token isolates new consumers; legacy publish is
+  removed after one release.
+- AckWait=900 s means a dead worker delays redelivery by up to 15 minutes.
+  Mitigation: acceptable for ≲1 h tasks; heartbeat interval (5 min) is a
+  worker constant that can be tightened without a consumer change.
+- The interview GitHub fallback polls (60 s); webhook wiring is deferred.
+
+**Neutral:**
+
+- ADR-005's verb list grows by `started`; existing subscribers using `>`
+  wildcards are unaffected.
+- The `homeric-pipeline` stream becomes authoritative for `hi.pipeline.>`;
+  consumers that used core NATS keep working (stream capture is additive).
+
+## References
+
+- [ADR 002](002-nats-event-bridge.md) — NATS event bridge
+- [ADR 005](005-nats-subject-schema.md) — subject schema this ADR extends
+- [ADR 008](008-nats-tls-encryption.md) / [ADR 009](009-nats-authentication.md)
+  / [ADR 010](010-nats-mtls-subject-scoped-auth.md) — transport security for
+  all publishers/consumers introduced here
+- [ADR 011](011-extract-python-orchestration-to-agamemnon.md) — Python
+  orchestration ownership
+- ProjectAgamemnon `AGENTS.md` — 4-level HMAS instantiation
+- ProjectOdyssey `agents/hierarchy.md` — 6-level/30-agent instantiation
+- Issue [#211](https://github.com/HomericIntelligence/Odysseus/issues/211) —
+  console `hi.myrmidon.>` subscription removal

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -19,6 +19,7 @@ choice, its context, decision rationale, and consequences.
 | [009](009-defer-multi-host-nomad-scheduling.md) | Defer Multi-Host Nomad Scheduling to a Future Phase | Proposed | — | — |
 | [011](011-extract-python-orchestration-to-agamemnon.md) | Extract Python Orchestration Layer from Keystone to ProjectAgamemnon | Accepted | — | — |
 | [012](012-slo-sla-definitions.md) | Define SLO/SLA Targets for the Agent Mesh | Proposed | — | — |
+| [013](013-hmas-mesh-wire-contracts.md) | HMAS Mesh Wire Contracts — Role-Addressed Dispatch, State Events, and Task Sizing | Proposed | — | — |
 
 ## How to Create a New ADR
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -28,15 +28,15 @@ a git submodule. Odysseus itself contains no application code.
 |-----------|----------|------|
 | **Odysseus** | meta | User interface, observability hub, and meta-repo. Bidirectional with user. Consumes Argus dashboards. |
 | **ProjectAgamemnon** | control | Planning, coordination, and HMAS orchestration (L0–L3). GitHub Issues/Projects is the backing store. Does not perform research or expose a user UI. |
-| **ProjectNestor** | control | Research, ideation, and search. Idea → research → review brief → handoff to Agamemnon. Uses Telemachy internally for multi-step workflows. |
+| **ProjectNestor** | control | Thin C++ intake/status/dispatch service for research. Accepts ideas (`POST /v1/research`), dispatches them to the research myrmidon pool, tracks status. Research, interviewing, and ideation run in research-pool myrmidons — never inside Nestor itself (LLM work never runs inside C++ services; see [ADR-013](adr/013-hmas-mesh-wire-contracts.md)). |
 | **ProjectKeystone** | transport | Invisible transport layer. BlazingMQ for intra-host (<500 ns, >2 M msg/sec); NATS JetStream (nats.c v3.12.0) for cross-host over Tailscale. Components talk *through* Keystone, never *to* it. |
 | **ProjectHermes** | infrastructure | External message delivery bridge. Routes external-service events into NATS and delivers outbound messages to external services. |
 | **ProjectArgus** | infrastructure | Observability: Prometheus metrics, Loki log aggregation, Grafana dashboards, Promtail scraping. Feeds Odysseus dashboards. |
 | **AchaeanFleet** | infrastructure | Container image library. All agent and service images. Built by Proteus; run on the `homeric-mesh` Podman network. |
 | **Myrmidons repo** | provisioning | GitOps source of truth. YAML manifests describe desired agent state; Agamemnon API reconciliation applies them. Also holds all agent templates and container specs. Multi-host scheduling via Nomad is deferred to a future phase (see [ADR-009](adr/009-defer-multi-host-nomad-scheduling.md)); currently supports `local` and `docker` deployment types only. |
-| **ProjectTelemachy** | provisioning | Declarative workflow engine. Used programmatically by Agamemnon and Nestor. Not a user-facing service. |
+| **ProjectTelemachy** | provisioning | Declarative workflow engine + work description and epic registration. Turns workflow YAML into GitHub epics with child issues and publishes `hi.pipeline.epic.*.registered` ([ADR-013](adr/013-hmas-mesh-wire-contracts.md)). Used programmatically by Agamemnon, Nestor, and research myrmidons. Not a user-facing service. |
 | **ProjectProteus** | ci-cd | CI/CD. Dagger TypeScript pipelines. Builds AchaeanFleet images; dispatches `agamemnon-apply` on merge. |
-| **Myrmidons (workers)** | workers | Single-host worker pool. Pull-based, rate-limited (MaxAckPending=1). Queue subscription determines role. Multi-host clustering via Nomad is deferred to a future phase (see [ADR-009](adr/009-defer-multi-host-nomad-scheduling.md)). |
+| **Myrmidons (workers)** | workers | The worker pool: all nodes that can run myrmidon agents. Pull-based from role-addressed queues `hi.myrmidon.{domain}.{role}.task.>` ([ADR-013](adr/013-hmas-mesh-wire-contracts.md)); myrmidon roles ARE the HMAS agentic roles at every level, crossed with domain (e.g. `research.chief-architect` vs `pipeline.chief-architect`). Multi-host clustering via Nomad is deferred to a future phase (see [ADR-009](adr/009-defer-multi-host-nomad-scheduling.md)). |
 | **ProjectScylla** | testing | AI agent ablation benchmarking; evaluates agent architectures across tiered configurations (T0–T6). |
 | **ProjectCharybdis** | testing | Chaos and resilience testing. Injects faults via Agamemnon `/v1/chaos/*` endpoints. |
 | **ProjectMnemosyne** | shared | Skills marketplace / team-knowledge memory store for the `advise` and `learn` plugins only. Not an agent-template registry. |
@@ -91,13 +91,13 @@ traverse the network.
   │                     ProjectKeystone                                 │
   │   BlazingMQ (intra-host) · NATS JetStream (cross-host/Tailscale)   │
   └──────┬──────────────────────┬──────────────────────────────────────┘
-         │ hi.myrmidon.{type}.> │ hi.research.>
-         ▼                      ▼
-  ┌─────────────────┐   ┌───────────────────┐
-  │  Myrmidons      │   │  Research workers  │
-  │  (worker pool)  │   │  (pull, rate-lim.) │
-  │  MaxAckPending=1│   │  MaxAckPending=1   │
-  └────────┬────────┘   └───────────────────┘
+         │ hi.myrmidon.pipeline.{role}.task.>   │ hi.myrmidon.research.{role}.task.>
+         ▼                                      ▼
+  ┌──────────────────────┐   ┌──────────────────────┐
+  │  Pipeline myrmidons  │   │  Research myrmidons   │
+  │  (pull, per-role     │   │  (pull, per-role      │
+  │   durable consumers) │   │   durable consumers)  │
+  └────────┬─────────────┘   └──────────────────────┘
            │ runs images from
            ▼
   ┌──────────────────────────────────────────────────────────────────┐
@@ -125,13 +125,75 @@ traverse the network.
 
 ## Pipeline Flow
 
+The full HMAS pipeline, end to end (wire contracts in
+[ADR-013](adr/013-hmas-mesh-wire-contracts.md)):
+
 ```
-User ↔ Odysseus ↔ Nestor ↔ Agamemnon ↔ Myrmidons workers
+ 1. User submits a high-level task via the Odysseus console
+       │  POST /v1/research (Nestor)
+       ▼
+ 2. Nestor registers the intake and dispatches to the research pool
+       │  hi.myrmidon.research.chief-architect.task.{id}
+       ▼
+ 3. A research myrmidon claims it: researches the idea, INTERVIEWS the
+    user (console live, GitHub issue comments as fallback), ideates
+    extensions, and produces a researched brief
+       │  hi.pipeline.interview.{intake_id}.question/.answer.{q_id}
+       ▼
+ 4. The work is described via ProjectTelemachy and registered in GitHub
+    as an epic with child issues (task-list body, state:needs-plan)
+       │  hi.pipeline.epic.{epic_key}.registered
+       ▼
+ 5. Agamemnon submits the HMAS root (Pending → Decomposing) and
+    dispatches a planning burst to the pipeline planner queue
+       │  hi.myrmidon.pipeline.chief-architect.task.{id}
+       ▼
+ 6. A planner myrmidon extends the epic into tasks/features/bugs/
+    sub-tasks in GitHub; the resulting brief is ingested
+       │  POST /v1/briefs  →  L0–L3 HmasTask tree (Delegated)
+       ▼
+ 7. Leaf tasks are dispatched to the worker pool; myrmidons on mesh
+    nodes claim individual tasks and move the state machine
+       │  hi.myrmidon.{domain}.{role}.task.{id}   (claim = assignment)
+       │  hi.tasks.{team}.{task}.started/completed/failed  (facts)
+       ▼
+ 8. Each worker: advise (before) → implement → PR → review gate
+    (state:implementation-go) → merge → learn (after)
+       │  child completion wakes blocked parents in Agamemnon
+       ▼
+ 9. delegate_unblocked_children dispatches the next burst until the
+    epic's tree reaches Completed
 ```
 
-Each hop is bidirectional. All communication flows **through** Keystone
-(invisible transport); no component holds a direct socket reference to another.
-Keystone is a transport detail, not a pipeline stage.
+Interviews, escalations, and dashboards flow back up the same subjects, so
+each hop is bidirectional. All communication flows **through** Keystone
+(invisible transport); no component holds a direct socket reference to
+another. Keystone is a transport detail, not a pipeline stage. All workers
+run AchaeanFleet container images and integrate advise-before / learn-after
+around every task.
+
+---
+
+## Task State Machine
+
+Two state systems cooperate, mapped one-to-one in
+[ADR-013](adr/013-hmas-mesh-wire-contracts.md) §10:
+
+- **Agamemnon TaskStateMachine** (per HMAS node):
+  `Pending → Decomposing → Delegated → InProgress → Completed`, with
+  `Escalated` (retry at parent layer) and `Failed` as exception paths.
+  Transitions are driven by NATS facts: worker `started` → InProgress,
+  `completed` → Completed (+ wake blocked children), `failed` → Failed.
+- **Hephaestus `state:*` labels** (per GitHub issue/PR):
+  `state:needs-plan → state:plan-go/-no-go → state:implementation-go/-no-go`,
+  plus `state:skip` on retry exhaustion. Only Hephaestus automation writes
+  these labels; only Agamemnon writes its own store; workers publish events.
+
+Task sizing: leaves are planned to ≲1 h of active work. There is no hard
+limit — a worker that overruns ~1 h checkpoints (commit/push + progress
+comment), registers the remainder as sub-tasks via `POST /v1/tasks/:id/split`,
+and completes its task as the first slice. Leases (5-min heartbeats,
+15-min AckWait, MaxDeliver=3) detect worker death only, never task length.
 
 ---
 
@@ -153,13 +215,20 @@ to Keystone itself; the transport is resolved at startup via configuration.
 
 All subjects use the `hi.` namespace prefix.
 
+See [ADR-013](adr/013-hmas-mesh-wire-contracts.md) for consumer settings,
+payload envelopes, and migration notes.
+
 | Subject pattern | Publishers | Subscribers | Notes |
 |-----------------|-----------|-------------|-------|
-| `hi.research.>` | Agamemnon, Nestor | Research myrmidons (pull) | JetStream pull consumer |
-| `hi.myrmidon.{type}.>` | Agamemnon | Pipeline myrmidons (pull) | JetStream pull consumer; `{type}` maps to queue group |
-| `hi.pipeline.>` | Odysseus, Argus, Hermes | Multiple (pub/sub) | Fan-out; Hermes bridges external events here |
+| `hi.myrmidon.{domain}.{role}.task.{task_id}` | Agamemnon, Nestor | Myrmidon pool (pull) | Role-addressed work queues; durable `myrmidon-{domain}-{role}`, AckWait 15 min, MaxDeliver 3 (ADR-013) |
+| `hi.myrmidon.{type}.{task_id}` | Agamemnon | — (legacy) | Two-token legacy form; dual-published for one release, then removed |
+| `hi.tasks.{team_id}.{task_id}.{verb}` | Workers, Agamemnon | Agamemnon, Odysseus, Argus | State facts; verbs `started`/`updated`/`completed`/`failed` (`started` added by ADR-013) |
+| `hi.pipeline.interview.{intake_id}.{question\|answer}.{q_id}` | Research myrmidons ↔ Odysseus console | Console, interviewing worker | Interview relay; GitHub issue comments as fallback |
+| `hi.pipeline.epic.{epic_key}.registered` | Telemachy | Agamemnon (durable `agamemnon-epics`) | Epic trigger; `epic_key = {repo_slug}-{issue_number}` |
+| `hi.pipeline.>` | Odysseus, Argus, Hermes, Telemachy | Multiple (pub/sub) | Fan-out; Hermes bridges external events here; stream `homeric-pipeline` |
+| `hi.research.{id}` | Nestor | Nestor, console | Research status/compat subject (dispatch rides `hi.myrmidon.research.*`) |
 | `hi.agents.>` | Agamemnon, Hermes | Argus (pub/sub) | Agent lifecycle events |
-| `hi.tasks.>` | Agamemnon | Odysseus, Argus (pub/sub) | Task state changes |
+| `hi.logs.myrmidon.{domain}.{role}.{agent_id}` | Workers | Argus/Loki, Odysseus | Structured worker logs; payloads carry `exec_host` |
 | `hi.logs.>` | All components | Argus/Loki, Odysseus (pub) | Structured log forwarding |
 
 ---

--- a/tools/odysseus-console.py
+++ b/tools/odysseus-console.py
@@ -1,26 +1,43 @@
 #!/usr/bin/env python3
-"""Odysseus Console — Real-time NATS event viewer for HomericIntelligence.
+"""Odysseus Console — NATS event viewer + pipeline entry point for HomericIntelligence.
 
-Subscribes to all hi.* NATS subjects and prints events as they arrive,
-providing real-time visibility into the distributed agent mesh.
+Watch mode (default) subscribes to all hi.* NATS subjects and prints events as
+they arrive, providing real-time visibility into the distributed agent mesh.
+Interview questions published by research myrmidons (ADR-013 §5) are surfaced
+as interactive prompts; answers are published back on the answer subject.
+
+Submit mode registers a new high-level task with ProjectNestor
+(POST /v1/research) and then drops into watch mode so the interview can begin.
 
 Handles NATS connection gracefully: shows [DISCONNECTED] / [CONNECTED] state
 instead of stack traces. Retries indefinitely until Ctrl+C.
 
 Usage:
-    NATS_URL=nats://100.92.173.32:4222 python3 tools/odysseus-console.py
+    python3 tools/odysseus-console.py                       # watch mode
+    python3 tools/odysseus-console.py submit "IDEA TEXT" \
+        [--context TEXT] [--repo OWNER/NAME] [--no-watch]
 
 Environment:
-    NATS_URL    NATS server URL (default: nats://localhost:4222)
-    SUBJECTS    Comma-separated subjects (default: all hi.* subjects)
+    NATS_URL            NATS server URL (default: nats://localhost:4222)
+    NATS_CLIENT_TOKEN   Client auth token (ADR-009); omit if server has no auth
+    NATS_CA_FILE        CA bundle for TLS verification (ADR-008); required for
+                        nats+tls:// / tls:// URLs with a private CA
+    SUBJECTS            Comma-separated subjects (default: all hi.* subjects)
+    NESTOR_URL          Nestor base URL (default: http://localhost:8081)
+    NESTOR_API_KEY      Bearer token for Nestor, if configured
 """
 
+import argparse
 import asyncio
 import json
 import logging
 import os
 import signal
+import ssl
 import sys
+import urllib.error
+import urllib.request
+import uuid
 from datetime import datetime, timezone
 
 # Suppress nats-py's internal traceback logging (it prints full stack traces
@@ -28,17 +45,19 @@ from datetime import datetime, timezone
 logging.getLogger("nats").setLevel(logging.CRITICAL)
 
 NATS_URL = os.environ.get("NATS_URL", "nats://localhost:4222")
+NESTOR_URL = os.environ.get("NESTOR_URL", "http://localhost:8081")
 DEFAULT_SUBJECTS = [
     "hi.pipeline.>",
     "hi.tasks.>",
     "hi.agents.>",
     "hi.logs.>",
     "hi.research.>",
-    # 'hi.myrmidon.>' was here but ADR-005's NATS subject schema does not
-    # define an 'hi.myrmidon' namespace — the subscription silently
-    # received nothing (issue #211). Re-add only when a real subject is
-    # documented in ADR-005.
+    # Role-addressed dispatch queues (hi.myrmidon.{domain}.{role}.task.>)
+    # are documented in ADR-013, resolving the issue #211 removal.
+    "hi.myrmidon.>",
 ]
+
+INTERVIEW_PREFIX = "hi.pipeline.interview."
 
 RETRY_INTERVAL = 3  # seconds between initial connection attempts
 
@@ -125,7 +144,135 @@ def clear_inline():
         _last_was_inline = False
 
 
-async def main() -> None:
+def envelope(**fields) -> dict:
+    """ADR-013 §3 payload envelope."""
+    return {
+        "schema": "hi/v1",
+        "ts": datetime.now(timezone.utc).isoformat(),
+        "msg_id": str(uuid.uuid4()),
+        **fields,
+    }
+
+
+def nats_connect_kwargs() -> dict:
+    """Auth/TLS connect options per ADR-008/009: token + CA-verified TLS."""
+    kwargs = {}
+    token = os.environ.get("NATS_CLIENT_TOKEN")
+    if token:
+        kwargs["token"] = token
+    ca_file = os.environ.get("NATS_CA_FILE")
+    if ca_file:
+        ctx = ssl.create_default_context(cafile=ca_file)
+        kwargs["tls"] = ctx
+    return kwargs
+
+
+# ── Interview panel ─────────────────────────────────────────────────────────
+
+
+class InterviewPanel:
+    """Surfaces interview questions as prompts and publishes answers.
+
+    Questions arrive on hi.pipeline.interview.{intake_id}.question.{q_id};
+    answers go out on hi.pipeline.interview.{intake_id}.answer.{q_id}
+    (ADR-013 §5). Questions are queued so events keep streaming while the
+    user types; one question is prompted at a time.
+    """
+
+    def __init__(self, nc):
+        self._nc = nc
+        self._queue: asyncio.Queue = asyncio.Queue()
+        self._task = asyncio.create_task(self._prompt_loop())
+
+    @staticmethod
+    def parse_question_subject(subject: str):
+        """Return (intake_id, q_id) for a question subject, else None."""
+        if not subject.startswith(INTERVIEW_PREFIX):
+            return None
+        parts = subject.split(".")
+        # hi.pipeline.interview.{intake_id}.question.{q_id}
+        if len(parts) == 6 and parts[4] == "question":
+            return parts[3], parts[5]
+        return None
+
+    def on_question(self, subject: str, data: bytes) -> bool:
+        """Queue a question event. Returns True if it was an interview question."""
+        parsed = self.parse_question_subject(subject)
+        if parsed is None:
+            return False
+        try:
+            payload = json.loads(data.decode())
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            payload = {}
+        if payload.get("status") == "assumed":
+            # Worker proceeded with assumptions — informational, no prompt.
+            return False
+        self._queue.put_nowait((parsed[0], parsed[1], payload))
+        return True
+
+    async def _prompt_loop(self):
+        loop = asyncio.get_running_loop()
+        while True:
+            intake_id, q_id, payload = await self._queue.get()
+            question = payload.get("question", "(no question text)")
+            clear_inline()
+            print(f"\n{YELLOW}{BOLD}❓ INTERVIEW [{intake_id}/{q_id}]{RESET}")
+            print(f"{YELLOW}{question}{RESET}")
+            try:
+                answer = await loop.run_in_executor(None, input, f"{BOLD}answer> {RESET}")
+            except (EOFError, RuntimeError):
+                print(f"{DIM}stdin unavailable — question left for the GitHub fallback{RESET}")
+                continue
+            answer = answer.strip()
+            if not answer:
+                print(f"{DIM}empty answer skipped — question left for the GitHub fallback{RESET}")
+                continue
+            subject = f"{INTERVIEW_PREFIX}{intake_id}.answer.{q_id}"
+            body = envelope(
+                intake_id=intake_id, q_id=q_id, answer=answer, channel="console"
+            )
+            try:
+                await self._nc.publish(subject, json.dumps(body).encode())
+                await self._nc.flush(timeout=5)
+                print(f"{GREEN}✓ answer published{RESET} {DIM}{subject}{RESET}\n")
+            except Exception as e:  # noqa: BLE001 - console must not crash on publish
+                print(f"{RED}✗ failed to publish answer: {e}{RESET}\n")
+
+    def stop(self):
+        self._task.cancel()
+
+
+# ── Submit mode ─────────────────────────────────────────────────────────────
+
+
+def submit_research(idea: str, context: str = "", repo: str = "") -> dict:
+    """POST the idea to Nestor's intake endpoint and return its response."""
+    body = {"idea": idea}
+    if context:
+        body["context"] = context
+    if repo:
+        body["repo"] = repo
+
+    req = urllib.request.Request(
+        f"{NESTOR_URL.rstrip('/')}/v1/research",
+        data=json.dumps(body).encode(),
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    api_key = os.environ.get("NESTOR_API_KEY")
+    if api_key:
+        req.add_header("Authorization", f"Bearer {api_key}")
+
+    ca_file = os.environ.get("NATS_CA_FILE")
+    ctx = ssl.create_default_context(cafile=ca_file) if ca_file else None
+    with urllib.request.urlopen(req, timeout=10, context=ctx) as resp:
+        return json.loads(resp.read().decode())
+
+
+# ── Watch mode ──────────────────────────────────────────────────────────────
+
+
+async def watch() -> None:
     try:
         import nats as nats_mod
     except ImportError:
@@ -163,14 +310,11 @@ async def main() -> None:
     async def on_closed():
         print_status("disconnected", "Connection closed", inline=True)
 
-    async def on_message(msg):
-        clear_inline()
-        print(format_event(msg.subject, msg.data), flush=True)
-
     # Outer loop: handles initial connection failures.
     # Once connected, nats-py handles reconnection internally via callbacks.
     while not stop.is_set():
         nc = None
+        panel = None
         try:
             print_status("reconnecting", f"Connecting to {NATS_URL}...", inline=True)
 
@@ -185,11 +329,19 @@ async def main() -> None:
                     closed_cb=on_closed,
                     allow_reconnect=False,
                     connect_timeout=3,
+                    **nats_connect_kwargs(),
                 ),
                 timeout=5,
             )
 
             print_status("connected", NATS_URL)
+
+            panel = InterviewPanel(nc)
+
+            async def on_message(msg):
+                clear_inline()
+                print(format_event(msg.subject, msg.data), flush=True)
+                panel.on_question(msg.subject, msg.data)
 
             subs = []
             for subject in subjects:
@@ -235,6 +387,9 @@ async def main() -> None:
                     await nc.close()
                 except Exception:
                     pass
+        finally:
+            if panel is not None:
+                panel.stop()
 
         # Wait before retrying, but stop immediately on Ctrl+C
         if not stop.is_set():
@@ -248,8 +403,52 @@ async def main() -> None:
     print(f"\n{DIM}Disconnected.{RESET}")
 
 
+def parse_args(argv):
+    parser = argparse.ArgumentParser(
+        prog="odysseus-console",
+        description="NATS event viewer + pipeline entry point for HomericIntelligence.",
+    )
+    sub = parser.add_subparsers(dest="command")
+
+    p_submit = sub.add_parser(
+        "submit", help="Submit a high-level task to Nestor (POST /v1/research)"
+    )
+    p_submit.add_argument("idea", help="High-level task / idea text")
+    p_submit.add_argument("--context", default="", help="Extra context for the researcher")
+    p_submit.add_argument("--repo", default="", help="Target repo (OWNER/NAME), if known")
+    p_submit.add_argument(
+        "--no-watch",
+        action="store_true",
+        help="Exit after submitting instead of dropping into watch mode",
+    )
+
+    return parser.parse_args(argv)
+
+
+def main() -> None:
+    args = parse_args(sys.argv[1:])
+
+    if args.command == "submit":
+        try:
+            result = submit_research(args.idea, args.context, args.repo)
+        except urllib.error.HTTPError as e:
+            print(f"{RED}✗ Nestor rejected the submission: HTTP {e.code}{RESET}", file=sys.stderr)
+            sys.exit(1)
+        except urllib.error.URLError as e:
+            print(f"{RED}✗ Nestor unreachable at {NESTOR_URL}: {e.reason}{RESET}", file=sys.stderr)
+            sys.exit(1)
+        research_id = result.get("id", "?")
+        print(f"{GREEN}✓ submitted{RESET} research_id={BOLD}{research_id}{RESET}")
+        print(f"{DIM}dispatch: hi.myrmidon.research.chief-architect.task.{research_id}{RESET}")
+        if args.no_watch:
+            return
+        print(f"{DIM}Entering watch mode for the interview... (Ctrl+C to quit){RESET}\n")
+
+    asyncio.run(watch())
+
+
 if __name__ == "__main__":
     try:
-        asyncio.run(main())
+        main()
     except KeyboardInterrupt:
         sys.exit(0)


### PR DESCRIPTION
## Summary

First PR of the HMAS mesh pipeline slice (design docs + user entry point). Defines the wire contracts every other repo's PR implements.

- **ADR-013** (`docs/adr/013-hmas-mesh-wire-contracts.md`): role-addressed dispatch subjects `hi.myrmidon.{domain}.{role}.task.{task_id}` with per-(domain,role) durable pull consumers (AckWait 15 min, MaxDeliver 3, 5-min heartbeats); `started` verb added to task state events (claim = assignment record); `hi/v1` payload envelope; task sizing (~1h soft) with **overrun checkpoint/split re-adjustment** via `POST /v1/tasks/:id/split` — leases detect worker death only, never task length; interview relay `hi.pipeline.interview.*` with GitHub-comment fallback; epic registration trigger `hi.pipeline.epic.{key}.registered`; event-vs-store ownership rule; extensible HMAS role taxonomy (roles by name, never level; haiku tier for junior roles).
- **architecture.md**: Pipeline Flow rewritten from a one-liner into the full 9-step HMAS sequence; new Task State Machine section (TaskStateMachine ↔ state:* labels mapping); NATS subject table updated; Nestor/Telemachy/worker-pool component contracts corrected.
- **odysseus-console.py**: new `submit` command (POST /v1/research to Nestor) as the user entry point; interactive interview panel (prompts on question events, publishes answers, mirrors ADR-013 fallback ladder); `hi.myrmidon.>` subscription re-added (resolves the #211 removal — the namespace is now documented); NATS token/TLS support per ADR-008/009.

## Test plan

- [x] `python3 -m py_compile` + smoke test (subject parsing, argparse, envelope)
- [x] `scripts/check-doc-field-drift.sh` OK
- [x] `e2e/tools/gen_test_matrix.py --validate/--check` OK
- [x] markdownlint clean on changed docs
- [ ] Live slice run once the remaining repos land (Hephaestus mesh pkg → AchaeanFleet vessel → Myrmidons manifests → Agamemnon → Telemachy → Nestor)

🤖 Generated with [Claude Code](https://claude.com/claude-code)