### PR TITLE
ci: enable merge queue readiness on main

### DIFF
--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -24,6 +24,8 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  merge_group:
+    types: [checks_requested]
   workflow_dispatch:
 
 concurrency:
@@ -223,6 +225,9 @@ jobs:
 
       - name: Validate justfile syntax
         run: just --list > /dev/null
+
+      - name: Validate merge-queue readiness
+        run: just test-merge-queue-readiness
 
       - name: Run release-contract regression tests
         run: bash tests/release/release.test.sh

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -5,7 +5,7 @@ name: Build Images
 # each a single pinnable, published artifact in GHCR.
 #
 # Registry:   ghcr.io/homericintelligence/<component> (lowercase)
-# Promotion:  pull_request -> BUILD ONLY (no push; validates images build)
+# Promotion:  pull_request / merge_group -> BUILD ONLY (no push)
 #             push to main -> build + push :sha-<short> and :latest
 #             push tag v*  -> build + push :<semver> tags
 #             matrix entries with publish: false are always BUILD ONLY
@@ -20,6 +20,8 @@ name: Build Images
 on:
   pull_request:
     branches: [main]
+  merge_group:
+    types: [checks_requested]
   push:
     branches: [main]
     tags:
@@ -96,7 +98,7 @@ jobs:
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c  # v4.2.0
 
       - name: Log in to GHCR
-        if: github.event_name != 'pull_request'
+        if: github.event_name != 'pull_request' && github.event_name != 'merge_group'
         uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0  # v4.4.0
         with:
           registry: ${{ env.REGISTRY }}
@@ -119,7 +121,7 @@ jobs:
         with:
           context: ${{ matrix.context }}
           file: ${{ matrix.file }}
