### PR TITLE
[Fix] Unbreak red main: argus-exporter GHCR 403, Nestor conan profile, stale install-test clone cache

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -8,6 +8,8 @@ name: Build Images
 # Promotion:  pull_request -> BUILD ONLY (no push; validates images build)
 #             push to main -> build + push :sha-<short> and :latest
 #             push tag v*  -> build + push :<semver> tags
+#             matrix entries with publish: false are always BUILD ONLY
+#             (their canonical image is published by the component's own repo)
 #
 # The component build contexts live in git submodules, so checkout uses
 # submodules: recursive. hello-myrmidon is intentionally OMITTED: its context
@@ -48,24 +50,36 @@ jobs:
           - component: agamemnon
             context: control/ProjectAgamemnon
             file: control/ProjectAgamemnon/Dockerfile
+            publish: true
           # nestor: research / ideation / handoff to Agamemnon
           - component: nestor
             context: control/ProjectNestor
             file: control/ProjectNestor/Dockerfile
+            publish: true
           # hermes: NATS event bridge (compose uses ${HERMES_DIR} ->
           # infrastructure/ProjectHermes)
           - component: hermes
             context: infrastructure/ProjectHermes
             file: infrastructure/ProjectHermes/Dockerfile
+            publish: true
           # argus-exporter: Prometheus exporter. Its Dockerfile (COPY exporter.py .)
           # needs the exporter/ dir as build context, while the Dockerfile itself
           # lives at repo root under e2e/ (compose references it as
           # dockerfile: ../../../e2e/Dockerfile.argus-exporter, relative to the
           # context). In Actions, `context` and `file` are both repo-root-relative,
           # so file: e2e/Dockerfile.argus-exporter resolves correctly.
+          #
+          # publish: false — BUILD-VALIDATE ONLY. The canonical
+          # ghcr.io/homericintelligence/argus-exporter package is created and
+          # published by ProjectArgus's own publish-exporter-image.yml, so it
+          # is access-scoped to that repo: a repo-scoped GITHUB_TOKEN from
+          # Odysseus gets "403 Forbidden" on blob push (this broke every main
+          # push of this workflow). Pushing the same :latest from two repos
+          # would also race; ProjectArgus stays the single publisher.
           - component: argus-exporter
             context: infrastructure/ProjectArgus/exporter
             file: e2e/Dockerfile.argus-exporter
+            publish: false
     steps:
       - name: Checkout (with submodule contexts)
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
@@ -105,7 +119,7 @@ jobs:
         with:
           context: ${{ matrix.context }}
           file: ${{ matrix.file }}
