### PR TITLE
fix(e2e): disable Grafana anonymous viewer access (#206)

### DIFF
--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -151,10 +151,10 @@ services:
     ports:
       - "3001:3000"
     environment:
-      # e2e-only: anonymous Viewer for the local demo stack (port 3001, no prod data).
-      # Never enable this in a prod-facing stack; see docs/deployment.md WARNING and #179.
-      GF_AUTH_ANONYMOUS_ENABLED: "true"
-      GF_AUTH_ANONYMOUS_ORG_ROLE: Viewer
+      # Anonymous access is DISABLED (#206): unauthenticated read access to
+      # observability data (metrics/traces/logs) can leak operational intel even
+      # in e2e. Log in with admin / $GF_E2E_ADMIN_PASSWORD (default below).
+      GF_AUTH_ANONYMOUS_ENABLED: "false"
       GF_SECURITY_ADMIN_PASSWORD: ${GF_E2E_ADMIN_PASSWORD:-e2e-not-for-prod}
       GF_SECURITY_ALLOW_EMBEDDING: "true"
       GF_ANALYTICS_REPORTING_ENABLED: "false"


### PR DESCRIPTION
## Summary

Fixes MINOR audit finding **#206** (§8 Security). `docker-compose.e2e.yml` enabled `GF_AUTH_ANONYMOUS_ENABLED=true` with `Viewer` role — unauthenticated read access to observability data (metrics/traces/logs), which leaks operational intelligence even in an e2e stack.

**Fix:** `GF_AUTH_ANONYMOUS_ENABLED: "false"` (removed the now-moot `GF_AUTH_ANONYMOUS_ORG_ROLE`). Access is via `admin` / `$GF_E2E_ADMIN_PASSWORD` (default unchanged).

## Verification
- YAML validated with `yaml.safe_load`.
- Confirmed the e2e health checks (`run-hermes-hub-e2e.sh`, `run-crosshost-e2e.sh`) only curl Grafana's **unauthenticated** `/api/health` endpoint (lines 170-175 / 164-169) — disabling anonymous Viewer does not break them.

Single-file, config-only. Closes #206.

🤖 Generated with [Claude Code](https://claude.com/claude-code)