### PR TITLE
fix(install): exit non-zero when checks fail instead of always reporting success (#372)

### DIFF
--- a/.github/workflows/install-test.yml
+++ b/.github/workflows/install-test.yml
@@ -117,10 +117,21 @@ jobs:
           echo "exit_code=${PIPESTATUS[0]}" >> "$GITHUB_OUTPUT"
 
       - name: Assert run 1 exit 0
+        env:
+          RUN1_EXIT: ${{ steps.run1.outputs.exit_code }}
         run: |
+          set -euo pipefail
+          # Assert on the captured exit code, not just a log grep. install.sh
+          # now exits non-zero when any check fails (issue #372); the previous
+          # 'Install complete' grep always matched because that string printed
+          # unconditionally, making a failed install structurally invisible.
+          if [[ "${RUN1_EXIT}" != "0" ]]; then
+            echo "ERROR: install.sh --install exited ${RUN1_EXIT} (expected 0)"
+            exit 1
+          fi
           grep -q "Install complete" /tmp/install-${{ matrix.os }}-run1.log || \
             { echo "ERROR: 'Install complete' not found in run 1 output"; exit 1; }
-          echo "Run 1: OK"
+          echo "Run 1: OK (exit ${RUN1_EXIT})"
 
       - name: Run 2 — idempotency check
         run: |


### PR DESCRIPTION
## Summary

`install.sh` reported success even when checks failed. At the final summary it
unconditionally printed `All phases passed.` and exited with the last `echo`'s
status (0), so a run with failed checks still exited 0 — CI could not detect the
failure. This is the CRITICAL audit finding #372 (violates the repo's own
`docs/runbooks/no-silent-failures.md`).

## Fixes

- **`install.sh`** — Gate the final summary on `$_FAIL`. When `$_FAIL > 0`, print
  a red `Install FAILED — N check(s) did not pass.` and `exit 1`; otherwise print
  the success message and `exit 0`. Explicit exits stop a trailing `echo` from
  resetting the status.
- **`scripts/install/user-install.sh`** and **`scripts/install/root-install.sh`** —
  Both *source* the phase scripts, so a `check_fail` only increments `_FAIL` and
  never sets the subprocess exit status. The subprocess exited 0 on a failed
  phase, and install.sh's `if bash …-install.sh; then` wrapper reported success.
  Added an `exit 1` gate on `$_FAIL` at the end of each so a failing phase
  propagates a non-zero exit to install.sh.
- **`.github/workflows/install-test.yml`** — The "Assert run 1 exit 0" step only
  grepped for `Install complete` (which always printed) and ignored the captured
  `exit_code`, making a failed install structurally invisible. It now asserts
  `steps.run1.outputs.exit_code == 0` (routed through an `env:` var — trusted
  internal step output, no untrusted `github.event.*` input), then keeps the log
  grep as a secondary check.

## Verification

```
$ bash -n install.sh && bash -n scripts/install/user-install.sh && bash -n scripts/install/root-install.sh
install.sh: OK
user-install.sh: OK
root-install.sh: OK
```

`shellcheck` on all three scripts: no NEW warnings. Remaining SC2317
(unreachable in the inline-helper fallback block) and SC1091 (sourced files not
followed) are pre-existing and unrelated to this change.

Gate control flow demonstrated by driving the exact summary block:

```
All phases passed.
gate exit code with _FAIL=0 -> 0
  x Failed checks:  2
Install FAILED — 2 check(s) did not pass.
gate exit code with _FAIL=2 -> 1
```

Subprocess gate:

```
sub _FAIL=0 -> 0
sub _FAIL=1 -> 1
```

### Diff of the install.sh gate

```diff
 [[ $_SKIP -gt 0 ]] && echo -e "  ${DIM}–${NC} Skipped:        ${_SKIP}"
-echo -e "${GREEN}All phases passed.${NC}"
+
+# Gate the final result on the failure counter. A trailing `echo` exits 0, so
+# without this the script always reported success — a broken install would
+# still exit 0 and CI could not detect it (issue #372).
+if [[ $_FAIL -gt 0 ]]; then
+    echo -e "${RED}Install FAILED — ${_FAIL} check(s) did not pass.${NC}" >&2
+    exit 1
+fi
+echo -e "${GREEN}All phases passed.${NC}"
+exit 0
```

Closes #372

🤖 Generated with [Claude Code](https://claude.com/claude-code)