### PR TITLE
chore(github): sync committed repo-ruleset-active.json to live ruleset (0 reviews, 11 checks)

### DIFF
--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -339,17 +339,28 @@ jobs:
           find .github/workflows -name "*.yml" | xargs check-jsonschema \
             --schemafile https://json.schemastore.org/github-workflow
 
-      - name: Validate ruleset JSON and require >=1 approving review
+      - name: Validate ruleset JSON and review-count policy
         run: |
-          for f in configs/github/org-ruleset.json \
-                   configs/github/org-ruleset-active.json \
-                   configs/github/repo-ruleset.json \
-                   configs/github/repo-ruleset-active.json; do
+          # Policy (#394): merges gate on REQUIRED STATUS CHECKS, not on required
+          # reviewers. The repo-scoped rulesets require 0 approvals (matching the
+          # live `homeric-main-baseline` ruleset — the only ruleset enforced on
+          # this repo). Org-scoped rulesets still assert >=1 (org policy is out of
+          # scope here). We validate every file is well-formed JSON and carries a
+          # numeric required_approving_review_count, and hold the intended count
+          # per scope so drift is still caught in both directions.
+          declare -A expected_min_reviews=(
+            [configs/github/org-ruleset.json]=1
+            [configs/github/org-ruleset-active.json]=1
+            [configs/github/repo-ruleset.json]=0
+            [configs/github/repo-ruleset-active.json]=0
+          )
+          for f in "${!expected_min_reviews[@]}"; do
             jq . "$f" > /dev/null
             count=$(jq 'first(.rules[] | select(.type=="pull_request")
                        | .parameters.required_approving_review_count)' "$f")
-            if [ -z "$count" ] || [ "$count" -lt 1 ]; then
-              echo "ERROR: $f has required_approving_review_count=$count (must be >=1)" >&2
+            want=${expected_min_reviews[$f]}
+            if [ -z "$count" ] || [ "$count" != "$want" ]; then
+              echo "ERROR: $f has required_approving_review_count=$count (expected $want)" >&2
               exit 1
             fi
             echo "$f OK (required_approving_review_count=$count)"

--- a/configs/github/repo-ruleset-active.json
+++ b/configs/github/repo-ruleset-active.json
@@ -14,28 +14,37 @@
     {
       "type": "pull_request",
       "parameters": {
-        "required_approving_review_count": 1,
+        "required_approving_review_count": 0,
         "dismiss_stale_reviews_on_push": false,
+        "required_reviewers": [],
         "require_code_owner_review": false,
+        "dismissal_restriction": { "enabled": false, "allowed_actors": [] },
         "require_last_push_approval": false,
-        "required_review_thread_resolution": true
+        "required_review_thread_resolution": true,
+        "allowed_merge_methods": ["merge", "squash", "rebase"]
       }
     },
     {
       "type": "required_status_checks",
       "parameters": {
         "strict_required_status_checks_policy": false,
+        "do_not_enforce_on_create": false,
         "required_status_checks": [
-          { "context": "lint",                    "integration_id": 15368 },
-          { "context": "unit-tests",              "integration_id": 15368 },
-          { "context": "integration-tests",       "integration_id": 15368 },
-          { "context": "security/dependency-scan","integration_id": 15368 },
-          { "context": "security/secrets-scan",   "integration_id": 15368 },
-          { "context": "build",                   "integration_id": 15368 },
-          { "context": "schema-validation",       "integration_id": 15368 },
-          { "context": "deps/version-sync",       "integration_id": 15368 }
+          { "context": "lint",                     "integration_id": 15368 },
+          { "context": "unit-tests",               "integration_id": 15368 },
+          { "context": "integration-tests",        "integration_id": 15368 },
+          { "context": "security/dependency-scan", "integration_id": 15368 },
+          { "context": "security/secrets-scan",    "integration_id": 15368 },
+          { "context": "build",                    "integration_id": 15368 },
+          { "context": "schema-validation",        "integration_id": 15368 },
+          { "context": "deps/version-sync",        "integration_id": 15368 },
+          { "context": "test",                     "integration_id": 15368 },
+          { "context": "install",                  "integration_id": 15368 },
+          { "context": "release",                  "integration_id": 15368 }
         ]
       }
-    }
+    },
+    { "type": "required_linear_history" },
+    { "type": "non_fast_forward" }
   ]
 }

--- a/configs/github/repo-ruleset.json
+++ b/configs/github/repo-ruleset.json
@@ -14,7 +14,7 @@
     {
       "type": "pull_request",
       "parameters": {
-        "required_approving_review_count": 1,
+        "required_approving_review_count": 0,
         "dismiss_stale_reviews_on_push": false,
         "require_code_owner_review": false,
         "require_last_push_approval": false,


### PR DESCRIPTION
## Summary

Reconciles the committed GitHub ruleset config + its CI guard with the **live** `homeric-main-baseline` ruleset (the only ruleset enforced on this repo), and with the stated merge policy: **merges gate on required status checks, not on required reviewers.**

### The drift this fixes
The committed `repo-ruleset-active.json` said `required_approving_review_count: 1` and the `schema-validation` CI guard hardcoded `>= 1` for all ruleset files — but the **live repo ruleset requires 0 approvals**. This drift caused a real misdiagnosis (a false "these PRs need approval" conclusion) even though PRs auto-merge with no review.

### Changes
1. `repo-ruleset-active.json` — synced field-by-field to live: `required_approving_review_count` 1→**0**, checks 8→**11** (+`test`, `install`, `release`), added live `allowed_merge_methods`/`required_reviewers`/`dismissal_restriction`, and the `required_linear_history` + `non_fast_forward` rule types.
2. `repo-ruleset.json` — `required_approving_review_count` 1→**0** (1-line change; matches live + the -active file).
3. `.github/workflows/_required.yml` — the review-count guard no longer hardcodes `>=1`; it now asserts the **intended per-scope count** (repo rulesets = 0, org rulesets = 1), so drift is still caught in both directions but with the correct checks-only policy for the repo scope.

### Scope note
Org-scoped rulesets (`org-ruleset*.json`) are **left at `1`** — org policy is out of scope for this repo-level reconciliation. Only the repo rulesets (which match the live enforced ruleset) are set to 0.

### Verification
- Every value in `repo-ruleset-active.json` diffed against the live `gh api .../rulesets/15556483` response.
- The updated guard simulated locally against all 4 files → PASS (repo=0, org=1).
- JSON + workflow YAML validated.

Config/CI-only. This is documentation + guard catching up to the live reality — no change to the live ruleset itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)