-          push: ${{ github.event_name != 'pull_request' }}
+          push: ${{ github.event_name != 'pull_request' && matrix.publish }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           # Cache scope is salted with -r2 to invalidate the pre-openssl-fix

--- a/.github/workflows/install-test.yml
+++ b/.github/workflows/install-test.yml
@@ -84,14 +84,27 @@ jobs:
 
       - name: Determine branch ref for container clone
         id: ref
+        # Ref/branch values are passed via env (not inline ${{ }} in the
+        # script body) so a crafted branch name cannot inject into the shell.
+        env:
+          INPUT_REF: ${{ inputs.ref }}
+          EVENT_NAME: ${{ github.event_name }}
+          HEAD_REF: ${{ github.head_ref }}
+          REF_NAME: ${{ github.ref_name }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PUSH_SHA: ${{ github.sha }}
         run: |
-          # workflow_dispatch override → manual ref
-          if [[ -n "${{ inputs.ref }}" ]]; then
-            echo "odysseus_ref=${{ inputs.ref }}" >> "$GITHUB_OUTPUT"
-          elif [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            echo "odysseus_ref=${{ github.head_ref }}" >> "$GITHUB_OUTPUT"
+          # workflow_dispatch override → manual ref (tip commit unknown → no
+          # pin; the container clones the ref's tip at image-build time)
+          if [[ -n "$INPUT_REF" ]]; then
+            echo "odysseus_ref=$INPUT_REF" >> "$GITHUB_OUTPUT"
+            echo "odysseus_commit=" >> "$GITHUB_OUTPUT"
+          elif [[ "$EVENT_NAME" == "pull_request" ]]; then
+            echo "odysseus_ref=$HEAD_REF" >> "$GITHUB_OUTPUT"
+            echo "odysseus_commit=$PR_HEAD_SHA" >> "$GITHUB_OUTPUT"
           else
-            echo "odysseus_ref=${{ github.ref_name }}" >> "$GITHUB_OUTPUT"
+            echo "odysseus_ref=$REF_NAME" >> "$GITHUB_OUTPUT"
+            echo "odysseus_commit=$PUSH_SHA" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Build install test image (cached)
@@ -99,7 +112,12 @@ jobs:
         with:
           context: tests/install
           file: tests/install/Dockerfile.${{ matrix.os }}
-          build-args: ODYSSEUS_REF=${{ steps.ref.outputs.odysseus_ref }}
+          # ODYSSEUS_COMMIT salts the baked-clone layer's cache key so a moved
+          # branch tip always rebuilds that layer — a branch-name-keyed cache
+          # previously served stale clones, testing pre-fix installer code.
+          build-args: |
+            ODYSSEUS_REF=${{ steps.ref.outputs.odysseus_ref }}
+            ODYSSEUS_COMMIT=${{ steps.ref.outputs.odysseus_commit }}
           load: true
           tags: odysseus-install-test-${{ matrix.os }}:ci
           # Cache keyed on OS + branch so PRs get warm cache from prior runs

--- a/justfile
+++ b/justfile
@@ -101,11 +101,14 @@ _build-agamemnon:
     pixi run cmake --build "{{BUILD_ROOT}}/Agamemnon"
 
 # Build Nestor (C++/CMake + Conan, debug preset)
+# Nestor renamed its profiles debug/release -> nestor-debug/nestor-release in
+# ProjectNestor#96 (portable-profiles fix); the other C++ submodules still
+# ship conan/profiles/debug.
 _build-nestor:
     @echo "--- Conan deps for control/ProjectNestor ---"
     cd control/ProjectNestor && pixi run conan install . \
         --output-folder="{{BUILD_ROOT}}/Nestor" \
-        --profile=conan/profiles/debug \
+        --profile=conan/profiles/nestor-debug \
         --build=missing
     @echo "--- Building control/ProjectNestor ---"
     @if [ -d "{{BUILD_ROOT}}/Nestor" ]; then rm -rf "{{BUILD_ROOT}}/Nestor/CMakeCache.txt" "{{BUILD_ROOT}}/Nestor/CMakeFiles" "{{BUILD_ROOT}}/Nestor/_deps"; fi

--- a/tests/install/Dockerfile.debian12
+++ b/tests/install/Dockerfile.debian12
@@ -12,9 +12,23 @@ WORKDIR /home/tester
 # Clone Odysseus from GitHub (clean, no submodule .git symlink issues)
 # --no-recurse-submodules: install.sh phase 30 handles submodule init
 ARG ODYSSEUS_REF=main
+# ODYSSEUS_COMMIT pins the exact commit baked into this layer AND salts the
+# layer-cache key: without it, a cached clone layer keyed only on the branch
+# NAME is reused after the branch moves, so the container silently tests a
+# stale tree (this made Install (ubuntu*) fail PR branches on long-fixed
+# installer bugs while a fresh debian12 rebuild of the same head passed).
+# Empty (e.g. local builds) = branch tip at build time, no cache-bust.
+ARG ODYSSEUS_COMMIT=""
 RUN git clone --depth 1 --branch "${ODYSSEUS_REF}" \
     --recurse-submodules --shallow-submodules \
     https://github.com/HomericIntelligence/Odysseus.git \
-    /home/tester/Projects/Odysseus
+    /home/tester/Projects/Odysseus \
+    && if [ -n "${ODYSSEUS_COMMIT}" ] \
+       && [ "$(git -C /home/tester/Projects/Odysseus rev-parse HEAD)" != "${ODYSSEUS_COMMIT}" ]; then \
+         git -C /home/tester/Projects/Odysseus fetch --depth 1 origin "${ODYSSEUS_COMMIT}" \
+         && git -C /home/tester/Projects/Odysseus checkout --detach "${ODYSSEUS_COMMIT}" \
+         && git -C /home/tester/Projects/Odysseus submodule update --init --recursive \
+              --depth 1 --recommend-shallow; \
+       fi
 
 WORKDIR /home/tester/Projects/Odysseus

--- a/tests/install/Dockerfile.ubuntu2204
+++ b/tests/install/Dockerfile.ubuntu2204
@@ -12,9 +12,23 @@ USER tester
 WORKDIR /home/tester
 
 ARG ODYSSEUS_REF=main
+# ODYSSEUS_COMMIT pins the exact commit baked into this layer AND salts the
+# layer-cache key: without it, a cached clone layer keyed only on the branch
+# NAME is reused after the branch moves, so the container silently tests a
+# stale tree (this made Install (ubuntu*) fail PR branches on long-fixed
+# installer bugs while a fresh debian12 rebuild of the same head passed).
+# Empty (e.g. local builds) = branch tip at build time, no cache-bust.
+ARG ODYSSEUS_COMMIT=""
 RUN git clone --depth 1 --branch "${ODYSSEUS_REF}" \
     --recurse-submodules --shallow-submodules \
     https://github.com/HomericIntelligence/Odysseus.git \
-    /home/tester/Projects/Odysseus
+    /home/tester/Projects/Odysseus \
+    && if [ -n "${ODYSSEUS_COMMIT}" ] \
+       && [ "$(git -C /home/tester/Projects/Odysseus rev-parse HEAD)" != "${ODYSSEUS_COMMIT}" ]; then \
+         git -C /home/tester/Projects/Odysseus fetch --depth 1 origin "${ODYSSEUS_COMMIT}" \
+         && git -C /home/tester/Projects/Odysseus checkout --detach "${ODYSSEUS_COMMIT}" \
+         && git -C /home/tester/Projects/Odysseus submodule update --init --recursive \
+              --depth 1 --recommend-shallow; \
+       fi
 
 WORKDIR /home/tester/Projects/Odysseus

--- a/tests/install/Dockerfile.ubuntu2404
+++ b/tests/install/Dockerfile.ubuntu2404
@@ -12,9 +12,23 @@ USER tester
 WORKDIR /home/tester
 
 ARG ODYSSEUS_REF=main
+# ODYSSEUS_COMMIT pins the exact commit baked into this layer AND salts the
+# layer-cache key: without it, a cached clone layer keyed only on the branch
+# NAME is reused after the branch moves, so the container silently tests a
+# stale tree (this made Install (ubuntu*) fail PR branches on long-fixed
+# installer bugs while a fresh debian12 rebuild of the same head passed).
+# Empty (e.g. local builds) = branch tip at build time, no cache-bust.
+ARG ODYSSEUS_COMMIT=""
 RUN git clone --depth 1 --branch "${ODYSSEUS_REF}" \
     --recurse-submodules --shallow-submodules \
     https://github.com/HomericIntelligence/Odysseus.git \
-    /home/tester/Projects/Odysseus
+    /home/tester/Projects/Odysseus \
+    && if [ -n "${ODYSSEUS_COMMIT}" ] \
+       && [ "$(git -C /home/tester/Projects/Odysseus rev-parse HEAD)" != "${ODYSSEUS_COMMIT}" ]; then \
+         git -C /home/tester/Projects/Odysseus fetch --depth 1 origin "${ODYSSEUS_COMMIT}" \
+         && git -C /home/tester/Projects/Odysseus checkout --detach "${ODYSSEUS_COMMIT}" \
+         && git -C /home/tester/Projects/Odysseus submodule update --init --recursive \
+              --depth 1 --recommend-shallow; \
+       fi
 
 WORKDIR /home/tester/Projects/Odysseus


### PR DESCRIPTION
## Summary

Root-cause fixes for the three infra bugs keeping `main` red and false-failing PR branches (full diagnosis in #411):

| Failing check | Root cause | Fix |
|---|---|---|
| `Build Images` / `build (argus-exporter, …)` on main pushes | `ghcr.io/homericintelligence/argus-exporter` is created/owned by ProjectArgus's `publish-exporter-image.yml`; Odysseus's repo-scoped `GITHUB_TOKEN` gets **403** on blob push. PR runs pass because they don't push. | Matrix `publish: false` for argus-exporter — build-validation only; ProjectArgus remains the single publisher (avoids two-writer `:latest` races too). |
| `Build idempotency` / `idempotent-build` | ProjectNestor renamed conan profiles `debug` → `nestor-debug` (ProjectNestor#96); meta-repo `justfile` `_build-nestor` still passed `--profile=conan/profiles/debug` → `ERROR: Profile not found`. | Use `conan/profiles/nestor-debug`. Verified: profile exists at the pinned submodule commit `859f810` and parses via `conan profile show` (includes `default`, sets Debug/cppstd 20). |
| `Install (ubuntu2204/2404)` false failures on PR branches (bit PR #407) | `tests/install/Dockerfile.*` bake `git clone --branch <ref>` into a layer cached under `scope=install-<os>-<branch NAME>` — the tip commit is not in the cache key, so runs reuse a **stale clone** and test old code (PR #407's ubuntu jobs ran pre-#410 installer scripts; debian12 cache-missed, rebuilt the same head, and passed). | New `ODYSSEUS_COMMIT` build-arg (event SHA) referenced inside the clone `RUN`: salts the layer cache per commit and, on the rare mid-run branch-move race, fetches + detaches to the exact pinned SHA. |

Also hardens `install-test.yml`'s ref step: `github.head_ref` / `inputs.ref` now flow through `env:` instead of inline `${{ }}` in the script body (Actions injection hygiene).

## Verification

- `just --list` parses the modified justfile.
- `conan profile show -pr conan/profiles/nestor-debug` resolves at the pinned Nestor commit.
- `docker build --check` passes for all three install Dockerfiles.
- Exact-SHA fetch semantics tested against github.com: tip-SHA fetch works; non-tip SHA correctly refuses (`not our ref`) — the fetch path only fires in the branch-moved race, where failing is the correct outcome (same semantics as `actions/checkout`).
- This PR touches `justfile`, so the `Build idempotency` workflow runs here (path filter) and exercises fix 2 end-to-end; `Install (*)` and `build (*, argus-exporter, …)` run on every PR and exercise fixes 1 & 3.

## Diagnosed, intentionally NOT fixed here (nightly, non-required)

`e2e-reliability-t1` (missing `conan profile detect` step) and `e2e-reliability-t4` (rootless podman socket not started) — both are documented in the workflow header as unable to go green until the `hello-world` myrmidon worker is restored (#391), so workflow changes there would only move the failure point. Details in #411.

## Note for PR #407

Its `Install (ubuntu*)` failures are **not caused by its submodule pins** — they are fix 3's stale-cache bug (evidence: failing logs show pre-#410 submodule paths; debian12 rebuilt fresh and passed the same head). After this PR merges, update #407 from main and its Install checks should pass.

Closes #411