### PR TITLE
chore(settings): swap hephaestus plugin → Athena marketplace

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,35 @@
 {
   "enabledPlugins": {
-    "hephaestus@ProjectHephaestus": true
+    "advise@Athena": true,
+    "brainstorm@Athena": true,
+    "code-review@Athena": true,
+    "create-reusable-utilities@Athena": true,
+    "finish-branch@Athena": true,
+    "git-worktrees@Athena": true,
+    "github-actions-python-cicd@Athena": true,
+    "learn@Athena": true,
+    "myrmidon-swarm@Athena": true,
+    "python-repo-modernization@Athena": true,
+    "repo-analyze@Athena": true,
+    "repo-analyze-full@Athena": true,
+    "repo-analyze-quick@Athena": true,
+    "repo-analyze-quick-full@Athena": true,
+    "repo-analyze-strict@Athena": true,
+    "repo-analyze-strict-full@Athena": true,
+    "review-pr-strict@Athena": true,
+    "skill-advisor@Athena": true,
+    "systematic-debugging@Athena": true,
+    "test-driven-development@Athena": true,
+    "tidy@Athena": true,
+    "verification@Athena": true,
+    "worktree-cleanup@Athena": true
+  },
+  "extraKnownMarketplaces": {
+    "Athena": {
+      "source": {
+        "source": "git",
+        "url": "https://github.com/HomericIntelligence/Athena.git"
+      }
+    }
   }
 }


### PR DESCRIPTION
## Summary
Migrate `.claude/settings.json` off the retired `hephaestus@ProjectHephaestus` plugin. The `hephaestus` skills were carved out to `HomericIntelligence/Athena` as 23 per-skill plugins.

## Changes
- Remove `hephaestus@ProjectHephaestus` from `enabledPlugins`.
- Enable the 23 `<skill>@Athena` per-skill plugins.
- Register the `Athena` marketplace under `extraKnownMarketplaces` (git source `https://github.com/HomericIntelligence/Athena.git`).
- Preserve all other settings (the file previously held only `enabledPlugins`).

## Verification
- Valid JSON; `hephaestus` fully removed; exactly 23 `@Athena` keys matching the expected set; Athena marketplace present.

Closes #400