### PR TITLE
fix(e2e): correct test-matrix totals 37->38 and wire the unit suite into CI (#375)

### DIFF
--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -199,8 +199,10 @@ jobs:
           set -euo pipefail
           # Executes the contract suite (totals, validate/check modes, print
           # mode). Previously unwired, so a stale hardcoded total (37 vs the
-          # live 38) went undetected — see #375.
-          python3 -m pytest e2e/tools/test_gen_test_matrix.py -q
+          # live 38) went undetected — see #375. Uses stdlib unittest (the test
+          # module is unittest-based) so it needs no pip install on the runner.
+          # Run from the tools dir since e2e/tools is not an importable package.
+          cd e2e/tools && python3 -m unittest test_gen_test_matrix -v
 
       - name: Install just
         uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3  # v4

--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -194,6 +194,14 @@ jobs:
           python3 e2e/tools/gen_test_matrix.py --validate
           python3 e2e/tools/gen_test_matrix.py --check
 
+      - name: Run e2e test-matrix generator unit tests
+        run: |
+          set -euo pipefail
+          # Executes the contract suite (totals, validate/check modes, print
+          # mode). Previously unwired, so a stale hardcoded total (37 vs the
+          # live 38) went undetected — see #375.
+          python3 -m pytest e2e/tools/test_gen_test_matrix.py -q
+
       - name: Install just
         uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3  # v4
 

--- a/e2e/tools/test_gen_test_matrix.py
+++ b/e2e/tools/test_gen_test_matrix.py
@@ -113,7 +113,7 @@ class TestSuiteContract(unittest.TestCase):
     def test_known_totals(self) -> None:
         rows = g.all_rows()
         all_ids = sorted({i for r in rows for i in r["ids"]})
-        self.assertEqual(len(rows), 37)
+        self.assertEqual(len(rows), 38)
         self.assertEqual(len(all_ids), 65)
         self.assertEqual(sum(1 for r in rows if r["topology"] == "T4"), 7)
 
@@ -157,7 +157,7 @@ class TestCheckMode(unittest.TestCase):
             rc = g.main(["--print"])
         self.assertEqual(rc, 0)
         self.assertIn("E2E Test Coverage Matrix", buf.getvalue())
-        self.assertIn("37 tests", buf.getvalue())
+        self.assertIn("38 tests", buf.getvalue())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Fixes CRITICAL audit finding **#375** — the only real unit suite (`e2e/tools/test_gen_test_matrix.py`) was RED and unwired from CI.

**The bug:** the contract test hardcoded `len(rows) == 37` (line 116) and `"37 tests"` (line 160), but the live scenario suite has **38**. Executing the suite yielded `2 failed, 17 passed`. It went unnoticed because **no workflow ran this test** — CI only ran `gen_test_matrix.py --validate --check` (which validates the generated README matrix, not the unit tests).

**Fix (two parts, matching the issue's acceptance):**
1. **Correct the stale totals** `37 → 38` in both spots. The generated matrix already correctly reports "38 tests, 65 unique scenario IDs, 7 T4-only" — only the test's hardcoded `37` was stale (`all_ids`=65 and `T4`=7 still matched and are unchanged). Suite is now **19 passed**.
2. **Wire the suite into CI:** added a `Run e2e test-matrix generator unit tests` step in `.github/workflows/_required.yml` right after the existing matrix-validation step, so future total drift is caught by a required check.

## Verification
```
$ python3 -m pytest e2e/tools/test_gen_test_matrix.py -q
...................                                                      [100%]
19 passed in 0.03s
```
(Before: `2 failed, 17 passed`.) YAML validated with `yaml.safe_load`.

Closes #375.

🤖 Generated with [Claude Code](https://claude.com/claude-code)