### PR TITLE
fix(ci): salt agamemnon image build cache scope to clear stale openssl layer

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -108,5 +108,11 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha,scope=${{ matrix.component }}
-          cache-to: type=gha,mode=max,scope=${{ matrix.component }}
+          # Cache scope is salted with -r2 to invalidate the pre-openssl-fix
+          # layer cache. The old agamemnon scope snapshotted a `conan install`
+          # layer whose generated CMakeDeps referenced a stale openssl package
+          # libdir, so restoring it made `cmake` configure abort with
+          # "Library 'ssl' not found" even after conanfile.py added openssl/3.6.2
+          # (verified: a from-scratch build with no conan cache links cleanly).
+          cache-from: type=gha,scope=${{ matrix.component }}-r2
+          cache-to: type=gha,mode=max,scope=${{ matrix.component }}-r2


### PR DESCRIPTION
## Problem
The `build (agamemnon, ...)` leg of `build-images.yml` fails at cmake configure with `Library 'ssl' not found in package` — even after ProjectAgamemnon **#448** added `openssl/3.6.2` as an explicit Conan requirement and Odysseus **#406** bumped the pin to it. Only the agamemnon component fails; nestor/hermes/argus build fine.

## Root cause (verified locally)
The buildx GHA layer cache (`cache-from: type=gha,scope=agamemnon`) snapshotted a **pre-fix `conan install` layer** whose generated CMakeDeps (`OpenSSL-Target-release.cmake`) reference an openssl package libdir from the *old transitive-via-libcurl* resolution. Restoring that layer makes `cmake` look for a `libssl` the fresh `openssl/3.6.2` package lays out elsewhere → `ssl not found`.

**Proof:** I reproduced both cases locally on the exact Dockerfile:
- With the conan cache warm → fails `Library 'ssl' not found` (matches CI).
- From scratch, no conan cache → openssl/3.6.2 builds and `ProjectAgamemnon_server` links cleanly (`[81/81] Linking CXX executable`, `Configuring done`).

So the Dockerfile + conanfile are correct; the CI failure is a poisoned cache.

## Fix
Salt the cache scope (`${{ matrix.component }}` → `${{ matrix.component }}-r2`) so the stale layer is unreachable and CI repopulates from a clean conan resolution. Uniform across components (only agamemnon was poisoned; harmless for the rest).

Unblocks the container-publish pipeline for the agamemnon image (#201 chain).