-          push: ${{ github.event_name != 'pull_request' && matrix.publish }}
+          push: ${{ github.event_name != 'pull_request' && github.event_name != 'merge_group' && matrix.publish }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           # Cache scope is salted with -r2 to invalidate the pre-openssl-fix

--- a/.github/workflows/install-test.yml
+++ b/.github/workflows/install-test.yml
@@ -5,6 +5,8 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  merge_group:
+    types: [checks_requested]
   schedule:
     - cron: "0 6 * * 1"  # Every Monday at 06:00 UTC
   workflow_dispatch:
@@ -17,9 +19,10 @@ on:
 jobs:
   # Canonical `install` check for the 8-category CI naming scheme
   # (docs/ci-naming-convention.md). The full multi-OS Docker matrix below is
-  # heavy (45 min × 3 images) and stays gated to schedule / workflow_dispatch.
-  # This lightweight smoke job runs on every main push/PR so the Ecosystem CI
-  # Status board's **install** column lights up quickly: it exercises the
+  # heavy (45 min × 3 images) and retains its existing push/PR/schedule/manual
+  # behavior, but is skipped for merge groups because it is not a required
+  # context. This lightweight smoke job runs on every main push/PR/merge group
+  # so the Ecosystem CI Status board's **install** column lights up quickly: it
   # installer's check-only detection path (no sudo, no apt, no Docker) and
   # asserts the installer is structurally sound and produces its detection
   # summary. Check-only mode exits 1 when components are missing on a bare
@@ -69,6 +72,7 @@ jobs:
 
   install-test:
     name: Install (${{ matrix.os }})
+    if: github.event_name != 'merge_group'
     runs-on: ubuntu-latest
     timeout-minutes: 45
     strategy:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,8 @@ on:
       - 'v[0-9]+.[0-9]+.[0-9]+'
   pull_request:
     branches: [main]
+  merge_group:
+    types: [checks_requested]
   workflow_dispatch:
 
 permissions:
@@ -16,7 +18,7 @@ jobs:
   # Canonical `release` check for the 8-category CI naming scheme
   # (docs/ci-naming-convention.md). Actual publishing is tag-gated (the
   # validate/publish jobs below run only on a vX.Y.Z tag push). This
-  # lightweight dry-run runs on every main push/PR so the Ecosystem CI Status
+  # lightweight dry-run runs on every main push/PR/merge group so the Ecosystem CI Status
   # board's **release** column lights up: it exercises the same release-gating
   # logic (CHANGELOG shape + release-contract regression tests + release-notes
   # extraction) WITHOUT creating a GitHub Release, so release regressions are

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -263,11 +263,12 @@ The `main` branch is protected by a GitHub **repository ruleset** (not classic b
 ### Protection Rules
 
 - **Direct pushes blocked** - All changes to `main` must go through pull requests (`deletion` and non-PR pushes are rejected).
-- **PR approval required** - At least 1 approving review is required before merging (`required_approving_review_count: 1`).
+- **Checks-only merge gate** - No approving review is required (`required_approving_review_count: 0`); required checks and resolved review threads remain mandatory.
 - **Review threads must be resolved** - All PR review conversations must be resolved before merge (`required_review_thread_resolution`).
 - **Signed commits required** - Commits on `main` must be signed (`required_signatures`).
-- **CI status checks must pass** - The required checks must be green before merge: `lint`, `unit-tests`, `integration-tests`, `security/dependency-scan`, `security/secrets-scan`, `build`, `schema-validation`, `deps/version-sync`.
+- **CI status checks must pass** - All 11 required checks must be green before merge: `lint`, `unit-tests`, `integration-tests`, `security/dependency-scan`, `security/secrets-scan`, `build`, `schema-validation`, `deps/version-sync`, `test`, `install`, and `release`.
 - **Linear history enforced** - Only squash merges are allowed (repo setting: `allow_squash_merge` only; merge-commit and rebase-merge are disabled). Squashing collapses each PR into a single commit on `main`, keeping the history clean and linear.
+- **Merge queue required** - Pull requests enter the `main` merge queue after their checks pass. The queue retests the merge group against the current tip using squash, `ALLGREEN`, at most 10 concurrent builds, at most 5 entries per merge group, a minimum group size of 1, a 5-minute minimum wait, and a 60-minute check timeout.
 
 ### Merge Convention
 
@@ -278,24 +279,17 @@ gh pr merge --auto --squash
 ```
 
 This will:
-1. Enable auto-merge on your PR (merge happens as soon as all conditions are met)
-2. Use squash strategy (the only strategy this repo permits), collapsing the PR into one linear-history commit
+1. Enable auto-merge on your PR (after activation, GitHub enqueues it as soon as all conditions are met)
+2. Use the repository's squash-only merge strategy, collapsing the PR into one linear-history commit
 3. Keep your branch name clean and commit history readable
 
 ### For Repo Admins
 
-If you are setting up a fresh fork or new repository and need to enable these rules:
-
-1. Go to **Settings** → **Branches**
-2. Click **Add rule** under "Branch protection rules"
-3. Enter `main` as the branch name pattern
-4. Enable:
-   - Require a pull request before merging (1 approval minimum)
-   - Require status checks to pass before merging
-   - Require branches to be up to date before merging
-   - Require a linear history (dismiss stale pull request approvals when new commits are pushed)
-5. Optionally require dismissal of stale reviews when new commits are pushed
-6. Save the rule
+Use the repository-owned ruleset files and follow
+`docs/runbooks/branch-protection-rollout.md`. For Odysseus issue #386, merge
+the workflow/configuration PR and verify its required checks before running the
+documented `--active --repos Odysseus` activation command. Do not enable the
+queue from the web UI ahead of that smoke check.
 
 ## Key References
 

--- a/configs/github/canonical-checks.md
+++ b/configs/github/canonical-checks.md
@@ -35,6 +35,15 @@ commits. Pull-request, push, schedule, and manual behavior remains independent.
 Run `just test-merge-queue-readiness` after changing a required workflow or a
 repo ruleset.
 
+These repository ruleset files describe Odysseus policy and supply the approved
+merge-queue parameters. They are not a fleet-wide replacement or creation
+payload. Existing repositories own their complete live rules and context lists;
+`tools/github/apply-repo-rulesets.sh` derives updates from that live state and
+patches only enforcement plus `merge_queue`. Argus has a separate 14-context,
+two-ruleset contract and a dedicated activation path in
+[Argus #550](https://github.com/HomericIntelligence/Argus/issues/550) and
+[PR #551](https://github.com/HomericIntelligence/Argus/pull/551).
+
 ## Informational checks (report but do not block merge)
 
 | Context name | Category | Validator |

--- a/configs/github/canonical-checks.md
+++ b/configs/github/canonical-checks.md
@@ -1,6 +1,6 @@
 # HomericIntelligence — Canonical Required CI Check Names
 
-All 15 repos must emit these exact GitHub Actions status check names.
+All 16 first-party repos must emit these exact GitHub Actions status check names.
 Each check must run a **real validator** — no echo-true placeholders.
 
 ## Required checks (block merge if failing)
@@ -15,6 +15,25 @@ Each check must run a **real validator** — no echo-true placeholders.
 | `build` | Build | pixi run build, cmake --build, docker build |
 | `schema-validation` | Validation | check-jsonschema against workflow YAMLs / pixi.toml / NATS schemas |
 | `deps/version-sync` | Validation | verify VERSION/pyproject.toml/pixi.toml/Conanfile parity |
+
+## Additional Odysseus required checks
+
+Odysseus's live repository ruleset also requires these three contexts. They are
+preserved in every repo-ruleset variant alongside the eight fleet contexts.
+
+| Context name | Workflow | Purpose |
+|---|---|---|
+| `test` | `Required Checks` | Aggregate `unit-tests` and `integration-tests` gate |
+| `install` | `Install test` | Lightweight installer smoke test |
+| `release` | `Release` | Non-publishing release-contract dry run |
+
+The `build` context is also emitted by `Build Images`. Every workflow that can
+emit one of the 11 required contexts handles `merge_group` with the
+`checks_requested` activity so the same gate is reported for queue-generated
+commits. Pull-request, push, schedule, and manual behavior remains independent.
+
+Run `just test-merge-queue-readiness` after changing a required workflow or a
+repo ruleset.
 
 ## Informational checks (report but do not block merge)
 

--- a/configs/github/repo-ruleset-active.json
+++ b/configs/github/repo-ruleset-active.json
@@ -21,7 +21,19 @@
         "dismissal_restriction": { "enabled": false, "allowed_actors": [] },
         "require_last_push_approval": false,
         "required_review_thread_resolution": true,
-        "allowed_merge_methods": ["merge", "squash", "rebase"]
+        "allowed_merge_methods": ["squash"]
+      }
+    },
+    {
+      "type": "merge_queue",
+      "parameters": {
+        "check_response_timeout_minutes": 60,
+        "grouping_strategy": "ALLGREEN",
+        "max_entries_to_build": 10,
+        "max_entries_to_merge": 5,
+        "merge_method": "SQUASH",
+        "min_entries_to_merge": 1,
+        "min_entries_to_merge_wait_minutes": 5
       }
     },
     {

--- a/configs/github/repo-ruleset-evaluate.json
+++ b/configs/github/repo-ruleset-evaluate.json
@@ -16,26 +16,47 @@
       "parameters": {
         "required_approving_review_count": 0,
         "dismiss_stale_reviews_on_push": false,
+        "required_reviewers": [],
         "require_code_owner_review": false,
+        "dismissal_restriction": { "enabled": false, "allowed_actors": [] },
         "require_last_push_approval": false,
-        "required_review_thread_resolution": true
+        "required_review_thread_resolution": true,
+        "allowed_merge_methods": ["squash"]
+      }
+    },
+    {
+      "type": "merge_queue",
+      "parameters": {
+        "check_response_timeout_minutes": 60,
+        "grouping_strategy": "ALLGREEN",
+        "max_entries_to_build": 10,
+        "max_entries_to_merge": 5,
+        "merge_method": "SQUASH",
+        "min_entries_to_merge": 1,
+        "min_entries_to_merge_wait_minutes": 5
       }
     },
     {
       "type": "required_status_checks",
       "parameters": {
         "strict_required_status_checks_policy": false,
+        "do_not_enforce_on_create": false,
         "required_status_checks": [
-          { "context": "lint",                    "integration_id": 15368 },
-          { "context": "unit-tests",              "integration_id": 15368 },
-          { "context": "integration-tests",       "integration_id": 15368 },
-          { "context": "security/dependency-scan","integration_id": 15368 },
-          { "context": "security/secrets-scan",   "integration_id": 15368 },
-          { "context": "build",                   "integration_id": 15368 },
-          { "context": "schema-validation",       "integration_id": 15368 },
-          { "context": "deps/version-sync",       "integration_id": 15368 }
+          { "context": "lint",                     "integration_id": 15368 },
+          { "context": "unit-tests",               "integration_id": 15368 },
+          { "context": "integration-tests",        "integration_id": 15368 },
+          { "context": "security/dependency-scan", "integration_id": 15368 },
+          { "context": "security/secrets-scan",    "integration_id": 15368 },
+          { "context": "build",                    "integration_id": 15368 },
+          { "context": "schema-validation",        "integration_id": 15368 },
+          { "context": "deps/version-sync",        "integration_id": 15368 },
+          { "context": "test",                     "integration_id": 15368 },
+          { "context": "install",                  "integration_id": 15368 },
+          { "context": "release",                  "integration_id": 15368 }
         ]
       }
-    }
+    },
+    { "type": "required_linear_history" },
+    { "type": "non_fast_forward" }
   ]
 }

--- a/configs/github/repo-ruleset.json
+++ b/configs/github/repo-ruleset.json
@@ -16,26 +16,47 @@
       "parameters": {
         "required_approving_review_count": 0,
         "dismiss_stale_reviews_on_push": false,
+        "required_reviewers": [],
         "require_code_owner_review": false,
+        "dismissal_restriction": { "enabled": false, "allowed_actors": [] },
         "require_last_push_approval": false,
-        "required_review_thread_resolution": true
+        "required_review_thread_resolution": true,
+        "allowed_merge_methods": ["squash"]
+      }
+    },
+    {
+      "type": "merge_queue",
+      "parameters": {
+        "check_response_timeout_minutes": 60,
+        "grouping_strategy": "ALLGREEN",
+        "max_entries_to_build": 10,
+        "max_entries_to_merge": 5,
+        "merge_method": "SQUASH",
+        "min_entries_to_merge": 1,
+        "min_entries_to_merge_wait_minutes": 5
       }
     },
     {
       "type": "required_status_checks",
       "parameters": {
         "strict_required_status_checks_policy": false,
+        "do_not_enforce_on_create": false,
         "required_status_checks": [
-          { "context": "lint",                    "integration_id": 15368 },
-          { "context": "unit-tests",              "integration_id": 15368 },
-          { "context": "integration-tests",       "integration_id": 15368 },
-          { "context": "security/dependency-scan","integration_id": 15368 },
-          { "context": "security/secrets-scan",   "integration_id": 15368 },
-          { "context": "build",                   "integration_id": 15368 },
-          { "context": "schema-validation",       "integration_id": 15368 },
-          { "context": "deps/version-sync",       "integration_id": 15368 }
+          { "context": "lint",                     "integration_id": 15368 },
+          { "context": "unit-tests",               "integration_id": 15368 },
+          { "context": "integration-tests",        "integration_id": 15368 },
+          { "context": "security/dependency-scan", "integration_id": 15368 },
+          { "context": "security/secrets-scan",    "integration_id": 15368 },
+          { "context": "build",                    "integration_id": 15368 },
+          { "context": "schema-validation",        "integration_id": 15368 },
+          { "context": "deps/version-sync",        "integration_id": 15368 },
+          { "context": "test",                     "integration_id": 15368 },
+          { "context": "install",                  "integration_id": 15368 },
+          { "context": "release",                  "integration_id": 15368 }
         ]
       }
-    }
+    },
+    { "type": "required_linear_history" },
+    { "type": "non_fast_forward" }
   ]
 }

--- a/docs/runbooks/branch-protection-rollout.md
+++ b/docs/runbooks/branch-protection-rollout.md
@@ -3,6 +3,11 @@
 How to add a new repo to the `homeric-main-baseline` ruleset, or re-apply the
 ruleset after a change.
 
+The repository-owned ruleset variants include the approved `main` merge queue:
+squash, `ALLGREEN`, maximum 10 queue builds, maximum 5 merged entries per
+group, minimum 1 entry, a 5-minute minimum wait, and a 60-minute check timeout.
+Queue activation is deliberately separate from landing workflow support.
+
 ## Prerequisites
 
 - `gh` CLI authenticated with org-admin scope
@@ -22,16 +27,43 @@ ruleset after a change.
    runs, then merge.
 
 3. Apply the ruleset to the new repo in shadow (evaluate) mode first:
+
    ```bash
    ./tools/github/apply-repo-rulesets.sh --evaluate --repos <NewRepo>
    ```
+
    (The bare invocation now applies the canonical `repo-ruleset.json`, which is
    `active`; pass `--evaluate` for the shadow pass.)
 
 4. Observe evaluate mode for one PR cycle, then flip to active:
+
    ```bash
    ./tools/github/apply-repo-rulesets.sh --active --repos <NewRepo>
    ```
+
+## Activating the Odysseus merge queue after issue #386
+
+Do not apply the queue while the readiness PR is open. After that PR merges:
+
+1. Confirm all 11 required contexts completed successfully on the merge commit.
+2. Run the offline contract again:
+
+   ```bash
+   just test-merge-queue-readiness
+   ```
+
+3. Activate only the Odysseus repository ruleset:
+
+   ```bash
+   ./tools/github/apply-repo-rulesets.sh --active --repos Odysseus
+   ```
+
+4. Queue one low-risk pull request with `gh pr merge --auto --squash`. Confirm
+   GitHub creates a merge group, all 11 required contexts report on that group,
+   and the pull request squash-merges through the queue.
+
+This runbook records the activation requirement; the issue #386 implementation
+PR must not run step 3 or otherwise mutate the live ruleset.
 
 ## Re-applying the ruleset to all repos
 
@@ -71,6 +103,7 @@ by the old context list during a ruleset migration. Use sparingly.
 ## Rollback
 
 Re-applying evaluate mode is instant and safe:
+
 ```bash
 ./tools/github/apply-repo-rulesets.sh --evaluate   # or: --repos <repo>
 ```
@@ -80,6 +113,7 @@ Re-applying evaluate mode is instant and safe:
 > Per-repo rulesets (`repos/<org>/<repo>/rulesets`) are the enforcing path.
 
 To remove the ruleset entirely from a single repo:
+
 ```bash
 ID=$(gh api repos/HomericIntelligence/<repo>/rulesets \
   --jq '.[] | select(.name=="homeric-main-baseline") | .id')

--- a/docs/runbooks/branch-protection-rollout.md
+++ b/docs/runbooks/branch-protection-rollout.md
@@ -8,6 +8,22 @@ squash, `ALLGREEN`, maximum 10 queue builds, maximum 5 merged entries per
 group, minimum 1 entry, a 5-minute minimum wait, and a 60-minute check timeout.
 Queue activation is deliberately separate from landing workflow support.
 
+The live rulesets in each target repository are authoritative. For an existing
+`homeric-main-baseline`, the apply script reads the live object and changes only
+its enforcement mode and single `merge_queue` rule. It refuses an update if its
+preservation check finds any change to required contexts, conditions, bypass
+actors, or unrelated rules. The JSON files in `configs/github/` supply only the
+approved queue rule and requested enforcement mode for this update path; their
+complete fixed payload never replaces repository-specific live policy or
+bootstraps a missing ruleset.
+
+Argus is independently authoritative and uses a dedicated
+`homeric-main-merge-queue` ruleset. Follow
+[Argus issue #550](https://github.com/HomericIntelligence/Argus/issues/550) and
+its [replacement implementation PR #551](https://github.com/HomericIntelligence/Argus/pull/551).
+The generic script permits an Argus dry-run for preservation evidence, but
+refuses live Argus activation.
+
 ## Prerequisites
 
 - `gh` CLI authenticated with org-admin scope
@@ -26,18 +42,25 @@ Queue activation is deliberately separate from landing workflow support.
 2. Open a PR, verify all 8 required contexts appear in the PR checks UI once CI
    runs, then merge.
 
-3. Apply the ruleset to the new repo in shadow (evaluate) mode first:
+3. Bootstrap `homeric-main-baseline` from a ruleset definition owned and tested
+   by the new repository. The central apply script intentionally refuses to
+   create a missing ruleset from Odysseus's fixed context list.
+
+4. After the repository-owned baseline exists, generate the scoped evaluate
+   payload without mutation:
+
+   ```bash
+   ./tools/github/apply-repo-rulesets.sh \
+     --evaluate --repos <NewRepo> --dry-run
+   ```
+
+   A target scope is mandatory. Use `--repos` for staged rollout; `--all` is an
+   explicit fleet-wide acknowledgement and still refuses Argus.
+
+5. Apply evaluate mode, observe it for one PR cycle, then flip to active:
 
    ```bash
    ./tools/github/apply-repo-rulesets.sh --evaluate --repos <NewRepo>
-   ```
-
-   (The bare invocation now applies the canonical `repo-ruleset.json`, which is
-   `active`; pass `--evaluate` for the shadow pass.)
-
-4. Observe evaluate mode for one PR cycle, then flip to active:
-
-   ```bash
    ./tools/github/apply-repo-rulesets.sh --active --repos <NewRepo>
    ```
 
@@ -52,33 +75,42 @@ Do not apply the queue while the readiness PR is open. After that PR merges:
    just test-merge-queue-readiness
    ```
 
-3. Activate only the Odysseus repository ruleset:
+3. Generate the exact Odysseus update payload without mutating GitHub. Confirm
+   it contains all live required contexts and differs only in enforcement and
+   the approved queue rule:
+
+   ```bash
+   ./tools/github/apply-repo-rulesets.sh \
+     --active --repos Odysseus --dry-run
+   ```
+
+4. Activate only the Odysseus repository ruleset:
 
    ```bash
    ./tools/github/apply-repo-rulesets.sh --active --repos Odysseus
    ```
 
-4. Queue one low-risk pull request with `gh pr merge --auto --squash`. Confirm
+5. Queue one low-risk pull request with `gh pr merge --auto --squash`. Confirm
    GitHub creates a merge group, all 11 required contexts report on that group,
    and the pull request squash-merges through the queue.
 
 This runbook records the activation requirement; the issue #386 implementation
-PR must not run step 3 or otherwise mutate the live ruleset.
+PR must not run step 4 or otherwise mutate the live ruleset.
 
 ## Re-applying the ruleset to all repos
 
 ```bash
 # Evaluate mode first (shadow enforcement — reports but doesn't block).
-# NOTE: the bare invocation applies the canonical repo-ruleset.json, which is
-# now "active"; use --evaluate explicitly for the shadow pass.
-./tools/github/apply-repo-rulesets.sh --evaluate
+# Name only repositories whose own rollout has approved the generic path.
+# Argus is rejected here because its issue #550 path owns a dedicated ruleset.
+./tools/github/apply-repo-rulesets.sh --evaluate --repos <RepoA,RepoB>
 
 # Check evaluate results
 gh api "repos/HomericIntelligence/<repo>/rulesets/rule-suites?ref=refs/heads/main" \
   --jq '.[] | {result, evaluation_result, pushed_at}' | head -20
 
 # Flip to active when evaluate shows all-pass
-./tools/github/apply-repo-rulesets.sh --active
+./tools/github/apply-repo-rulesets.sh --active --repos <RepoA,RepoB>
 ```
 
 ## Verify a repo's ruleset state
@@ -102,11 +134,15 @@ by the old context list during a ruleset migration. Use sparingly.
 
 ## Rollback
 
-Re-applying evaluate mode is instant and safe:
+Re-applying evaluate mode is the scoped rollback for a repository whose queue
+uses `homeric-main-baseline`:
 
 ```bash
-./tools/github/apply-repo-rulesets.sh --evaluate   # or: --repos <repo>
+./tools/github/apply-repo-rulesets.sh --evaluate --repos <repo>
 ```
+
+For Argus, disable only its dedicated `homeric-main-merge-queue` ruleset as
+documented in Argus #550/#551. Do not edit either required-check ruleset.
 
 > Note: `org-ruleset.json` is not applied on the current GitHub plan —
 > `gh api orgs/HomericIntelligence/rulesets` returns 404 / requires `admin:org`.

--- a/justfile
+++ b/justfile
@@ -316,6 +316,10 @@ test-justfile-recipes:
 lint-test-scripts:
     bash scripts/lint-test-scripts.sh
 
+# Validate required-check workflows and repo rulesets are merge-queue ready (#386)
+test-merge-queue-readiness:
+    bash tests/github/merge-queue-readiness.test.sh
+
 # Render Nomad config placeholders to a deploy-local dir (default /etc/nomad.d).
 # Nomad agent HCL does NOT expand OS env vars, so render before `nomad agent -config`.
 # Requires NOMAD_SERVER_IP and NOMAD_ADVERTISE_ADDR (e.g. export NOMAD_SERVER_IP=$(tailscale ip -4)).
@@ -741,13 +745,13 @@ hermes-hub-logs SERVICE="":
 # GitHub Org Ruleset Management
 # ===========================================================================
 
-# Snapshot all 15 repos' current classic branch protection to a timestamped backup file
+# Snapshot all 16 repos' current classic branch protection to a timestamped backup file
 ruleset-backup:
     mkdir -p configs/github/backups
     ./tools/github/snapshot-protection.sh > "configs/github/backups/rulesets-$(date +%Y%m%d-%H%M%S).json"
     @echo "Backup written."
 
-# Snapshot all 15 repos' classic branch protection to the canonical pre-ruleset backup file
+# Snapshot all 16 repos' classic branch protection to the canonical pre-ruleset backup file
 protection-snapshot:
     mkdir -p configs/github/backups
     ./tools/github/snapshot-protection.sh > configs/github/backups/branch-protection-pre-ruleset.json
@@ -757,11 +761,11 @@ protection-snapshot:
 ruleset-apply FILE="configs/github/org-ruleset.json":
     ./tools/github/apply-org-ruleset.sh "{{FILE}}"
 
-# Create or update the per-repo branch ruleset on all 15 repos (evaluate mode)
+# Create or update the per-repo branch ruleset on all 16 repos (evaluate mode)
 repo-rulesets-apply:
     ./tools/github/apply-repo-rulesets.sh
 
-# Create or update the per-repo branch ruleset on all 15 repos (active/enforcing mode)
+# Create or update the per-repo branch ruleset on all 16 repos (active/enforcing mode)
 repo-rulesets-activate:
     ./tools/github/apply-repo-rulesets.sh --active
 
@@ -797,9 +801,10 @@ ruleset-enforcement-check:
     #!/usr/bin/env bash
     set -euo pipefail
     declare -A expected=(
-      [configs/github/repo-ruleset.json]=evaluate
+      [configs/github/repo-ruleset.json]=active
       [configs/github/repo-ruleset-active.json]=active
-      [configs/github/org-ruleset.json]=evaluate
+      [configs/github/repo-ruleset-evaluate.json]=evaluate
+      [configs/github/org-ruleset.json]=active
       [configs/github/org-ruleset-active.json]=active
     )
     fail=0
@@ -813,9 +818,9 @@ ruleset-enforcement-check:
       fi
     done
     [ "$fail" -eq 0 ] || { echo "FAILED: ruleset enforcement drift detected" >&2; exit 1; }
-    echo "PASSED: all 4 ruleset configs hold their intended enforcement"
+    echo "PASSED: all ruleset configs hold their intended enforcement"
 
-# Remove classic branch protection from ALL 15 repos (requires confirmation; run after ruleset is active)
+# Remove classic branch protection from ALL 16 repos (requires confirmation; run after ruleset is active)
 protection-remove-all:
     ./tools/github/remove-classic-protection.sh --all
 

--- a/justfile
+++ b/justfile
@@ -319,6 +319,7 @@ lint-test-scripts:
 # Validate required-check workflows and repo rulesets are merge-queue ready (#386)
 test-merge-queue-readiness:
     bash tests/github/merge-queue-readiness.test.sh
+    bash tests/github/apply-repo-rulesets.test.sh
 
 # Render Nomad config placeholders to a deploy-local dir (default /etc/nomad.d).
 # Nomad agent HCL does NOT expand OS env vars, so render before `nomad agent -config`.
@@ -761,13 +762,13 @@ protection-snapshot:
 ruleset-apply FILE="configs/github/org-ruleset.json":
     ./tools/github/apply-org-ruleset.sh "{{FILE}}"
 
-# Create or update the per-repo branch ruleset on all 16 repos (evaluate mode)
-repo-rulesets-apply:
-    ./tools/github/apply-repo-rulesets.sh
+# Patch approved repositories' live rulesets in evaluate mode (comma-separated names)
+repo-rulesets-apply REPOS:
+    ./tools/github/apply-repo-rulesets.sh --evaluate --repos "{{REPOS}}"
 
-# Create or update the per-repo branch ruleset on all 16 repos (active/enforcing mode)
-repo-rulesets-activate:
-    ./tools/github/apply-repo-rulesets.sh --active
+# Patch approved repositories' live rulesets in active mode (comma-separated names)
+repo-rulesets-activate REPOS:
+    ./tools/github/apply-repo-rulesets.sh --active --repos "{{REPOS}}"
 
 # Validate the live org ruleset against the canonical JSON and print current enforcement + checks
 ruleset-validate:

--- a/tests/fixtures/github/argus-ruleset-contract.json
+++ b/tests/fixtures/github/argus-ruleset-contract.json
@@ -1,0 +1,94 @@
+{
+  "repository": "HomericIntelligence/Argus",
+  "source": {
+    "issue": "https://github.com/HomericIntelligence/Argus/issues/550",
+    "implementation_pr": "https://github.com/HomericIntelligence/Argus/pull/551"
+  },
+  "rulesets": [
+    {
+      "id": 15556501,
+      "name": "homeric-main-baseline",
+      "target": "branch",
+      "source_type": "Repository",
+      "source": "HomericIntelligence/Argus",
+      "enforcement": "active",
+      "conditions": {
+        "ref_name": {
+          "include": ["refs/heads/main"],
+          "exclude": []
+        }
+      },
+      "bypass_actors": [
+        {
+          "actor_id": 5,
+          "actor_type": "RepositoryRole",
+          "bypass_mode": "pull_request"
+        }
+      ],
+      "rules": [
+        { "type": "deletion" },
+        { "type": "required_signatures" },
+        {
+          "type": "pull_request",
+          "parameters": {
+            "required_approving_review_count": 0,
+            "dismiss_stale_reviews_on_push": false,
+            "require_code_owner_review": false,
+            "require_last_push_approval": false,
+            "required_review_thread_resolution": true,
+            "allowed_merge_methods": ["squash"]
+          }
+        },
+        {
+          "type": "required_status_checks",
+          "parameters": {
+            "strict_required_status_checks_policy": false,
+            "required_status_checks": [
+              { "context": "lint", "integration_id": 15368 },
+              { "context": "unit-tests", "integration_id": 15368 },
+              { "context": "integration-tests", "integration_id": 15368 },
+              { "context": "security/dependency-scan", "integration_id": 15368 },
+              { "context": "security/secrets-scan", "integration_id": 15368 },
+              { "context": "config-validate", "integration_id": 15368 },
+              { "context": "schema-validation", "integration_id": 15368 },
+              { "context": "deps/version-sync", "integration_id": 15368 },
+              { "context": "test", "integration_id": 15368 },
+              { "context": "package", "integration_id": 15368 },
+              { "context": "install", "integration_id": 15368 },
+              { "context": "release", "integration_id": 15368 },
+              { "context": "build", "integration_id": 15368 }
+            ]
+          }
+        },
+        { "type": "required_linear_history" },
+        { "type": "non_fast_forward" }
+      ]
+    },
+    {
+      "id": 15556502,
+      "name": "homeric-main-extras",
+      "target": "branch",
+      "source_type": "Repository",
+      "source": "HomericIntelligence/Argus",
+      "enforcement": "active",
+      "conditions": {
+        "ref_name": {
+          "include": ["refs/heads/main"],
+          "exclude": []
+        }
+      },
+      "bypass_actors": [],
+      "rules": [
+        {
+          "type": "required_status_checks",
+          "parameters": {
+            "strict_required_status_checks_policy": false,
+            "required_status_checks": [
+              { "context": "Validate configs", "integration_id": 15368 }
+            ]
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/github/mock-ruleset-gh.sh
+++ b/tests/fixtures/github/mock-ruleset-gh.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${GH_RULESET_FIXTURE:?GH_RULESET_FIXTURE is required}"
+: "${GH_CALL_LOG:?GH_CALL_LOG is required}"
+
+printf '%s\n' "$*" >> "$GH_CALL_LOG"
+
+if [[ "$1" != "api" ]]; then
+  echo "unexpected gh command: $*" >&2
+  exit 2
+fi
+shift
+
+case "$1" in
+  'repos/HomericIntelligence/Argus/rulesets?includes_parents=false')
+    jq '[.rulesets[] | {id, name, target, enforcement}]' "$GH_RULESET_FIXTURE"
+    ;;
+  repos/HomericIntelligence/Argus/rulesets/15556501)
+    jq '.rulesets[] | select(.name == "homeric-main-baseline")' \
+      "$GH_RULESET_FIXTURE"
+    ;;
+  *)
+    echo "unexpected gh api endpoint: $1" >&2
+    exit 2
+    ;;
+esac

--- a/tests/github/apply-repo-rulesets.test.sh
+++ b/tests/github/apply-repo-rulesets.test.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+# Safety regression for repository-authoritative ruleset updates.
+set -euo pipefail
+
+REPO_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+cd "$REPO_ROOT"
+
+fixture=tests/fixtures/github/argus-ruleset-contract.json
+tmp_dir=$(mktemp -d)
+trap 'rm -rf "$tmp_dir"' EXIT
+mkdir -p "$tmp_dir/bin"
+cp tests/fixtures/github/mock-ruleset-gh.sh "$tmp_dir/bin/gh"
+chmod +x "$tmp_dir/bin/gh"
+
+output=$(
+  PATH="$tmp_dir/bin:$PATH" \
+    GH_RULESET_FIXTURE="$fixture" \
+    GH_CALL_LOG="$tmp_dir/gh-calls.log" \
+    tools/github/apply-repo-rulesets.sh \
+      --active --repos Argus --dry-run
+)
+
+payload=$(sed -n 's/^DRY-RUN Argus payload: //p' <<<"$output")
+if [[ -z "$payload" ]]; then
+  echo "FAIL: dry-run did not emit an Argus update payload" >&2
+  exit 1
+fi
+
+expected_contexts=$(jq -c '[
+  .rulesets[].rules[]
+  | select(.type == "required_status_checks")
+  | .parameters.required_status_checks[].context
+]' "$fixture")
+
+actual_contexts=$(jq -nc --argjson payload "$payload" '[
+  $payload.rules[]
+  | select(.type == "required_status_checks")
+  | .parameters.required_status_checks[].context
+] + ["Validate configs"]')
+
+if [[ "$actual_contexts" != "$expected_contexts" ]]; then
+  echo "FAIL: Argus's complete 14-context contract was not preserved" >&2
+  printf 'Expected: %s\nActual:   %s\n' "$expected_contexts" "$actual_contexts" >&2
+  exit 1
+fi
+
+if ! jq -e --argjson payload "$payload" '
+    def unrelated:
+      {
+        name,
+        target,
+        conditions,
+        bypass_actors,
+        rules: [.rules[] | select(.type != "merge_queue")]
+      };
+    (.rulesets[] | select(.name == "homeric-main-baseline") | unrelated)
+      == ($payload | unrelated)
+  ' "$fixture" >/dev/null; then
+  echo "FAIL: dry-run changed or lost an unrelated Argus rule" >&2
+  exit 1
+fi
+
+if ! jq -ne --argjson payload "$payload" '
+    [$payload.rules[] | select(.type == "merge_queue") | .parameters] == [{
+      "check_response_timeout_minutes": 60,
+      "grouping_strategy": "ALLGREEN",
+      "max_entries_to_build": 10,
+      "max_entries_to_merge": 5,
+      "merge_method": "SQUASH",
+      "min_entries_to_merge": 1,
+      "min_entries_to_merge_wait_minutes": 5
+    }]
+  ' >/dev/null; then
+  echo "FAIL: dry-run payload lacks the approved merge-queue policy" >&2
+  exit 1
+fi
+
+if grep -Eq -- '(^| )(-X|--method) (PUT|POST)( |$)' "$tmp_dir/gh-calls.log"; then
+  echo "FAIL: dry-run attempted to mutate a live ruleset" >&2
+  cat "$tmp_dir/gh-calls.log" >&2
+  exit 1
+fi
+
+echo "PASS: Argus dry-run preserves all 14 contexts and every unrelated rule"
+
+jq 'del(.rulesets[] | select(.name == "homeric-main-baseline").bypass_actors)' \
+  "$fixture" > "$tmp_dir/incomplete-argus.json"
+if PATH="$tmp_dir/bin:$PATH" \
+    GH_RULESET_FIXTURE="$tmp_dir/incomplete-argus.json" \
+    GH_CALL_LOG="$tmp_dir/gh-calls.log" \
+    tools/github/apply-repo-rulesets.sh \
+      --active --repos Argus --dry-run \
+      >"$tmp_dir/incomplete-response.log" 2>&1; then
+  echo "FAIL: updater accepted a live response with hidden bypass actors" >&2
+  exit 1
+fi
+
+if ! grep -qF "live ruleset response is incomplete" \
+    "$tmp_dir/incomplete-response.log"; then
+  echo "FAIL: incomplete-response refusal was not explicit" >&2
+  cat "$tmp_dir/incomplete-response.log" >&2
+  exit 1
+fi
+
+echo "PASS: updater fails closed when repository authority fields are hidden"
+
+jq 'del(.rulesets[] | select(.name == "homeric-main-baseline"))' \
+  "$fixture" > "$tmp_dir/no-baseline-argus.json"
+if PATH="$tmp_dir/bin:$PATH" \
+    GH_RULESET_FIXTURE="$tmp_dir/no-baseline-argus.json" \
+    GH_CALL_LOG="$tmp_dir/gh-calls.log" \
+    tools/github/apply-repo-rulesets.sh \
+      --active --repos Argus --dry-run \
+      >"$tmp_dir/no-baseline.log" 2>&1; then
+  echo "FAIL: updater accepted a repository with no owned baseline" >&2
+  exit 1
+fi
+
+if ! grep -qF "bootstrap it from repository-owned policy" \
+    "$tmp_dir/no-baseline.log"; then
+  echo "FAIL: missing-baseline refusal did not identify repository authority" >&2
+  cat "$tmp_dir/no-baseline.log" >&2
+  exit 1
+fi
+
+if grep -Eq -- '(^| )(-X|--method) (PUT|POST)( |$)' "$tmp_dir/gh-calls.log"; then
+  echo "FAIL: missing-baseline path attempted a live mutation" >&2
+  cat "$tmp_dir/gh-calls.log" >&2
+  exit 1
+fi
+
+echo "PASS: updater never bootstraps a repository from the fixed payload"
+
+if PATH="$tmp_dir/bin:$PATH" \
+    GH_RULESET_FIXTURE="$fixture" \
+    GH_CALL_LOG="$tmp_dir/gh-calls.log" \
+    tools/github/apply-repo-rulesets.sh --active --repos Argus \
+      >"$tmp_dir/argus-active.log" 2>&1; then
+  echo "FAIL: generic activation did not defer to Argus's dedicated authority" >&2
+  exit 1
+fi
+
+if ! grep -qF "Argus owns a dedicated merge-queue ruleset path" \
+    "$tmp_dir/argus-active.log"; then
+  echo "FAIL: Argus refusal did not identify the dedicated authority" >&2
+  cat "$tmp_dir/argus-active.log" >&2
+  exit 1
+fi
+
+if grep -Eq -- '(^| )(-X|--method) (PUT|POST)( |$)' "$tmp_dir/gh-calls.log"; then
+  echo "FAIL: generic Argus activation attempted a live mutation" >&2
+  cat "$tmp_dir/gh-calls.log" >&2
+  exit 1
+fi
+
+echo "PASS: generic activation defers Argus to its dedicated ruleset path"

--- a/tests/github/merge-queue-readiness.test.sh
+++ b/tests/github/merge-queue-readiness.test.sh
@@ -1,0 +1,167 @@
+#!/usr/bin/env bash
+# Regression contract for the repository-owned merge-queue configuration.
+set -euo pipefail
+
+REPO_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+cd "$REPO_ROOT"
+
+checks=0
+failures=0
+
+pass() {
+  checks=$((checks + 1))
+  echo "PASS: $1"
+}
+
+fail() {
+  checks=$((checks + 1))
+  failures=$((failures + 1))
+  echo "FAIL: $1" >&2
+}
+
+expected_required_workflows=(
+  .github/workflows/_required.yml
+  .github/workflows/build-images.yml
+  .github/workflows/install-test.yml
+  .github/workflows/release.yml
+)
+
+required_context_pattern='^[[:space:]]{4}name: (lint|unit-tests|integration-tests|security/dependency-scan|security/secrets-scan|build|schema-validation|deps/version-sync|test|install|release)$'
+mapfile -t required_workflows < <(
+  grep -lE "$required_context_pattern" .github/workflows/*.yml | sort
+)
+
+if [[ "${required_workflows[*]}" == "${expected_required_workflows[*]}" ]]; then
+  pass "required contexts are supplied by the expected four workflows"
+else
+  fail "required-context workflow inventory has drifted"
+  printf 'Expected: %s\nActual:   %s\n' \
+    "${expected_required_workflows[*]}" "${required_workflows[*]}" >&2
+fi
+
+for workflow in "${required_workflows[@]}"; do
+  on_block=$(awk '
+    /^on:$/ { in_on = 1; next }
+    in_on && /^[^[:space:]#]/ { exit }
+    in_on { print }
+  ' "$workflow")
+
+  for existing_trigger in push pull_request workflow_dispatch; do
+    if grep -qE "^  ${existing_trigger}:" <<<"$on_block"; then
+      pass "$workflow preserves $existing_trigger"
+    else
+      fail "$workflow is missing existing trigger $existing_trigger"
+    fi
+  done
+
+  if grep -qE '^  merge_group:$' <<<"$on_block" &&
+     grep -A1 -E '^  merge_group:$' <<<"$on_block" |
+       grep -qE '^    types: \[checks_requested\]$'; then
+    pass "$workflow handles merge_group checks_requested"
+  else
+    fail "$workflow must handle merge_group checks_requested"
+  fi
+done
+
+if [[ $(grep -Fc "github.event_name != 'merge_group'" \
+    .github/workflows/build-images.yml) -eq 2 ]]; then
+  pass "Build Images never authenticates or publishes for merge groups"
+else
+  fail "Build Images must be build-only for merge groups"
+fi
+
+if grep -qE "^[[:space:]]+if: github.event_name != 'merge_group'$" \
+    .github/workflows/install-test.yml; then
+  pass "Install test excludes the non-required matrix from merge groups"
+else
+  fail "Install test must exclude its non-required matrix from merge groups"
+fi
+
+expected_contexts='["lint","unit-tests","integration-tests","security/dependency-scan","security/secrets-scan","build","schema-validation","deps/version-sync","test","install","release"]'
+ruleset_files=(
+  configs/github/repo-ruleset.json
+  configs/github/repo-ruleset-active.json
+  configs/github/repo-ruleset-evaluate.json
+)
+
+declare -A expected_enforcement=(
+  [configs/github/repo-ruleset.json]=active
+  [configs/github/repo-ruleset-active.json]=active
+  [configs/github/repo-ruleset-evaluate.json]=evaluate
+)
+
+for ruleset in "${ruleset_files[@]}"; do
+  if jq -e '
+      .target == "branch" and
+      .conditions.ref_name.include == ["refs/heads/main"] and
+      .conditions.ref_name.exclude == []
+    ' "$ruleset" >/dev/null; then
+    pass "$ruleset targets only main"
+  else
+    fail "$ruleset must target only main"
+  fi
+
+  if jq -e --arg expected "${expected_enforcement[$ruleset]}" \
+      '.enforcement == $expected' "$ruleset" >/dev/null; then
+    pass "$ruleset keeps its intended enforcement mode"
+  else
+    fail "$ruleset enforcement mode has drifted"
+  fi
+
+  if jq -e --argjson expected "$expected_contexts" '
+      [.rules[] | select(.type == "required_status_checks")
+        | .parameters.required_status_checks[].context] == $expected
+    ' "$ruleset" >/dev/null; then
+    pass "$ruleset preserves all required checks"
+  else
+    fail "$ruleset does not preserve the required-check contract"
+  fi
+
+  if jq -e '
+      [.rules[] | select(.type == "required_status_checks")
+        | .parameters.strict_required_status_checks_policy] == [false]
+    ' "$ruleset" >/dev/null; then
+    pass "$ruleset preserves non-strict branch checks"
+  else
+    fail "$ruleset strict required-check policy has drifted"
+  fi
+
+  if jq -e '
+      [.rules[] | select(.type == "pull_request")
+        | .parameters
+        | {
+            required_approving_review_count,
+            required_review_thread_resolution,
+            allowed_merge_methods
+          }] == [{
+            "required_approving_review_count": 0,
+            "required_review_thread_resolution": true,
+            "allowed_merge_methods": ["squash"]
+          }]
+    ' "$ruleset" >/dev/null; then
+    pass "$ruleset preserves the review gate and remains squash-only"
+  else
+    fail "$ruleset review or squash-only pull-request policy has drifted"
+  fi
+
+  if jq -e '
+      [.rules[] | select(.type == "merge_queue") | .parameters] == [{
+        "check_response_timeout_minutes": 60,
+        "grouping_strategy": "ALLGREEN",
+        "max_entries_to_build": 10,
+        "max_entries_to_merge": 5,
+        "merge_method": "SQUASH",
+        "min_entries_to_merge": 1,
+        "min_entries_to_merge_wait_minutes": 5
+      }]
+    ' "$ruleset" >/dev/null; then
+    pass "$ruleset has the approved merge-queue policy"
+  else
+    fail "$ruleset merge-queue policy is absent or has drifted"
+  fi
+done
+
+echo "Results: $((checks - failures))/$checks checks passed"
+if ((failures > 0)); then
+  exit 1
+fi

--- a/tools/github/apply-repo-rulesets.sh
+++ b/tools/github/apply-repo-rulesets.sh
@@ -2,12 +2,14 @@
 set -euo pipefail
 
 # apply-repo-rulesets.sh [--active|--evaluate] [--repos repo1,repo2,...]
-# Creates or updates the homeric-main-baseline branch ruleset on every repo.
+#                         [--all] [--dry-run]
+# Adds or updates only the merge-queue rule and enforcement mode in an existing
+# homeric-main-baseline ruleset. All other live rules remain repository-owned.
 # Usage:
-#   ./tools/github/apply-repo-rulesets.sh                    # canonical (active) mode, all repos
-#   ./tools/github/apply-repo-rulesets.sh --active           # active (enforcing) mode, all repos
-#   ./tools/github/apply-repo-rulesets.sh --evaluate         # evaluate (shadow) mode, all repos
+#   ./tools/github/apply-repo-rulesets.sh --active --all     # active (enforcing) mode, all repos
+#   ./tools/github/apply-repo-rulesets.sh --evaluate --all   # evaluate (shadow) mode, all repos
 #   ./tools/github/apply-repo-rulesets.sh --repos Foo,Bar    # canonical mode, specific repos only
+#   ./tools/github/apply-repo-rulesets.sh --dry-run --repos Foo
 
 ORG="HomericIntelligence"
 RULESET_NAME="homeric-main-baseline"
@@ -16,13 +18,24 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 
 ENFORCEMENT=""
 REPOS_OVERRIDE=""
+DRY_RUN=false
+ALL_REPOS=false
 
 while [[ $# -gt 0 ]]; do
   case "${1:-}" in
     --active)        ENFORCEMENT="active"; shift ;;
     --evaluate)      ENFORCEMENT="evaluate"; shift ;;
-    --repos)         REPOS_OVERRIDE="$2"; shift 2 ;;
+    --repos)
+      if [[ $# -lt 2 || -z "${2:-}" ]]; then
+        echo "ERROR: --repos requires a non-empty comma-separated value" >&2
+        exit 2
+      fi
+      REPOS_OVERRIDE="$2"
+      shift 2
+      ;;
     --repos=*)       REPOS_OVERRIDE="${1#--repos=}"; shift ;;
+    --dry-run)       DRY_RUN=true; shift ;;
+    --all)           ALL_REPOS=true; shift ;;
     *) echo "Unknown argument: $1" >&2; exit 2 ;;
   esac
 done
@@ -38,18 +51,45 @@ else
   echo "Applying canonical ruleset ($(jq -r .enforcement "$JSON_FILE") mode)"
 fi
 
-if [[ -n "$REPOS_OVERRIDE" ]]; then
+desired_enforcement=$(jq -er '.enforcement' "$JSON_FILE")
+desired_merge_queue=$(jq -ec '
+  [.rules[] | select(.type == "merge_queue")] as $rules
+  | if ($rules | length) != 1
+    then error("canonical ruleset must contain exactly one merge_queue rule")
+    else $rules[0]
+    end
+' "$JSON_FILE")
+
+tmp_dir=$(mktemp -d)
+trap 'rm -rf "$tmp_dir"' EXIT
+
+if [[ -n "$REPOS_OVERRIDE" && "$ALL_REPOS" == true ]]; then
+  echo "ERROR: use either --repos or --all, not both" >&2
+  exit 2
+elif [[ -n "$REPOS_OVERRIDE" ]]; then
   IFS=',' read -ra REPOS <<< "$REPOS_OVERRIDE"
   echo "Targeting ${#REPOS[@]} repo(s) from --repos override: ${REPOS[*]}"
-else
+elif [[ "$ALL_REPOS" == true ]]; then
   mapfile -t REPOS < <(gh repo list "$ORG" --json name,isArchived --limit 100 \
     --jq '[.[] | select(.isArchived == false) | .name] | sort | .[]')
   echo "Discovered ${#REPOS[@]} active repo(s) via gh repo list"
+else
+  echo "ERROR: target scope is required; pass --repos <names> or explicit --all" >&2
+  exit 2
 fi
 
 if [[ ${#REPOS[@]} -eq 0 ]]; then
   echo "ERROR: no repos resolved (gh API failure or --repos was empty)" >&2
   exit 1
+fi
+
+if [[ "$DRY_RUN" != true ]]; then
+  for repo in "${REPOS[@]}"; do
+    if [[ "$repo" == "Argus" ]]; then
+      echo "ERROR: Argus owns a dedicated merge-queue ruleset path; see Argus #550/#551" >&2
+      exit 1
+    fi
+  done
 fi
 
 ok=0
@@ -59,25 +99,100 @@ for repo in "${REPOS[@]}"; do
   echo ""
   echo "--- $repo ---"
 
-  existing_id=$(gh api "repos/$ORG/$repo/rulesets" --paginate \
-    --jq ".[] | select(.name == \"$RULESET_NAME\") | .id" 2>/dev/null || echo "")
+  ruleset_list="$tmp_dir/$repo-rulesets.json"
+  if ! gh api "repos/$ORG/$repo/rulesets?includes_parents=false" > "$ruleset_list"; then
+    echo "  FAILED: could not list repository rulesets" >&2
+    fail=$((fail + 1))
+    continue
+  fi
+
+  mapfile -t existing_ids < <(
+    jq -r --arg name "$RULESET_NAME" \
+      '.[] | select(.name == $name) | .id' "$ruleset_list"
+  )
+
+  if [[ ${#existing_ids[@]} -gt 1 ]]; then
+    echo "  FAILED: multiple rulesets named '$RULESET_NAME'; refusing ambiguous update" >&2
+    fail=$((fail + 1))
+    continue
+  fi
+
+  existing_id="${existing_ids[0]:-}"
 
   if [[ -z "$existing_id" ]]; then
-    echo "  Creating..."
-    if gh api -X POST "repos/$ORG/$repo/rulesets" --input "$JSON_FILE" > /dev/null 2>&1; then
-      echo "  Created."
-      ok=$((ok + 1))
-    else
-      echo "  FAILED"
-      fail=$((fail + 1))
-    fi
+    echo "  FAILED: '$RULESET_NAME' is absent; bootstrap it from repository-owned policy" >&2
+    fail=$((fail + 1))
   else
-    echo "  Updating (id: $existing_id)..."
-    if gh api -X PUT "repos/$ORG/$repo/rulesets/$existing_id" --input "$JSON_FILE" > /dev/null 2>&1; then
-      echo "  Updated."
+    live_ruleset="$tmp_dir/$repo-$existing_id-live.json"
+    update_payload="$tmp_dir/$repo-$existing_id-update.json"
+
+    if ! gh api "repos/$ORG/$repo/rulesets/$existing_id" > "$live_ruleset"; then
+      echo "  FAILED: could not read live ruleset id $existing_id" >&2
+      fail=$((fail + 1))
+      continue
+    fi
+
+    if ! jq -e \
+        --arg enforcement "$desired_enforcement" \
+        --arg source "$ORG/$repo" \
+        --argjson merge_queue "$desired_merge_queue" '
+      ([.rules[] | select(.type == "merge_queue")] | length) as $queue_count
+      | if .source_type != "Repository" or .source != $source
+        then error("ruleset is not owned by the target repository")
+        elif (has("name") and has("target") and has("bypass_actors")
+          and has("conditions") and has("rules")) | not
+        then error("live ruleset response is incomplete")
+        elif $queue_count > 1
+        then error("live ruleset has multiple merge_queue rules")
+        else {
+          name,
+          target,
+          enforcement: $enforcement,
+          bypass_actors,
+          conditions,
+          rules: (
+            if $queue_count == 1
+            then [.rules[] | if .type == "merge_queue" then $merge_queue else . end]
+            else .rules + [$merge_queue]
+            end
+          )
+        }
+        end
+    ' "$live_ruleset" > "$update_payload"; then
+      echo "  FAILED: could not derive a scoped update from the live ruleset" >&2
+      fail=$((fail + 1))
+      continue
+    fi
+
+    if ! jq -e --slurpfile candidate "$update_payload" '
+      def unrelated:
+        {
+          name,
+          target,
+          bypass_actors,
+          conditions,
+          rules: [.rules[] | select(.type != "merge_queue")]
+        };
+      unrelated == ($candidate[0] | unrelated)
+    ' "$live_ruleset" > /dev/null; then
+      echo "  FAILED: scoped update would change or remove an unrelated live rule" >&2
+      fail=$((fail + 1))
+      continue
+    fi
+
+    if [[ "$DRY_RUN" == true ]]; then
+      echo "DRY-RUN $repo payload: $(jq -c . "$update_payload")"
+      ok=$((ok + 1))
+      continue
+    fi
+
+    echo "  Updating only enforcement and merge_queue (id: $existing_id)..."
+    if gh api -X PUT "repos/$ORG/$repo/rulesets/$existing_id" \
+        --input "$update_payload" > /dev/null; then
+      echo "  Updated; repository-specific contexts and unrelated rules preserved."
       ok=$((ok + 1))
     else
-      echo "  FAILED"
+      echo "  FAILED" >&2
       fail=$((fail + 1))
     fi
   fi
@@ -85,3 +200,6 @@ done
 
 echo ""
 echo "Done: $ok succeeded, $fail failed"
+if ((fail > 0)); then
+  exit 1
+fi


### PR DESCRIPTION
Closes #386

Implements the repository-owned workflow, validation, documentation, and ruleset-readiness changes for the HomericIntelligence merge-queue rollout tracked by Odysseus #386.

Live ruleset activation remains staged for post-merge smoke validation.