### PR TITLE
ci: enable merge queue with repository-owned ruleset preservation

### DIFF
--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -24,7 +24,12 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  merge_group:
+    types: [checks_requested]
   workflow_dispatch:
+
+permissions:
+  contents: read
 
 concurrency:
   group: required-checks-${{ github.ref }}
@@ -37,6 +42,8 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Install yamllint
         run: pip install yamllint
@@ -90,6 +97,8 @@ jobs:
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: "Reject silent-failure workaround in shell/YAML/Dockerfile/justfile/HCL"
         run: |
@@ -174,6 +183,8 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Install markdown parser
         run: pip install markdown
@@ -234,6 +245,7 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
+          persist-credentials: false
           submodules: true
 
       - name: Install just
@@ -289,6 +301,8 @@ jobs:
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Trivy filesystem scan on configs/
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25  # v0.36.0
@@ -306,6 +320,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Run Gitleaks
         run: |
@@ -323,6 +338,8 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Install pixi
         uses: prefix-dev/setup-pixi@a09b6247153796b190642a2b53fac4241043cf6f  # v0.10.0
@@ -341,6 +358,8 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Install check-jsonschema
         run: pip install check-jsonschema
@@ -414,6 +433,7 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
+          persist-credentials: false
           submodules: true
 
       - name: Check for uninitialized submodules

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -5,7 +5,7 @@ name: Build Images
 # each a single pinnable, published artifact in GHCR.
 #
 # Registry:   ghcr.io/homericintelligence/<component> (lowercase)
-# Promotion:  pull_request -> BUILD ONLY (no push; validates images build)
+# Promotion:  pull_request / merge_group / manual -> BUILD ONLY (no push)
 #             push to main -> build + push :sha-<short> and :latest
 #             push tag v*  -> build + push :<semver> tags
 #             matrix entries with publish: false are always BUILD ONLY
@@ -20,6 +20,8 @@ name: Build Images
 on:
   pull_request:
     branches: [main]
+  merge_group:
+    types: [checks_requested]
   push:
     branches: [main]
     tags:
@@ -34,14 +36,18 @@ env:
   REGISTRY: ghcr.io
   IMAGE_NAMESPACE: ghcr.io/homericintelligence
 
+permissions:
+  contents: read
+
 jobs:
-  build:
+  validate:
     name: build
+    if: >-
+      github.event_name == 'pull_request' ||
+      github.event_name == 'merge_group' ||
+      github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    permissions:
-      contents: read
-      packages: write
     strategy:
       fail-fast: false
       matrix:
@@ -84,6 +90,69 @@ jobs:
       - name: Checkout (with submodule contexts)
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
+          persist-credentials: false
+          submodules: recursive
+
+      - name: Verify build context exists
+        run: test -f "${MATRIX_FILE}" && test -d "${MATRIX_CONTEXT}"
+        env:
+          MATRIX_FILE: ${{ matrix.file }}
+          MATRIX_CONTEXT: ${{ matrix.context }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c  # v4.2.0
+
+      - name: Derive tags and labels
+        id: meta
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302  # v6.2.0
+        with:
+          images: ${{ env.IMAGE_NAMESPACE }}/${{ matrix.component }}
+          tags: type=sha,prefix=sha-
+
+      - name: Build without publishing
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a  # v7.3.0
+        with:
+          context: ${{ matrix.context }}
+          file: ${{ matrix.file }}
+          push: false
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=${{ matrix.component }}-r2
+          cache-to: type=gha,mode=max,scope=${{ matrix.component }}-r2
+
+  publish:
+    name: build
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      packages: write  # Push-only job publishes reviewed images to GHCR.
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - component: agamemnon
+            context: control/Agamemnon
+            file: control/Agamemnon/Dockerfile
+            publish: true
+          - component: nestor
+            context: control/Nestor
+            file: control/Nestor/Dockerfile
+            publish: true
+          - component: hermes
+            context: infrastructure/Hermes
+            file: infrastructure/Hermes/Dockerfile
+            publish: true
+          - component: argus-exporter
+            context: infrastructure/Argus/exporter
+            file: e2e/Dockerfile.argus-exporter
+            publish: false
+    steps:
+      - name: Checkout (with submodule contexts)
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
           submodules: recursive
 
       - name: Verify build context exists
@@ -96,7 +165,6 @@ jobs:
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c  # v4.2.0
 
       - name: Log in to GHCR
-        if: github.event_name != 'pull_request'
         uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0  # v4.4.0
         with:
           registry: ${{ env.REGISTRY }}
@@ -119,7 +187,7 @@ jobs:
         with:
           context: ${{ matrix.context }}
           file: ${{ matrix.file }}
-          push: ${{ github.event_name != 'pull_request' && matrix.publish }}
+          push: ${{ matrix.publish }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           # Cache scope is salted with -r2 to invalidate the pre-openssl-fix

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,9 @@ jobs:
       - name: Validate justfile (parse round-trip)
         run: just --summary
 
+      - name: Validate merge-queue readiness and ruleset mutation safety
+        run: just test-merge-queue-readiness
+
       - name: Symlink integrity audit
         run: |
           broken=0

--- a/.github/workflows/install-test.yml
+++ b/.github/workflows/install-test.yml
@@ -5,6 +5,8 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  merge_group:
+    types: [checks_requested]
   schedule:
     - cron: "0 6 * * 1"  # Every Monday at 06:00 UTC
   workflow_dispatch:
@@ -13,6 +15,9 @@ on:
         description: Branch/SHA to clone inside containers
         required: false
         default: ""
+
+permissions:
+  contents: read
 
 jobs:
   # Canonical `install` check for the 8-category CI naming scheme
@@ -30,6 +35,8 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Installer script is valid bash
         run: bash -n install.sh
@@ -69,6 +76,7 @@ jobs:
 
   install-test:
     name: Install (${{ matrix.os }})
+    if: github.event_name != 'merge_group'
     runs-on: ubuntu-latest
     timeout-minutes: 45
     strategy:
@@ -78,6 +86,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c  # v4.2.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,20 +7,22 @@ on:
       - 'v[0-9]+.[0-9]+.[0-9]+'
   pull_request:
     branches: [main]
+  merge_group:
+    types: [checks_requested]
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   # Canonical `release` check for the 8-category CI naming scheme
   # (docs/ci-naming-convention.md). Actual publishing is tag-gated (the
   # validate/publish jobs below run only on a vX.Y.Z tag push). This
-  # lightweight dry-run runs on every main push/PR so the Ecosystem CI Status
-  # board's **release** column lights up: it exercises the same release-gating
-  # logic (CHANGELOG shape + release-contract regression tests + release-notes
-  # extraction) WITHOUT creating a GitHub Release, so release regressions are
-  # caught on `main` before a tag is ever cut.
+  # lightweight dry-run runs on every main push/PR/merge group/manual dispatch
+  # so the Ecosystem CI Status board's **release** column lights up: it
+  # exercises the same release-gating logic (CHANGELOG shape + release-contract
+  # regression tests + release-notes extraction) WITHOUT creating a GitHub
+  # Release, so release regressions are caught before a tag is ever cut.
   release:
     name: release
     # Skip on tag pushes — the real validate/publish jobs handle tags.
@@ -31,6 +33,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: CHANGELOG has an Unreleased section
         run: |
@@ -64,6 +67,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Extract version from git tag
         id: tag
@@ -105,14 +109,17 @@ jobs:
   publish:
     name: publish-release
     # Tag-only: never publishes a GitHub Release on main push/PR.
-    if: ${{ startsWith(github.ref, 'refs/tags/') }}
+    if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     needs: validate
+    permissions:
+      contents: write  # Trusted tag-push job creates the GitHub Release.
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Extract version from git tag
         id: tag

--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,6 @@ node_modules/
 
 # Git worktrees
 .worktrees/
+
+# Generated live ruleset recovery snapshots (operator-local, never commit)
+configs/github/backups/ruleset-mutations/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -258,16 +258,21 @@ Address review comments promptly:
 
 ## Branch Protection Policy
 
-The `main` branch is protected by a GitHub **repository ruleset** (not classic branch protection) to ensure code quality and prevent accidents. The active ruleset is committed at `configs/github/repo-ruleset-active.json` and is the source of truth for these rules; see the runbook `docs/runbooks/branch-protection-rollout.md` for how it is applied. These rules are enforced automatically by GitHub:
+The `main` branch is protected by a live GitHub repository ruleset. The complete
+live ruleset is authoritative. `configs/github/repo-ruleset*.json` records the
+reviewed Odysseus input parameters but is not a fleet-wide replacement payload;
+see `docs/runbooks/branch-protection-rollout.md` for read-back and staged
+activation.
 
 ### Protection Rules
 
 - **Direct pushes blocked** - All changes to `main` must go through pull requests (`deletion` and non-PR pushes are rejected).
-- **PR approval required** - At least 1 approving review is required before merging (`required_approving_review_count: 1`).
+- **Checks-only merge gate** - The live repository ruleset requires 0 approvals; required checks and resolved review threads remain mandatory.
 - **Review threads must be resolved** - All PR review conversations must be resolved before merge (`required_review_thread_resolution`).
 - **Signed commits required** - Commits on `main` must be signed (`required_signatures`).
-- **CI status checks must pass** - The required checks must be green before merge: `lint`, `unit-tests`, `integration-tests`, `security/dependency-scan`, `security/secrets-scan`, `build`, `schema-validation`, `deps/version-sync`.
-- **Linear history enforced** - Only squash merges are allowed (repo setting: `allow_squash_merge` only; merge-commit and rebase-merge are disabled). Squashing collapses each PR into a single commit on `main`, keeping the history clean and linear.
+- **CI status checks must pass** - The 11 live contexts are `lint`, `unit-tests`, `integration-tests`, `security/dependency-scan`, `security/secrets-scan`, `build`, `schema-validation`, `deps/version-sync`, `test`, `install`, and `release`.
+- **Current merge metadata** - GitHub currently reports `allow_merge_commit: true`, `allow_squash_merge: true`, and `allow_rebase_merge: false`. This rollout configures the merge queue itself to use `SQUASH`.
+- **Merge queue is staged** - Workflow readiness lands first. A human-reviewed, post-merge operator step dry-runs the live-derived payload, activates one pilot, and records a queued smoke result before any fleet rollout.
 
 ### Merge Convention
 
@@ -277,25 +282,16 @@ Always use the following command to merge your PR:
 gh pr merge --auto --squash
 ```
 
-This will:
-1. Enable auto-merge on your PR (merge happens as soon as all conditions are met)
-2. Use squash strategy (the only strategy this repo permits), collapsing the PR into one linear-history commit
-3. Keep your branch name clean and commit history readable
+This enables auto-merge using squash. After queue activation, GitHub enqueues the
+PR once its entry conditions are met and retests the synthetic merge group
+against the current `main` tip.
 
 ### For Repo Admins
 
-If you are setting up a fresh fork or new repository and need to enable these rules:
-
-1. Go to **Settings** → **Branches**
-2. Click **Add rule** under "Branch protection rules"
-3. Enter `main` as the branch name pattern
-4. Enable:
-   - Require a pull request before merging (1 approval minimum)
-   - Require status checks to pass before merging
-   - Require branches to be up to date before merging
-   - Require a linear history (dismiss stale pull request approvals when new commits are pushed)
-5. Optionally require dismissal of stale reviews when new commits are pushed
-6. Save the rule
+Use the repository-owned policy process and
+`docs/runbooks/branch-protection-rollout.md`. Do not create a live baseline from
+the generic Odysseus JSON, activate a queue before its workflows reach `main`,
+or skip independent human review of workflow changes.
 
 ## Key References
 

--- a/configs/github/canonical-checks.md
+++ b/configs/github/canonical-checks.md
@@ -1,6 +1,7 @@
 # HomericIntelligence — Canonical Required CI Check Names
 
-All 15 repos must emit these exact GitHub Actions status check names.
+All 16 first-party repositories must emit these exact GitHub Actions status
+check names.
 Each check must run a **real validator** — no echo-true placeholders.
 
 ## Required checks (block merge if failing)
@@ -15,6 +16,25 @@ Each check must run a **real validator** — no echo-true placeholders.
 | `build` | Build | pixi run build, cmake --build, docker build |
 | `schema-validation` | Validation | check-jsonschema against workflow YAMLs / pixi.toml / NATS schemas |
 | `deps/version-sync` | Validation | verify VERSION/pyproject.toml/pixi.toml/Conanfile parity |
+
+## Additional Odysseus required checks
+
+Odysseus's live repository ruleset also requires `test`, `install`, and
+`release`, for 11 contexts total. The repository ruleset input artifacts retain
+those exact names, and each supplying workflow handles
+`merge_group: checks_requested` before queue activation.
+
+Repository context lists are not interchangeable. The current regression
+fixtures preserve these live unions:
+
+- Argus: 14 contexts across two rulesets; its dedicated rollout is
+  [replacement PR #552](https://github.com/HomericIntelligence/Argus/pull/552).
+- Proteus: 13 contexts across two rulesets.
+- Myrmidons: 7 contexts in its baseline ruleset.
+
+The generic updater derives its candidate from each complete live baseline and
+never replaces a repository's required contexts from this document or a fixed
+JSON payload.
 
 ## Informational checks (report but do not block merge)
 

--- a/configs/github/repo-ruleset-active.json
+++ b/configs/github/repo-ruleset-active.json
@@ -25,6 +25,18 @@
       }
     },
     {
+      "type": "merge_queue",
+      "parameters": {
+        "check_response_timeout_minutes": 60,
+        "grouping_strategy": "ALLGREEN",
+        "max_entries_to_build": 10,
+        "max_entries_to_merge": 5,
+        "merge_method": "SQUASH",
+        "min_entries_to_merge": 1,
+        "min_entries_to_merge_wait_minutes": 5
+      }
+    },
+    {
       "type": "required_status_checks",
       "parameters": {
         "strict_required_status_checks_policy": false,

--- a/configs/github/repo-ruleset-evaluate.json
+++ b/configs/github/repo-ruleset-evaluate.json
@@ -22,9 +22,22 @@
       }
     },
     {
+      "type": "merge_queue",
+      "parameters": {
+        "check_response_timeout_minutes": 60,
+        "grouping_strategy": "ALLGREEN",
+        "max_entries_to_build": 10,
+        "max_entries_to_merge": 5,
+        "merge_method": "SQUASH",
+        "min_entries_to_merge": 1,
+        "min_entries_to_merge_wait_minutes": 5
+      }
+    },
+    {
       "type": "required_status_checks",
       "parameters": {
         "strict_required_status_checks_policy": false,
+        "do_not_enforce_on_create": false,
         "required_status_checks": [
           { "context": "lint",                    "integration_id": 15368 },
           { "context": "unit-tests",              "integration_id": 15368 },
@@ -33,7 +46,10 @@
           { "context": "security/secrets-scan",   "integration_id": 15368 },
           { "context": "build",                   "integration_id": 15368 },
           { "context": "schema-validation",       "integration_id": 15368 },
-          { "context": "deps/version-sync",       "integration_id": 15368 }
+          { "context": "deps/version-sync",       "integration_id": 15368 },
+          { "context": "test",                    "integration_id": 15368 },
+          { "context": "install",                 "integration_id": 15368 },
+          { "context": "release",                 "integration_id": 15368 }
         ]
       }
     }

--- a/configs/github/repo-ruleset.json
+++ b/configs/github/repo-ruleset.json
@@ -22,9 +22,22 @@
       }
     },
     {
+      "type": "merge_queue",
+      "parameters": {
+        "check_response_timeout_minutes": 60,
+        "grouping_strategy": "ALLGREEN",
+        "max_entries_to_build": 10,
+        "max_entries_to_merge": 5,
+        "merge_method": "SQUASH",
+        "min_entries_to_merge": 1,
+        "min_entries_to_merge_wait_minutes": 5
+      }
+    },
+    {
       "type": "required_status_checks",
       "parameters": {
         "strict_required_status_checks_policy": false,
+        "do_not_enforce_on_create": false,
         "required_status_checks": [
           { "context": "lint",                    "integration_id": 15368 },
           { "context": "unit-tests",              "integration_id": 15368 },
@@ -33,7 +46,10 @@
           { "context": "security/secrets-scan",   "integration_id": 15368 },
           { "context": "build",                   "integration_id": 15368 },
           { "context": "schema-validation",       "integration_id": 15368 },
-          { "context": "deps/version-sync",       "integration_id": 15368 }
+          { "context": "deps/version-sync",       "integration_id": 15368 },
+          { "context": "test",                    "integration_id": 15368 },
+          { "context": "install",                 "integration_id": 15368 },
+          { "context": "release",                 "integration_id": 15368 }
         ]
       }
     }

--- a/docs/runbooks/branch-protection-rollout.md
+++ b/docs/runbooks/branch-protection-rollout.md
@@ -1,87 +1,129 @@
-# Branch Protection Rollout Runbook
+# Branch Protection and Merge Queue Rollout
 
-How to add a new repo to the `homeric-main-baseline` ruleset, or re-apply the
-ruleset after a change.
+This runbook stages the `homeric-main-baseline` merge-queue rollout without
+replacing repository-specific protection.
+
+## Authority and artifacts
+
+Live complete repository rulesets are authoritative. Always read the exact
+repository-owned ruleset from GitHub before diagnosing or changing protection.
+The files under `configs/github/` are an input and review artifact for approved
+enforcement and merge-queue parameters; they are not a complete fleet-wide
+replacement payload and can drift from live rules.
+
+`tools/github/apply-repo-rulesets.sh` fails closed unless it finds exactly one
+repository-owned `homeric-main-baseline`. It derives the candidate from that
+complete live response and changes only:
+
+- the requested enforcement mode; and
+- one `merge_queue` rule, added or replaced with the reviewed parameters.
+
+The script preserves required contexts, bypass actors, target conditions, and
+all unrelated rules. It refuses incomplete required-status-check schemas,
+ambiguous baselines, and missing baselines. It never bootstraps a repository
+from a fixed generic context list.
+
+Argus is not activated through this generic path. Its 14 contexts span two
+rulesets and its dedicated rollout is tracked by
+[Argus #550](https://github.com/HomericIntelligence/Argus/issues/550) and
+[replacement PR #552](https://github.com/HomericIntelligence/Argus/pull/552).
 
 ## Prerequisites
 
-- `gh` CLI authenticated with org-admin scope
-- Run all commands from the Odysseus root directory
+- `gh` authenticated with repository-administration scope
+- `jq` and `just` available
+- commands run from the Odysseus repository root
+- workflow changes merged to each target repository's default branch
+- independent human review completed for changes under `.github/workflows/`
+- an operator assigned to inspect dry-run and read-back evidence
 
-## Adding a new repo
+## New repository baseline
 
-1. In the new repo, create `.github/workflows/_required.yml` using
-   `research/Scylla/.github/workflows/_required.yml` as the reference.
-   The workflow must be named `Required Checks` and have `name:` fields that
-   match the contexts in `configs/github/canonical-checks.md`. There are
-   **8 required contexts**; `_required.yml` also defines a 9th job
-   (`forbid-suppressions`) that is intentionally NOT a required context.
-   Each job must invoke a real validator for that repo's stack.
+Create a complete repository-owned baseline through that repository's reviewed
+policy process. Ensure its required contexts are already emitted on pull-request
+branches before making them required. This script intentionally refuses to
+create a missing baseline.
 
-2. Open a PR, verify all 8 required contexts appear in the PR checks UI once CI
-   runs, then merge.
+After the baseline exists, continue with the staged activation below.
 
-3. Apply the ruleset to the new repo in shadow (evaluate) mode first:
+## Staged activation
+
+Do not mutate live rulesets from the implementation PR. Activation starts only
+after the workflow/configuration PR is merged and its required checks have
+completed on `main`.
+
+1. Run the offline readiness and security gates:
+
    ```bash
-   ./tools/github/apply-repo-rulesets.sh --evaluate --repos <NewRepo>
+   just test-merge-queue-readiness
+   pixi run ci
    ```
-   (The bare invocation now applies the canonical `repo-ruleset.json`, which is
-   `active`; pass `--evaluate` for the shadow pass.)
 
-4. Observe evaluate mode for one PR cycle, then flip to active:
+2. Confirm every required workflow on `main` handles
+   `merge_group: checks_requested`. Confirm its validation jobs are read-only;
+   publishing permissions must remain limited to trusted push or tag jobs.
+
+3. Generate a no-write candidate for one pilot repository:
+
    ```bash
-   ./tools/github/apply-repo-rulesets.sh --active --repos <NewRepo>
+   ./tools/github/apply-repo-rulesets.sh \
+     --active --repos <PilotRepo> --dry-run
    ```
 
-## Re-applying the ruleset to all repos
+4. Compare the candidate with the complete live ruleset. Required contexts,
+   bypass actors, conditions, and non-queue rules must be identical. Stop on
+   any difference.
+
+5. With explicit operator approval, activate only the pilot:
+
+   ```bash
+   ./tools/github/apply-repo-rulesets.sh --active --repos <PilotRepo>
+   ```
+
+6. Read the ruleset back from GitHub and run one representative queued PR.
+   Record the merge-group SHA and exact required-check results. The queue is not
+   validated until the synthetic merge group reports every required context and
+   merges with `SQUASH`.
+
+7. Repeat the dry-run, review, activation, and read-back per repository. Use
+   `--all` only as an explicit, separately approved fleet operation after the
+   pilot succeeds. Fleet operations audit and skip Argus; complete its
+   separately reviewed #550/#552 rollout through the Argus-owned path.
+
+`--evaluate` changes the enforcement mode of the complete baseline. Use it only
+when that baseline is already intentionally in a staged evaluate state. Do not
+downgrade an active protection baseline merely to shadow-test the queue.
+
+## Read-only verification
+
+List repository-owned rulesets and fetch the complete baseline:
 
 ```bash
-# Evaluate mode first (shadow enforcement — reports but doesn't block).
-# NOTE: the bare invocation applies the canonical repo-ruleset.json, which is
-# now "active"; use --evaluate explicitly for the shadow pass.
-./tools/github/apply-repo-rulesets.sh --evaluate
+REPO=HomericIntelligence/<repo>
+gh api "repos/${REPO}/rulesets?includes_parents=false" \
+  --jq '.[] | {id, name, source, source_type, enforcement}'
 
-# Check evaluate results
-gh api "repos/HomericIntelligence/<repo>/rulesets/rule-suites?ref=refs/heads/main" \
-  --jq '.[] | {result, evaluation_result, pushed_at}' | head -20
-
-# Flip to active when evaluate shows all-pass
-./tools/github/apply-repo-rulesets.sh --active
+ID=$(gh api "repos/${REPO}/rulesets?includes_parents=false" \
+  --jq '.[] | select(.name=="homeric-main-baseline" and
+                     .source_type=="Repository") | .id')
+gh api "repos/${REPO}/rulesets/${ID}" \
+  --jq '{name, enforcement, conditions, bypass_actors, rules}'
 ```
 
-## Verify a repo's ruleset state
+Verify the required contexts and queue rule from that complete response:
 
 ```bash
-gh api repos/HomericIntelligence/<repo>/rulesets \
-  --jq '.[] | select(.name=="homeric-main-baseline") | {id, enforcement}'
-
-# Full detail (contexts list)
-ID=$(gh api repos/HomericIntelligence/<repo>/rulesets \
-  --jq '.[] | select(.name=="homeric-main-baseline") | .id')
-gh api repos/HomericIntelligence/<repo>/rulesets/$ID \
-  --jq '.rules[] | select(.type=="required_status_checks") | .parameters.required_status_checks[].context'
+gh api "repos/${REPO}/rulesets/${ID}" \
+  --jq '.rules[] | select(.type=="required_status_checks") |
+        .parameters.required_status_checks[].context'
+gh api "repos/${REPO}/rulesets/${ID}" \
+  --jq '.rules[] | select(.type=="merge_queue")'
 ```
 
-## Bypass actor (admin merge)
+## Rollback boundary
 
-The ruleset has a `RepositoryRole` bypass actor (id 5 = admin) in `pull_request`
-mode. Admins can bypass the ruleset to merge a PR that would otherwise be blocked
-by the old context list during a ruleset migration. Use sparingly.
-
-## Rollback
-
-Re-applying evaluate mode is instant and safe:
-```bash
-./tools/github/apply-repo-rulesets.sh --evaluate   # or: --repos <repo>
-```
-
-> Note: `org-ruleset.json` is not applied on the current GitHub plan —
-> `gh api orgs/HomericIntelligence/rulesets` returns 404 / requires `admin:org`.
-> Per-repo rulesets (`repos/<org>/<repo>/rulesets`) are the enforcing path.
-
-To remove the ruleset entirely from a single repo:
-```bash
-ID=$(gh api repos/HomericIntelligence/<repo>/rulesets \
-  --jq '.[] | select(.name=="homeric-main-baseline") | .id')
-gh api -X DELETE repos/HomericIntelligence/<repo>/rulesets/$ID
-```
+Rollback is an operator action against the freshly read live ruleset. Preserve a
+complete pre-change response before activation, modify only the queue rule or
+enforcement field, and read the result back. Never disable, replace, or delete
+unrelated status, review, signature, or bypass rules to recover from a queue
+problem.

--- a/docs/runbooks/branch-protection-rollout.md
+++ b/docs/runbooks/branch-protection-rollout.md
@@ -12,8 +12,13 @@ enforcement and merge-queue parameters; they are not a complete fleet-wide
 replacement payload and can drift from live rules.
 
 `tools/github/apply-repo-rulesets.sh` fails closed unless it finds exactly one
-repository-owned `homeric-main-baseline`. It derives the candidate from that
-complete live response and changes only:
+repository-owned `homeric-main-baseline` whose fetched detail response has
+`target: branch` and the exact main-only scope
+`conditions.ref_name.include == ["refs/heads/main"]` and
+`conditions.ref_name.exclude == []`. Wildcards, renamed rulesets, alternate or
+missing branches, malformed scope, and inherited rulesets are rejected before
+the script derives a payload. It derives the candidate from the complete live
+response and changes only:
 
 - the requested enforcement mode; and
 - one `merge_queue` rule, added or replaced with the reviewed parameters.
@@ -23,6 +28,17 @@ all unrelated rules. It refuses incomplete required-status-check schemas,
 ambiguous baselines, and missing baselines. It never bootstraps a repository
 from a fixed generic context list.
 
+Before every non-dry-run PUT, the script atomically saves the complete fetched
+pre-state under `configs/github/backups/ruleset-mutations/` (or an explicit
+`--snapshot-dir`). That ignored operator-local snapshot survives process exit.
+After PUT, the script fetches the ruleset again and requires an exact match for
+`name`, `target`, `enforcement`, `bypass_actors`, `conditions`, and every rule.
+Any failed or ambiguous PUT, failed readback, mismatched postcondition, or
+interrupt while the mutation is armed triggers rollback from the pre-state,
+followed by an exact rollback readback. The operation aborts before processing
+another repository. If rollback cannot be verified, it reports `UNCERTAIN
+MUTATION` and retains the durable snapshot for operator recovery.
+
 Argus is not activated through this generic path. Its 14 contexts span two
 rulesets and its dedicated rollout is tracked by
 [Argus #550](https://github.com/HomericIntelligence/Argus/issues/550) and
@@ -31,7 +47,8 @@ rulesets and its dedicated rollout is tracked by
 ## Prerequisites
 
 - `gh` authenticated with repository-administration scope
-- `jq` and `just` available
+- `jq`, `just`, and Python with PyYAML available (the pixi environment provides
+  all three)
 - commands run from the Odysseus repository root
 - workflow changes merged to each target repository's default branch
 - independent human review completed for changes under `.github/workflows/`
@@ -77,13 +94,16 @@ completed on `main`.
 5. With explicit operator approval, activate only the pilot:
 
    ```bash
-   ./tools/github/apply-repo-rulesets.sh --active --repos <PilotRepo>
+   ./tools/github/apply-repo-rulesets.sh \
+     --active --repos <PilotRepo> \
+     --snapshot-dir <durable-operator-path>/<PilotRepo>
    ```
 
-6. Read the ruleset back from GitHub and run one representative queued PR.
-   Record the merge-group SHA and exact required-check results. The queue is not
-   validated until the synthetic merge group reports every required context and
-   merges with `SQUASH`.
+6. Preserve the script's snapshot path and exact-postcondition output. Then
+   independently read the ruleset back from GitHub and run one representative
+   queued PR. Record the merge-group SHA and exact required-check results. The
+   queue is not validated until the synthetic merge group reports every
+   required context and merges with `SQUASH`.
 
 7. Repeat the dry-run, review, activation, and read-back per repository. Use
    `--all` only as an explicit, separately approved fleet operation after the
@@ -122,8 +142,15 @@ gh api "repos/${REPO}/rulesets/${ID}" \
 
 ## Rollback boundary
 
-Rollback is an operator action against the freshly read live ruleset. Preserve a
-complete pre-change response before activation, modify only the queue rule or
-enforcement field, and read the result back. Never disable, replace, or delete
-unrelated status, review, signature, or bypass rules to recover from a queue
-problem.
+The apply script automatically arms rollback before PUT and verifies rollback
+after any ambiguous write or postcondition failure. A verified rollback still
+terminates the operation; rerun only after diagnosing the failed mutation. An
+`UNCERTAIN MUTATION` is a fleet-wide stop condition: do not run another apply,
+and do not hand-edit protection. Use the reported durable pre-state snapshot to
+construct the same writable projection (`name`, `target`, `enforcement`,
+`bypass_actors`, `conditions`, and `rules`), restore it with an explicitly
+reviewed PUT, and verify an exact readback.
+
+Never disable, replace, or delete unrelated status, review, signature, or
+bypass rules to recover from a queue problem. Retain the snapshot and the exact
+API output as incident evidence until independent review confirms recovery.

--- a/docs/runbooks/branch-protection-rollout.md
+++ b/docs/runbooks/branch-protection-rollout.md
@@ -34,8 +34,10 @@ pre-state under `configs/github/backups/ruleset-mutations/` (or an explicit
 After PUT, the script fetches the ruleset again and requires an exact match for
 `name`, `target`, `enforcement`, `bypass_actors`, `conditions`, and every rule.
 Any failed or ambiguous PUT, failed readback, mismatched postcondition, or
-interrupt while the mutation is armed triggers rollback from the pre-state,
-followed by an exact rollback readback. The operation aborts before processing
+HUP/INT/TERM while the mutation is armed triggers rollback from the pre-state,
+followed by an exact rollback readback. HUP/INT/TERM are ignored while rollback
+and its readback run so recovery is protected from a second ordinary shell
+interrupt as far as the shell permits. The operation aborts before processing
 another repository. If rollback cannot be verified, it reports `UNCERTAIN
 MUTATION` and retains the durable snapshot for operator recovery.
 
@@ -110,9 +112,11 @@ completed on `main`.
    pilot succeeds. Fleet operations audit and skip Argus; complete its
    separately reviewed #550/#552 rollout through the Argus-owned path.
 
-`--evaluate` changes the enforcement mode of the complete baseline. Use it only
-when that baseline is already intentionally in a staged evaluate state. Do not
-downgrade an active protection baseline merely to shadow-test the queue.
+`--evaluate` changes the enforcement mode of the complete baseline. Updating an
+already staged evaluate baseline remains supported, but active-to-evaluate
+transitions fail before snapshot or PUT. Use `--evaluate --dry-run` (including
+`just repo-rulesets-apply`) for a no-write preview against an active baseline.
+Do not downgrade active protection merely to shadow-test the queue.
 
 ## Read-only verification
 

--- a/justfile
+++ b/justfile
@@ -316,6 +316,11 @@ test-justfile-recipes:
 lint-test-scripts:
     bash scripts/lint-test-scripts.sh
 
+# Validate required-check workflows and repository-owned ruleset preservation (#386)
+test-merge-queue-readiness:
+    bash tests/github/merge-queue-readiness.test.sh
+    bash tests/github/apply-repo-rulesets.test.sh
+
 # Render Nomad config placeholders to a deploy-local dir (default /etc/nomad.d).
 # Nomad agent HCL does NOT expand OS env vars, so render before `nomad agent -config`.
 # Requires NOMAD_SERVER_IP and NOMAD_ADVERTISE_ADDR (e.g. export NOMAD_SERVER_IP=$(tailscale ip -4)).
@@ -741,13 +746,13 @@ hermes-hub-logs SERVICE="":
 # GitHub Org Ruleset Management
 # ===========================================================================
 
-# Snapshot all 15 repos' current classic branch protection to a timestamped backup file
+# Snapshot all first-party repos' current classic branch protection
 ruleset-backup:
     mkdir -p configs/github/backups
     ./tools/github/snapshot-protection.sh > "configs/github/backups/rulesets-$(date +%Y%m%d-%H%M%S).json"
     @echo "Backup written."
 
-# Snapshot all 15 repos' classic branch protection to the canonical pre-ruleset backup file
+# Snapshot all first-party repos' classic protection to the canonical backup
 protection-snapshot:
     mkdir -p configs/github/backups
     ./tools/github/snapshot-protection.sh > configs/github/backups/branch-protection-pre-ruleset.json
@@ -757,13 +762,13 @@ protection-snapshot:
 ruleset-apply FILE="configs/github/org-ruleset.json":
     ./tools/github/apply-org-ruleset.sh "{{FILE}}"
 
-# Create or update the per-repo branch ruleset on all 15 repos (evaluate mode)
+# Explicit eligible-fleet evaluate update; Argus is audited and skipped
 repo-rulesets-apply:
-    ./tools/github/apply-repo-rulesets.sh
+    ./tools/github/apply-repo-rulesets.sh --evaluate --all
 
-# Create or update the per-repo branch ruleset on all 15 repos (active/enforcing mode)
+# Explicit eligible-fleet activation; Argus is audited and skipped
 repo-rulesets-activate:
-    ./tools/github/apply-repo-rulesets.sh --active
+    ./tools/github/apply-repo-rulesets.sh --active --all
 
 # Validate the live org ruleset against the canonical JSON and print current enforcement + checks
 ruleset-validate:
@@ -797,9 +802,10 @@ ruleset-enforcement-check:
     #!/usr/bin/env bash
     set -euo pipefail
     declare -A expected=(
-      [configs/github/repo-ruleset.json]=evaluate
+      [configs/github/repo-ruleset.json]=active
       [configs/github/repo-ruleset-active.json]=active
-      [configs/github/org-ruleset.json]=evaluate
+      [configs/github/repo-ruleset-evaluate.json]=evaluate
+      [configs/github/org-ruleset.json]=active
       [configs/github/org-ruleset-active.json]=active
     )
     fail=0
@@ -813,9 +819,9 @@ ruleset-enforcement-check:
       fi
     done
     [ "$fail" -eq 0 ] || { echo "FAILED: ruleset enforcement drift detected" >&2; exit 1; }
-    echo "PASSED: all 4 ruleset configs hold their intended enforcement"
+    echo "PASSED: all ruleset configs hold their intended enforcement"
 
-# Remove classic branch protection from ALL 15 repos (requires confirmation; run after ruleset is active)
+# Remove classic protection fleet-wide (requires confirmation and active rulesets)
 protection-remove-all:
     ./tools/github/remove-classic-protection.sh --all
 

--- a/justfile
+++ b/justfile
@@ -762,9 +762,9 @@ protection-snapshot:
 ruleset-apply FILE="configs/github/org-ruleset.json":
     ./tools/github/apply-org-ruleset.sh "{{FILE}}"
 
-# Explicit eligible-fleet evaluate update; Argus is audited and skipped
+# Read-only eligible-fleet evaluate preview; Argus is audited and skipped
 repo-rulesets-apply:
-    ./tools/github/apply-repo-rulesets.sh --evaluate --all
+    ./tools/github/apply-repo-rulesets.sh --evaluate --all --dry-run
 
 # Explicit eligible-fleet activation; Argus is audited and skipped
 repo-rulesets-activate:

--- a/justfile
+++ b/justfile
@@ -338,7 +338,7 @@ render-nomad-configs OUT_DIR="/etc/nomad.d":
     if command -v nomad >/dev/null 2>&1; then nomad fmt -check "{{ OUT_DIR }}"/*.hcl; fi
 
 # Run all CI checks locally
-ci: lint validate-configs check-doc-field-drift
+ci: lint validate-configs check-doc-field-drift test-merge-queue-readiness
     @echo "All checks passed"
 
 # Cut a release: validate tag↔pixi.toml↔CHANGELOG, create tag, push (triggers release.yml)

--- a/tests/fixtures/github/argus-ruleset-contract.json
+++ b/tests/fixtures/github/argus-ruleset-contract.json
@@ -1,0 +1,115 @@
+{
+  "provenance": {
+    "captured_at": "2026-07-16T23:49:25Z",
+    "repository_api": "https://api.github.com/repos/HomericIntelligence/Argus",
+    "ruleset_api": [
+      "https://api.github.com/repos/HomericIntelligence/Argus/rulesets/15556485",
+      "https://api.github.com/repos/HomericIntelligence/Argus/rulesets/18221125"
+    ],
+    "rollout_issue": "https://github.com/HomericIntelligence/Argus/issues/550",
+    "replacement_pr": "https://github.com/HomericIntelligence/Argus/pull/552",
+    "replacement_pr_head": "b335eb95a49d8e89b580b52879cc7b0bcffa510a"
+  },
+  "repository": "HomericIntelligence/Argus",
+  "expected_context_union": [
+    "lint",
+    "unit-tests",
+    "integration-tests",
+    "security/dependency-scan",
+    "security/secrets-scan",
+    "config-validate",
+    "schema-validation",
+    "deps/version-sync",
+    "test",
+    "package",
+    "install",
+    "release",
+    "build",
+    "Validate configs"
+  ],
+  "rulesets": [
+    {
+      "id": 15556485,
+      "name": "homeric-main-baseline",
+      "target": "branch",
+      "source_type": "Repository",
+      "source": "HomericIntelligence/Argus",
+      "enforcement": "active",
+      "conditions": {
+        "ref_name": { "exclude": [], "include": ["refs/heads/main"] }
+      },
+      "bypass_actors": [
+        {
+          "actor_id": 5,
+          "actor_type": "RepositoryRole",
+          "bypass_mode": "pull_request"
+        }
+      ],
+      "rules": [
+        { "type": "deletion" },
+        { "type": "required_signatures" },
+        {
+          "type": "pull_request",
+          "parameters": {
+            "required_approving_review_count": 0,
+            "dismiss_stale_reviews_on_push": false,
+            "required_reviewers": [],
+            "require_code_owner_review": false,
+            "dismissal_restriction": { "enabled": false, "allowed_actors": [] },
+            "require_last_push_approval": false,
+            "required_review_thread_resolution": true,
+            "allowed_merge_methods": ["merge", "squash", "rebase"]
+          }
+        },
+        {
+          "type": "required_status_checks",
+          "parameters": {
+            "strict_required_status_checks_policy": false,
+            "do_not_enforce_on_create": false,
+            "required_status_checks": [
+              { "context": "lint", "integration_id": 15368 },
+              { "context": "unit-tests", "integration_id": 15368 },
+              { "context": "integration-tests", "integration_id": 15368 },
+              { "context": "security/dependency-scan", "integration_id": 15368 },
+              { "context": "security/secrets-scan", "integration_id": 15368 },
+              { "context": "config-validate", "integration_id": 15368 },
+              { "context": "schema-validation", "integration_id": 15368 },
+              { "context": "deps/version-sync", "integration_id": 15368 },
+              { "context": "test", "integration_id": 15368 },
+              { "context": "package", "integration_id": 15368 },
+              { "context": "install", "integration_id": 15368 },
+              { "context": "release", "integration_id": 15368 },
+              { "context": "build", "integration_id": 15368 }
+            ]
+          }
+        },
+        { "type": "required_linear_history" },
+        { "type": "non_fast_forward" }
+      ]
+    },
+    {
+      "id": 18221125,
+      "name": "homeric-main-extras",
+      "target": "branch",
+      "source_type": "Repository",
+      "source": "HomericIntelligence/Argus",
+      "enforcement": "active",
+      "conditions": {
+        "ref_name": { "exclude": [], "include": ["refs/heads/main"] }
+      },
+      "bypass_actors": [],
+      "rules": [
+        {
+          "type": "required_status_checks",
+          "parameters": {
+            "strict_required_status_checks_policy": false,
+            "do_not_enforce_on_create": false,
+            "required_status_checks": [
+              { "context": "Validate configs", "integration_id": 15368 }
+            ]
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/github/argus-ruleset-contract.json
+++ b/tests/fixtures/github/argus-ruleset-contract.json
@@ -1,6 +1,6 @@
 {
   "provenance": {
-    "captured_at": "2026-07-16T23:49:25Z",
+    "captured_at": "2026-07-17T00:58:08Z",
     "repository_api": "https://api.github.com/repos/HomericIntelligence/Argus",
     "ruleset_api": [
       "https://api.github.com/repos/HomericIntelligence/Argus/rulesets/15556485",
@@ -8,7 +8,7 @@
     ],
     "rollout_issue": "https://github.com/HomericIntelligence/Argus/issues/550",
     "replacement_pr": "https://github.com/HomericIntelligence/Argus/pull/552",
-    "replacement_pr_head": "b335eb95a49d8e89b580b52879cc7b0bcffa510a"
+    "replacement_pr_head_at_capture": "b335eb95a49d8e89b580b52879cc7b0bcffa510a"
   },
   "repository": "HomericIntelligence/Argus",
   "expected_context_union": [

--- a/tests/fixtures/github/mock-ruleset-gh.sh
+++ b/tests/fixtures/github/mock-ruleset-gh.sh
@@ -7,6 +7,23 @@ set -euo pipefail
 printf '%q ' "$@" >> "$GH_CALL_LOG"
 printf '\n' >> "$GH_CALL_LOG"
 
+next_counter() {
+  local counter_file=$1
+  local value=0
+  if [[ -s "$counter_file" ]]; then
+    value=$(<"$counter_file")
+  fi
+  value=$((value + 1))
+  printf '%s\n' "$value" >"$counter_file"
+  printf '%s\n' "$value"
+}
+
+count_selected() {
+  local selected=${1:-}
+  local count=$2
+  [[ ",$selected," == *",$count,"* ]]
+}
+
 if [[ "${1:-}" == "repo" && "${2:-}" == "list" ]]; then
   : "${GH_REPO_LIST:?GH_REPO_LIST is required for gh repo list}"
   printf '%s\n' "$GH_REPO_LIST"
@@ -65,20 +82,85 @@ if [[ "$method" != GET ]]; then
     echo "mock refuses mutation: method=$method input=$input" >&2
     exit 2
   }
-  jq . "$input"
+
+  put_count=1
+  if [[ -n "${GH_PUT_COUNT_FILE:-}" ]]; then
+    put_count=$(next_counter "$GH_PUT_COUNT_FILE")
+  fi
+  if count_selected "${GH_FAIL_PUT_BEFORE_WRITE_AT:-}" "$put_count"; then
+    echo "mock PUT failure before write at call $put_count" >&2
+    exit 1
+  fi
+
+  if [[ -n "${GH_RULESET_STATE:-}" ]]; then
+    [[ -s "$GH_RULESET_STATE" ]] || {
+      echo "mock state file is missing: $GH_RULESET_STATE" >&2
+      exit 2
+    }
+    state_tmp="$GH_RULESET_STATE.tmp"
+    jq --slurpfile current "$GH_RULESET_STATE" '
+      . + {
+        id: $current[0].id,
+        source: $current[0].source,
+        source_type: $current[0].source_type
+      }
+    ' "$input" >"$state_tmp"
+    mv "$state_tmp" "$GH_RULESET_STATE"
+    if count_selected "${GH_CORRUPT_PUT_AT:-}" "$put_count"; then
+      state_tmp="$GH_RULESET_STATE.tmp"
+      jq '.conditions.ref_name.include = ["refs/heads/not-main"]' \
+        "$GH_RULESET_STATE" >"$state_tmp"
+      mv "$state_tmp" "$GH_RULESET_STATE"
+    fi
+  fi
+
+  if count_selected "${GH_FAIL_PUT_AFTER_WRITE_AT:-}" "$put_count"; then
+    echo "mock PUT failure after write at call $put_count" >&2
+    exit 1
+  fi
+
+  if [[ -n "${GH_RULESET_STATE:-}" ]]; then
+    jq . "$GH_RULESET_STATE"
+  else
+    jq . "$input"
+  fi
   exit 0
 fi
 
 repository=$(jq -r '.repository' "$GH_RULESET_FIXTURE")
 case "$endpoint" in
   "repos/$repository/rulesets?includes_parents=false")
-    jq '[.rulesets[] | {id, name, target, enforcement}]' \
+    jq --arg name_override "${GH_RULESET_LIST_NAME_OVERRIDE:-}" '
+      [.rulesets | to_entries[] as $entry | $entry.value | {
+        id,
+        name: (
+          if $name_override != "" and $entry.key == 0
+          then $name_override
+          else .name
+          end
+        ),
+        target,
+        enforcement
+      }]
+    ' \
       "$GH_RULESET_FIXTURE"
     ;;
   "repos/$repository/rulesets/"*)
     ruleset_id="${endpoint##*/}"
-    jq --argjson id "$ruleset_id" \
-      '.rulesets[] | select(.id == $id)' "$GH_RULESET_FIXTURE"
+    detail_count=1
+    if [[ -n "${GH_DETAIL_GET_COUNT_FILE:-}" ]]; then
+      detail_count=$(next_counter "$GH_DETAIL_GET_COUNT_FILE")
+    fi
+    if count_selected "${GH_FAIL_DETAIL_GET_AT:-}" "$detail_count"; then
+      echo "mock detail GET failure at call $detail_count" >&2
+      exit 1
+    fi
+    if [[ -n "${GH_RULESET_STATE:-}" ]]; then
+      jq --argjson id "$ruleset_id" 'select(.id == $id)' "$GH_RULESET_STATE"
+    else
+      jq --argjson id "$ruleset_id" \
+        '.rulesets[] | select(.id == $id)' "$GH_RULESET_FIXTURE"
+    fi
     ;;
   *)
     echo "unexpected gh api endpoint: $endpoint" >&2

--- a/tests/fixtures/github/mock-ruleset-gh.sh
+++ b/tests/fixtures/github/mock-ruleset-gh.sh
@@ -155,6 +155,11 @@ case "$endpoint" in
       echo "mock detail GET failure at call $detail_count" >&2
       exit 1
     fi
+    if count_selected "${GH_SIGNAL_HUP_DETAIL_GET_AT:-}" "$detail_count"; then
+      echo "mock sends HUP during detail GET at call $detail_count" >&2
+      kill -HUP "$PPID"
+      exit 1
+    fi
     if [[ -n "${GH_RULESET_STATE:-}" ]]; then
       jq --argjson id "$ruleset_id" 'select(.id == $id)' "$GH_RULESET_STATE"
     else

--- a/tests/fixtures/github/mock-ruleset-gh.sh
+++ b/tests/fixtures/github/mock-ruleset-gh.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${GH_RULESET_FIXTURE:?GH_RULESET_FIXTURE is required}"
+: "${GH_CALL_LOG:?GH_CALL_LOG is required}"
+
+printf '%q ' "$@" >> "$GH_CALL_LOG"
+printf '\n' >> "$GH_CALL_LOG"
+
+if [[ "${1:-}" == "repo" && "${2:-}" == "list" ]]; then
+  : "${GH_REPO_LIST:?GH_REPO_LIST is required for gh repo list}"
+  printf '%s\n' "$GH_REPO_LIST"
+  exit 0
+fi
+
+if [[ "${1:-}" != "api" ]]; then
+  echo "unexpected gh command: $*" >&2
+  exit 2
+fi
+shift
+
+for argument in "$@"; do
+  case "$argument" in
+    PUT|POST|PATCH|DELETE)
+      if [[ "${GH_ALLOW_MUTATION:-false}" != true ]]; then
+        echo "mock refuses mutation method: $argument" >&2
+        exit 2
+      fi
+      ;;
+  esac
+done
+
+method=GET
+input=""
+endpoint=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -X|--method)
+      method=$2
+      shift 2
+      ;;
+    --input)
+      input=$2
+      shift 2
+      ;;
+    --jq)
+      shift 2
+      ;;
+    --paginate)
+      shift
+      ;;
+    -* )
+      echo "unexpected gh api option: $1" >&2
+      exit 2
+      ;;
+    *)
+      endpoint=$1
+      shift
+      ;;
+  esac
+done
+
+if [[ "$method" != GET ]]; then
+  [[ "${GH_ALLOW_MUTATION:-false}" == true && -n "$input" ]] || {
+    echo "mock refuses mutation: method=$method input=$input" >&2
+    exit 2
+  }
+  jq . "$input"
+  exit 0
+fi
+
+repository=$(jq -r '.repository' "$GH_RULESET_FIXTURE")
+case "$endpoint" in
+  "repos/$repository/rulesets?includes_parents=false")
+    jq '[.rulesets[] | {id, name, target, enforcement}]' \
+      "$GH_RULESET_FIXTURE"
+    ;;
+  "repos/$repository/rulesets/"*)
+    ruleset_id="${endpoint##*/}"
+    jq --argjson id "$ruleset_id" \
+      '.rulesets[] | select(.id == $id)' "$GH_RULESET_FIXTURE"
+    ;;
+  *)
+    echo "unexpected gh api endpoint: $endpoint" >&2
+    exit 2
+    ;;
+esac

--- a/tests/fixtures/github/myrmidons-ruleset-contract.json
+++ b/tests/fixtures/github/myrmidons-ruleset-contract.json
@@ -1,0 +1,77 @@
+{
+  "provenance": {
+    "captured_at": "2026-07-16T23:49:25Z",
+    "repository_api": "https://api.github.com/repos/HomericIntelligence/Myrmidons",
+    "ruleset_api": [
+      "https://api.github.com/repos/HomericIntelligence/Myrmidons/rulesets/15556489"
+    ],
+    "rollout_issue": "https://github.com/HomericIntelligence/Myrmidons/issues/765",
+    "replacement_pr": "https://github.com/HomericIntelligence/Myrmidons/pull/767",
+    "replacement_pr_head": "c940de8481fca516794519c3350aa8513f308943"
+  },
+  "repository": "HomericIntelligence/Myrmidons",
+  "expected_context_union": [
+    "lint",
+    "unit-tests",
+    "security/dependency-scan",
+    "security/secrets-scan",
+    "build",
+    "schema-validation",
+    "deps/version-sync"
+  ],
+  "rulesets": [
+    {
+      "id": 15556489,
+      "name": "homeric-main-baseline",
+      "target": "branch",
+      "source_type": "Repository",
+      "source": "HomericIntelligence/Myrmidons",
+      "enforcement": "active",
+      "conditions": {
+        "ref_name": { "exclude": [], "include": ["refs/heads/main"] }
+      },
+      "bypass_actors": [
+        {
+          "actor_id": 5,
+          "actor_type": "RepositoryRole",
+          "bypass_mode": "pull_request"
+        }
+      ],
+      "rules": [
+        { "type": "deletion" },
+        { "type": "required_signatures" },
+        {
+          "type": "pull_request",
+          "parameters": {
+            "required_approving_review_count": 0,
+            "dismiss_stale_reviews_on_push": false,
+            "required_reviewers": [],
+            "require_code_owner_review": false,
+            "dismissal_restriction": { "enabled": false, "allowed_actors": [] },
+            "require_last_push_approval": false,
+            "required_review_thread_resolution": true,
+            "allowed_merge_methods": ["merge", "squash", "rebase"]
+          }
+        },
+        {
+          "type": "required_status_checks",
+          "parameters": {
+            "strict_required_status_checks_policy": false,
+            "do_not_enforce_on_create": false,
+            "required_status_checks": [
+              { "context": "lint", "integration_id": 15368 },
+              { "context": "unit-tests", "integration_id": 15368 },
+              { "context": "security/dependency-scan", "integration_id": 15368 },
+              { "context": "security/secrets-scan", "integration_id": 15368 },
+              { "context": "build", "integration_id": 15368 },
+              { "context": "schema-validation", "integration_id": 15368 },
+              { "context": "deps/version-sync", "integration_id": 15368 }
+            ]
+          }
+        },
+        { "type": "required_linear_history" },
+        { "type": "non_fast_forward" }
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/github/myrmidons-ruleset-contract.json
+++ b/tests/fixtures/github/myrmidons-ruleset-contract.json
@@ -1,13 +1,13 @@
 {
   "provenance": {
-    "captured_at": "2026-07-16T23:49:25Z",
+    "captured_at": "2026-07-17T00:58:08Z",
     "repository_api": "https://api.github.com/repos/HomericIntelligence/Myrmidons",
     "ruleset_api": [
       "https://api.github.com/repos/HomericIntelligence/Myrmidons/rulesets/15556489"
     ],
     "rollout_issue": "https://github.com/HomericIntelligence/Myrmidons/issues/765",
     "replacement_pr": "https://github.com/HomericIntelligence/Myrmidons/pull/767",
-    "replacement_pr_head": "c940de8481fca516794519c3350aa8513f308943"
+    "replacement_pr_head_at_capture": "0b50f16334c3bf9be66c957c97d338968a38cb83"
   },
   "repository": "HomericIntelligence/Myrmidons",
   "expected_context_union": [

--- a/tests/fixtures/github/proteus-ruleset-contract.json
+++ b/tests/fixtures/github/proteus-ruleset-contract.json
@@ -1,0 +1,113 @@
+{
+  "provenance": {
+    "captured_at": "2026-07-16T23:49:25Z",
+    "repository_api": "https://api.github.com/repos/HomericIntelligence/Proteus",
+    "ruleset_api": [
+      "https://api.github.com/repos/HomericIntelligence/Proteus/rulesets/15556490",
+      "https://api.github.com/repos/HomericIntelligence/Proteus/rulesets/18221113"
+    ],
+    "rollout_issue": "https://github.com/HomericIntelligence/Proteus/issues/214",
+    "replacement_pr": "https://github.com/HomericIntelligence/Proteus/pull/216",
+    "replacement_pr_head": "94da0478907c01551a6bae29f3d4645e8e886f30"
+  },
+  "repository": "HomericIntelligence/Proteus",
+  "expected_context_union": [
+    "lint",
+    "unit-tests",
+    "integration-tests",
+    "security/dependency-scan",
+    "security/secrets-scan",
+    "build",
+    "schema-validation",
+    "deps/version-sync",
+    "test",
+    "package",
+    "install",
+    "release",
+    "Lint Shell Scripts"
+  ],
+  "rulesets": [
+    {
+      "id": 15556490,
+      "name": "homeric-main-baseline",
+      "target": "branch",
+      "source_type": "Repository",
+      "source": "HomericIntelligence/Proteus",
+      "enforcement": "active",
+      "conditions": {
+        "ref_name": { "exclude": [], "include": ["refs/heads/main"] }
+      },
+      "bypass_actors": [
+        {
+          "actor_id": 5,
+          "actor_type": "RepositoryRole",
+          "bypass_mode": "pull_request"
+        }
+      ],
+      "rules": [
+        { "type": "deletion" },
+        { "type": "required_signatures" },
+        {
+          "type": "pull_request",
+          "parameters": {
+            "required_approving_review_count": 0,
+            "dismiss_stale_reviews_on_push": false,
+            "required_reviewers": [],
+            "require_code_owner_review": false,
+            "dismissal_restriction": { "enabled": false, "allowed_actors": [] },
+            "require_last_push_approval": false,
+            "required_review_thread_resolution": true,
+            "allowed_merge_methods": ["merge", "squash", "rebase"]
+          }
+        },
+        {
+          "type": "required_status_checks",
+          "parameters": {
+            "strict_required_status_checks_policy": false,
+            "do_not_enforce_on_create": false,
+            "required_status_checks": [
+              { "context": "lint", "integration_id": 15368 },
+              { "context": "unit-tests", "integration_id": 15368 },
+              { "context": "integration-tests", "integration_id": 15368 },
+              { "context": "security/dependency-scan", "integration_id": 15368 },
+              { "context": "security/secrets-scan", "integration_id": 15368 },
+              { "context": "build", "integration_id": 15368 },
+              { "context": "schema-validation", "integration_id": 15368 },
+              { "context": "deps/version-sync", "integration_id": 15368 },
+              { "context": "test", "integration_id": 15368 },
+              { "context": "package", "integration_id": 15368 },
+              { "context": "install", "integration_id": 15368 },
+              { "context": "release", "integration_id": 15368 }
+            ]
+          }
+        },
+        { "type": "required_linear_history" },
+        { "type": "non_fast_forward" }
+      ]
+    },
+    {
+      "id": 18221113,
+      "name": "homeric-main-extras",
+      "target": "branch",
+      "source_type": "Repository",
+      "source": "HomericIntelligence/Proteus",
+      "enforcement": "active",
+      "conditions": {
+        "ref_name": { "exclude": [], "include": ["refs/heads/main"] }
+      },
+      "bypass_actors": [],
+      "rules": [
+        {
+          "type": "required_status_checks",
+          "parameters": {
+            "strict_required_status_checks_policy": false,
+            "do_not_enforce_on_create": false,
+            "required_status_checks": [
+              { "context": "Lint Shell Scripts", "integration_id": 15368 }
+            ]
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/github/proteus-ruleset-contract.json
+++ b/tests/fixtures/github/proteus-ruleset-contract.json
@@ -1,6 +1,6 @@
 {
   "provenance": {
-    "captured_at": "2026-07-16T23:49:25Z",
+    "captured_at": "2026-07-17T00:58:08Z",
     "repository_api": "https://api.github.com/repos/HomericIntelligence/Proteus",
     "ruleset_api": [
       "https://api.github.com/repos/HomericIntelligence/Proteus/rulesets/15556490",
@@ -8,7 +8,7 @@
     ],
     "rollout_issue": "https://github.com/HomericIntelligence/Proteus/issues/214",
     "replacement_pr": "https://github.com/HomericIntelligence/Proteus/pull/216",
-    "replacement_pr_head": "94da0478907c01551a6bae29f3d4645e8e886f30"
+    "replacement_pr_head_at_capture": "3ed68db6e77e6c2ffac9baa334807c2fcddb3664"
   },
   "repository": "HomericIntelligence/Proteus",
   "expected_context_union": [

--- a/tests/github/apply-repo-rulesets.test.sh
+++ b/tests/github/apply-repo-rulesets.test.sh
@@ -20,12 +20,13 @@ run_dry_run() {
   local fixture=$1
   local repo=$2
   local output_file=$3
+  local mode=${4:---active}
   : >"$tmp_dir/gh-calls.log"
   PATH="$tmp_dir/bin:$PATH" \
     GH_RULESET_FIXTURE="$fixture" \
     GH_CALL_LOG="$tmp_dir/gh-calls.log" \
     tools/github/apply-repo-rulesets.sh \
-      --active --repos "$repo" --dry-run >"$output_file" 2>&1
+      "$mode" --repos "$repo" --dry-run >"$output_file" 2>&1
 }
 
 assert_fixture_contract() {
@@ -382,8 +383,9 @@ run_live_update() {
     GH_FAIL_PUT_BEFORE_WRITE_AT="${GH_FAIL_PUT_BEFORE_WRITE_AT:-}" \
     GH_FAIL_PUT_AFTER_WRITE_AT="${GH_FAIL_PUT_AFTER_WRITE_AT:-}" \
     GH_FAIL_DETAIL_GET_AT="${GH_FAIL_DETAIL_GET_AT:-}" \
+    GH_SIGNAL_HUP_DETAIL_GET_AT="${GH_SIGNAL_HUP_DETAIL_GET_AT:-}" \
     RULESET_SNAPSHOT_DIR="$snapshot_dir" \
-    tools/github/apply-repo-rulesets.sh --active --repos "$repos" \
+    tools/github/apply-repo-rulesets.sh "${RULESET_MODE:---active}" --repos "$repos" \
       >"$output_file" 2>&1
 }
 
@@ -400,6 +402,65 @@ assert_durable_snapshot() {
 }
 
 myrmidons_fixture=tests/fixtures/github/myrmidons-ruleset-contract.json
+
+evaluate_preview="$tmp_dir/evaluate-preview.log"
+run_dry_run "$myrmidons_fixture" Myrmidons "$evaluate_preview" --evaluate || {
+  cat "$evaluate_preview" >&2
+  fail "active baseline evaluate dry-run was rejected"
+}
+evaluate_payload=$(sed -n 's/^DRY-RUN Myrmidons payload: //p' "$evaluate_preview")
+jq -en --argjson payload "$evaluate_payload" \
+  '$payload.enforcement == "evaluate"' >/dev/null || \
+  fail "evaluate dry-run did not render the staged candidate"
+if grep -Eq -- '(^| )(-X|--method)(=| )(PUT|POST|PATCH|DELETE)( |$)' \
+    "$tmp_dir/gh-calls.log"; then
+  fail "evaluate dry-run attempted a live mutation"
+fi
+echo "PASS: active baseline permits an explicit no-write evaluate preview"
+
+evaluate_recipe=$(just --dry-run repo-rulesets-apply 2>&1)
+grep -qF 'apply-repo-rulesets.sh --evaluate --all --dry-run' \
+  <<<"$evaluate_recipe" || \
+  fail "fleet evaluate recipe is not a no-write preview"
+echo "PASS: fleet evaluate entry path is dry-run only"
+
+active_downgrade_state="$tmp_dir/active-downgrade-state.json"
+active_downgrade_pre="$tmp_dir/active-downgrade-pre.json"
+active_downgrade_snapshots="$tmp_dir/active-downgrade-snapshots"
+seed_ruleset_state "$myrmidons_fixture" "$active_downgrade_state"
+cp "$active_downgrade_state" "$active_downgrade_pre"
+if RULESET_MODE=--evaluate run_live_update \
+    "$myrmidons_fixture" Myrmidons "$active_downgrade_state" \
+    "$active_downgrade_snapshots" "$tmp_dir/active-downgrade.log" \
+    "$tmp_dir/active-downgrade-put-count" \
+    "$tmp_dir/active-downgrade-get-count"; then
+  fail "updater accepted an active-to-evaluate enforcement downgrade"
+fi
+jq -e --slurpfile expected "$active_downgrade_pre" '. == $expected[0]' \
+  "$active_downgrade_state" >/dev/null || \
+  fail "active-to-evaluate refusal changed live state"
+[[ ! -s "$tmp_dir/active-downgrade-put-count" ]] || \
+  fail "active-to-evaluate refusal issued a PUT"
+grep -qF 'refusing active-to-evaluate downgrade' \
+  "$tmp_dir/active-downgrade.log" || \
+  fail "active-to-evaluate refusal did not explain the safety boundary"
+echo "PASS: active enforcement cannot be downgraded to evaluate"
+
+staged_state="$tmp_dir/staged-state.json"
+staged_snapshots="$tmp_dir/staged-snapshots"
+seed_ruleset_state "$myrmidons_fixture" "$staged_state"
+jq '.enforcement = "evaluate"' "$staged_state" >"$staged_state.tmp"
+mv "$staged_state.tmp" "$staged_state"
+if ! RULESET_MODE=--evaluate run_live_update \
+    "$myrmidons_fixture" Myrmidons "$staged_state" "$staged_snapshots" \
+    "$tmp_dir/staged.log" "$tmp_dir/staged-put-count" \
+    "$tmp_dir/staged-get-count"; then
+  cat "$tmp_dir/staged.log" >&2
+  fail "explicit staged evaluate update was rejected"
+fi
+jq -e '.enforcement == "evaluate"' "$staged_state" >/dev/null || \
+  fail "staged evaluate update changed enforcement unexpectedly"
+echo "PASS: an already staged evaluate baseline remains explicitly updateable"
 
 success_state="$tmp_dir/success-state.json"
 success_pre="$tmp_dir/success-pre.json"
@@ -489,6 +550,37 @@ jq -e --slurpfile expected "$readback_pre" '. == $expected[0]' \
 [[ $(<"$tmp_dir/readback-get-count") -eq 3 ]] || \
   fail "readback-failure rollback must be verified by another GET"
 echo "PASS: failed post-PUT readback triggers verified rollback"
+
+hup_state="$tmp_dir/hup-state.json"
+hup_pre="$tmp_dir/hup-pre.json"
+hup_snapshots="$tmp_dir/hup-snapshots"
+seed_ruleset_state "$myrmidons_fixture" "$hup_state"
+cp "$hup_state" "$hup_pre"
+if GH_SIGNAL_HUP_DETAIL_GET_AT=2 run_live_update \
+    "$myrmidons_fixture" Myrmidons,Proteus "$hup_state" "$hup_snapshots" \
+    "$tmp_dir/hup.log" "$tmp_dir/hup-put-count" \
+    "$tmp_dir/hup-get-count"; then
+  fail "updater accepted HUP during ambiguous post-PUT readback"
+fi
+assert_durable_snapshot "$hup_snapshots" "$hup_pre" "HUP rollback"
+jq -e --slurpfile expected "$hup_pre" '. == $expected[0]' \
+  "$hup_state" >/dev/null || fail "HUP left live state unverified"
+[[ $(<"$tmp_dir/hup-put-count") -eq 2 ]] || \
+  fail "HUP must trigger exactly one rollback PUT"
+[[ $(<"$tmp_dir/hup-get-count") -eq 3 ]] || \
+  fail "HUP rollback must be verified by an exact readback"
+grep -qF 'UNCERTAIN MUTATION: received HUP during an armed mutation' \
+  "$tmp_dir/hup.log" || {
+  cat "$tmp_dir/hup.log" >&2
+  fail "HUP ambiguity did not report uncertain mutation"
+}
+grep -qF 'Rollback verified exactly' "$tmp_dir/hup.log" || \
+  fail "HUP rollback was not reported as verified"
+if grep -qF 'repos/HomericIntelligence/Proteus/rulesets' \
+    "$tmp_dir/gh-calls.log"; then
+  fail "fleet processing continued after HUP"
+fi
+echo "PASS: HUP ambiguity reports uncertainty and restores verified pre-state"
 
 uncertain_state="$tmp_dir/uncertain-state.json"
 uncertain_snapshots="$tmp_dir/uncertain-snapshots"

--- a/tests/github/apply-repo-rulesets.test.sh
+++ b/tests/github/apply-repo-rulesets.test.sh
@@ -1,0 +1,311 @@
+#!/usr/bin/env bash
+# Safety regressions for repository-authoritative ruleset updates.
+set -euo pipefail
+
+REPO_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+cd "$REPO_ROOT"
+
+tmp_dir=$(mktemp -d)
+trap 'rm -rf "$tmp_dir"' EXIT
+mkdir -p "$tmp_dir/bin"
+cp tests/fixtures/github/mock-ruleset-gh.sh "$tmp_dir/bin/gh"
+chmod +x "$tmp_dir/bin/gh"
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+run_dry_run() {
+  local fixture=$1
+  local repo=$2
+  local output_file=$3
+  : >"$tmp_dir/gh-calls.log"
+  PATH="$tmp_dir/bin:$PATH" \
+    GH_RULESET_FIXTURE="$fixture" \
+    GH_CALL_LOG="$tmp_dir/gh-calls.log" \
+    tools/github/apply-repo-rulesets.sh \
+      --active --repos "$repo" --dry-run >"$output_file" 2>&1
+}
+
+assert_fixture_contract() {
+  local fixture=$1
+  local repo=$2
+  local expected_count=$3
+  local output_file="$tmp_dir/$repo-output.log"
+
+  run_dry_run "$fixture" "$repo" "$output_file" || {
+    cat "$output_file" >&2
+    fail "$repo dry-run failed"
+  }
+
+  local payload
+  payload=$(sed -n "s/^DRY-RUN $repo payload: //p" "$output_file")
+  [[ -n "$payload" ]] || fail "$repo dry-run did not emit an update payload"
+
+  local expected_contexts actual_contexts
+  expected_contexts=$(jq -Sc '.expected_context_union | sort' "$fixture")
+  actual_contexts=$(jq -nSc \
+    --argjson payload "$payload" \
+    --slurpfile fixture "$fixture" '
+      ([
+        $payload.rules[]
+        | select(.type == "required_status_checks")
+        | .parameters.required_status_checks[].context
+      ] + [
+        $fixture[0].rulesets[]
+        | select(.name != "homeric-main-baseline")
+        | .rules[]
+        | select(.type == "required_status_checks")
+        | .parameters.required_status_checks[].context
+      ]) | sort
+    ')
+
+  [[ "$actual_contexts" == "$expected_contexts" ]] || {
+    printf 'Expected: %s\nActual:   %s\n' \
+      "$expected_contexts" "$actual_contexts" >&2
+    fail "$repo exact context union changed"
+  }
+
+  [[ $(jq 'length' <<<"$actual_contexts") -eq "$expected_count" ]] || \
+    fail "$repo context union is not exactly $expected_count entries"
+
+  jq -e --argjson payload "$payload" '
+    def unrelated:
+      {
+        name,
+        target,
+        conditions,
+        bypass_actors,
+        rules: [.rules[] | select(.type != "merge_queue")]
+      };
+    (.rulesets[] | select(.name == "homeric-main-baseline") | unrelated)
+      == ($payload | unrelated)
+  ' "$fixture" >/dev/null || fail "$repo unrelated baseline policy changed"
+
+  jq -ne --argjson payload "$payload" '
+    [$payload.rules[] | select(.type == "merge_queue") | .parameters] == [{
+      "check_response_timeout_minutes": 60,
+      "grouping_strategy": "ALLGREEN",
+      "max_entries_to_build": 10,
+      "max_entries_to_merge": 5,
+      "merge_method": "SQUASH",
+      "min_entries_to_merge": 1,
+      "min_entries_to_merge_wait_minutes": 5
+    }]
+  ' >/dev/null || fail "$repo payload lacks the approved queue policy"
+
+  if grep -Eq -- '(^| )(-X|--method)(=| )(PUT|POST|PATCH|DELETE)( |$)' \
+      "$tmp_dir/gh-calls.log"; then
+    cat "$tmp_dir/gh-calls.log" >&2
+    fail "$repo dry-run attempted a live mutation"
+  fi
+
+  echo "PASS: $repo preserves unrelated rules and exact $expected_count-context union"
+}
+
+assert_fixture_provenance() {
+  local fixture=$1
+  local repo=$2
+  local expected_rulesets=$3
+  local expected_issue=$4
+  local expected_pr=$5
+  local expected_head=$6
+
+  jq -e \
+    --arg repo "$repo" \
+    --argjson expected_rulesets "$expected_rulesets" \
+    --arg expected_issue "$expected_issue" \
+    --arg expected_pr "$expected_pr" \
+    --arg expected_head "$expected_head" '
+      . as $fixture |
+      $fixture.repository == ("HomericIntelligence/" + $repo) and
+      ($fixture.provenance.captured_at
+        | test("^2026-07-16T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$")) and
+      $fixture.provenance.repository_api ==
+        ("https://api.github.com/repos/HomericIntelligence/" + $repo) and
+      $fixture.provenance.rollout_issue == $expected_issue and
+      $fixture.provenance.replacement_pr == $expected_pr and
+      $fixture.provenance.replacement_pr_head == $expected_head and
+      ($fixture.rulesets | length) == $expected_rulesets and
+      ($fixture.provenance.ruleset_api | length) == $expected_rulesets and
+      all(
+        $fixture.rulesets[];
+        .id as $id |
+        ($fixture.provenance.ruleset_api | index(
+          "https://api.github.com/repos/HomericIntelligence/" +
+          $repo + "/rulesets/" + ($id | tostring)
+        )) != null
+      )
+    ' "$fixture" >/dev/null || fail "$repo fixture provenance is incomplete or stale"
+
+  echo "PASS: $repo fixture records current API and replacement provenance"
+}
+
+contracts=(
+  "tests/fixtures/github/argus-ruleset-contract.json:Argus:14"
+  "tests/fixtures/github/proteus-ruleset-contract.json:Proteus:13"
+  "tests/fixtures/github/myrmidons-ruleset-contract.json:Myrmidons:7"
+)
+
+for contract in "${contracts[@]}"; do
+  IFS=: read -r fixture repo expected_count <<<"$contract"
+  assert_fixture_contract "$fixture" "$repo" "$expected_count"
+done
+
+assert_fixture_provenance \
+  tests/fixtures/github/argus-ruleset-contract.json Argus 2 \
+  https://github.com/HomericIntelligence/Argus/issues/550 \
+  https://github.com/HomericIntelligence/Argus/pull/552 \
+  b335eb95a49d8e89b580b52879cc7b0bcffa510a
+assert_fixture_provenance \
+  tests/fixtures/github/proteus-ruleset-contract.json Proteus 2 \
+  https://github.com/HomericIntelligence/Proteus/issues/214 \
+  https://github.com/HomericIntelligence/Proteus/pull/216 \
+  94da0478907c01551a6bae29f3d4645e8e886f30
+assert_fixture_provenance \
+  tests/fixtures/github/myrmidons-ruleset-contract.json Myrmidons 1 \
+  https://github.com/HomericIntelligence/Myrmidons/issues/765 \
+  https://github.com/HomericIntelligence/Myrmidons/pull/767 \
+  c940de8481fca516794519c3350aa8513f308943
+
+argus_fixture=tests/fixtures/github/argus-ruleset-contract.json
+
+assert_incomplete_authority_rejected() {
+  local name=$1
+  local jq_filter=$2
+  local expected_message=$3
+  local broken_fixture="$tmp_dir/$name.json"
+  local output_file="$tmp_dir/$name.log"
+
+  jq "$jq_filter" "$argus_fixture" >"$broken_fixture"
+  if run_dry_run "$broken_fixture" Argus "$output_file"; then
+    fail "updater accepted incomplete required-check authority: $name"
+  fi
+  grep -qF "$expected_message" "$output_file" || {
+    cat "$output_file" >&2
+    fail "$name refusal did not identify incomplete required-check authority"
+  }
+  if grep -Eq -- '(^| )(-X|--method)(=| )(PUT|POST|PATCH|DELETE)( |$)' \
+      "$tmp_dir/gh-calls.log"; then
+    cat "$tmp_dir/gh-calls.log" >&2
+    fail "$name incomplete-authority path attempted a mutation"
+  fi
+  echo "PASS: updater rejects $name"
+}
+
+authority_error="required_status_checks authority is incomplete"
+assert_incomplete_authority_rejected \
+  missing-required-status-rule \
+  'del(.rulesets[0].rules[] | select(.type == "required_status_checks"))' \
+  "$authority_error"
+assert_incomplete_authority_rejected \
+  missing-parameters \
+  'del(.rulesets[0].rules[] | select(.type == "required_status_checks").parameters)' \
+  "$authority_error"
+assert_incomplete_authority_rejected \
+  missing-required-status-checks \
+  'del(.rulesets[0].rules[] | select(.type == "required_status_checks").parameters.required_status_checks)' \
+  "$authority_error"
+assert_incomplete_authority_rejected \
+  non-object-parameters \
+  '(.rulesets[0].rules[] | select(.type == "required_status_checks").parameters) = []' \
+  "$authority_error"
+assert_incomplete_authority_rejected \
+  non-array-required-status-checks \
+  '(.rulesets[0].rules[] | select(.type == "required_status_checks").parameters.required_status_checks) = {}' \
+  "$authority_error"
+assert_incomplete_authority_rejected \
+  empty-context-array \
+  '(.rulesets[0].rules[] | select(.type == "required_status_checks").parameters.required_status_checks) = []' \
+  "$authority_error"
+assert_incomplete_authority_rejected \
+  missing-context-string \
+  'del(.rulesets[0].rules[] | select(.type == "required_status_checks").parameters.required_status_checks[0].context)' \
+  "$authority_error"
+assert_incomplete_authority_rejected \
+  blank-context-string \
+  '(.rulesets[0].rules[] | select(.type == "required_status_checks").parameters.required_status_checks[0].context) = "   "' \
+  "$authority_error"
+assert_incomplete_authority_rejected \
+  non-string-context \
+  '(.rulesets[0].rules[] | select(.type == "required_status_checks").parameters.required_status_checks[0].context) = 7' \
+  "$authority_error"
+assert_incomplete_authority_rejected \
+  missing-integration-id \
+  'del(.rulesets[0].rules[] | select(.type == "required_status_checks").parameters.required_status_checks[0].integration_id)' \
+  "$authority_error"
+assert_incomplete_authority_rejected \
+  invalid-integration-id \
+  '(.rulesets[0].rules[] | select(.type == "required_status_checks").parameters.required_status_checks[0].integration_id) = 0' \
+  "$authority_error"
+assert_incomplete_authority_rejected \
+  non-object-required-check \
+  '(.rulesets[0].rules[] | select(.type == "required_status_checks").parameters.required_status_checks[0]) = null' \
+  "$authority_error"
+assert_incomplete_authority_rejected \
+  missing-strict-policy \
+  'del(.rulesets[0].rules[] | select(.type == "required_status_checks").parameters.strict_required_status_checks_policy)' \
+  "$authority_error"
+assert_incomplete_authority_rejected \
+  non-boolean-strict-policy \
+  '(.rulesets[0].rules[] | select(.type == "required_status_checks").parameters.strict_required_status_checks_policy) = "false"' \
+  "$authority_error"
+assert_incomplete_authority_rejected \
+  missing-enforce-on-create \
+  'del(.rulesets[0].rules[] | select(.type == "required_status_checks").parameters.do_not_enforce_on_create)' \
+  "$authority_error"
+assert_incomplete_authority_rejected \
+  non-boolean-enforce-on-create \
+  '(.rulesets[0].rules[] | select(.type == "required_status_checks").parameters.do_not_enforce_on_create) = 0' \
+  "$authority_error"
+assert_incomplete_authority_rejected \
+  duplicate-required-status-rule \
+  '.rulesets[0].rules += [(.rulesets[0].rules[] | select(.type == "required_status_checks"))]' \
+  "$authority_error"
+assert_incomplete_authority_rejected \
+  duplicate-required-context \
+  '(.rulesets[0].rules[] | select(.type == "required_status_checks").parameters.required_status_checks) += [(.rulesets[0].rules[] | select(.type == "required_status_checks").parameters.required_status_checks[0])]' \
+  "$authority_error"
+
+jq 'del(.rulesets[] | select(.name == "homeric-main-baseline"))' \
+  "$argus_fixture" >"$tmp_dir/no-baseline.json"
+if run_dry_run "$tmp_dir/no-baseline.json" Argus "$tmp_dir/no-baseline.log"; then
+  fail "updater accepted a repository with no owned baseline"
+fi
+grep -qF "bootstrap it from repository-owned policy" "$tmp_dir/no-baseline.log" || \
+  fail "missing-baseline refusal did not identify repository ownership"
+echo "PASS: updater never bootstraps from a generic fixed-context payload"
+
+if PATH="$tmp_dir/bin:$PATH" \
+    GH_RULESET_FIXTURE="$argus_fixture" \
+    GH_CALL_LOG="$tmp_dir/gh-calls.log" \
+    tools/github/apply-repo-rulesets.sh --active --repos Argus \
+      >"$tmp_dir/argus-active.log" 2>&1; then
+  fail "generic activation did not defer to Argus's dedicated authority"
+fi
+grep -qF "Argus owns a dedicated merge-queue ruleset path" \
+  "$tmp_dir/argus-active.log" || fail "Argus refusal did not identify its authority"
+echo "PASS: generic live activation defers Argus to its dedicated ruleset"
+
+: >"$tmp_dir/gh-calls.log"
+if ! PATH="$tmp_dir/bin:$PATH" \
+    GH_RULESET_FIXTURE=tests/fixtures/github/myrmidons-ruleset-contract.json \
+    GH_CALL_LOG="$tmp_dir/gh-calls.log" \
+    GH_REPO_LIST=$'Argus\nMyrmidons' \
+    GH_ALLOW_MUTATION=true \
+    tools/github/apply-repo-rulesets.sh --active --all \
+      >"$tmp_dir/all-active.log" 2>&1; then
+  cat "$tmp_dir/all-active.log" >&2
+  fail "explicit fleet activation could not continue past dedicated Argus"
+fi
+grep -qF "Skipping Argus; dedicated rollout is Argus #550/#552" \
+  "$tmp_dir/all-active.log" || fail "fleet activation did not audit the Argus skip"
+if grep -qF 'repos/HomericIntelligence/Argus/rulesets' \
+    "$tmp_dir/gh-calls.log"; then
+  cat "$tmp_dir/gh-calls.log" >&2
+  fail "fleet activation called an Argus ruleset endpoint"
+fi
+grep -qF 'repos/HomericIntelligence/Myrmidons/rulesets/15556489' \
+  "$tmp_dir/gh-calls.log" || fail "fleet activation did not update Myrmidons"
+echo "PASS: explicit fleet activation skips Argus and continues with other repos"

--- a/tests/github/apply-repo-rulesets.test.sh
+++ b/tests/github/apply-repo-rulesets.test.sh
@@ -121,12 +121,12 @@ assert_fixture_provenance() {
       . as $fixture |
       $fixture.repository == ("HomericIntelligence/" + $repo) and
       ($fixture.provenance.captured_at
-        | test("^2026-07-16T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$")) and
+        | test("^2026-07-17T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$")) and
       $fixture.provenance.repository_api ==
         ("https://api.github.com/repos/HomericIntelligence/" + $repo) and
       $fixture.provenance.rollout_issue == $expected_issue and
       $fixture.provenance.replacement_pr == $expected_pr and
-      $fixture.provenance.replacement_pr_head == $expected_head and
+      $fixture.provenance.replacement_pr_head_at_capture == $expected_head and
       ($fixture.rulesets | length) == $expected_rulesets and
       ($fixture.provenance.ruleset_api | length) == $expected_rulesets and
       all(
@@ -139,7 +139,7 @@ assert_fixture_provenance() {
       )
     ' "$fixture" >/dev/null || fail "$repo fixture provenance is incomplete or stale"
 
-  echo "PASS: $repo fixture records current API and replacement provenance"
+  echo "PASS: $repo fixture records capture-time API and replacement provenance"
 }
 
 contracts=(
@@ -162,12 +162,12 @@ assert_fixture_provenance \
   tests/fixtures/github/proteus-ruleset-contract.json Proteus 2 \
   https://github.com/HomericIntelligence/Proteus/issues/214 \
   https://github.com/HomericIntelligence/Proteus/pull/216 \
-  94da0478907c01551a6bae29f3d4645e8e886f30
+  3ed68db6e77e6c2ffac9baa334807c2fcddb3664
 assert_fixture_provenance \
   tests/fixtures/github/myrmidons-ruleset-contract.json Myrmidons 1 \
   https://github.com/HomericIntelligence/Myrmidons/issues/765 \
   https://github.com/HomericIntelligence/Myrmidons/pull/767 \
-  c940de8481fca516794519c3350aa8513f308943
+  0b50f16334c3bf9be66c957c97d338968a38cb83
 
 argus_fixture=tests/fixtures/github/argus-ruleset-contract.json
 
@@ -268,6 +268,69 @@ assert_incomplete_authority_rejected \
   '(.rulesets[0].rules[] | select(.type == "required_status_checks").parameters.required_status_checks) += [(.rulesets[0].rules[] | select(.type == "required_status_checks").parameters.required_status_checks[0])]' \
   "$authority_error"
 
+assert_identity_scope_rejected() {
+  local name=$1
+  local jq_filter=$2
+  local list_name_override=${3:-}
+  local broken_fixture="$tmp_dir/$name.json"
+  local output_file="$tmp_dir/$name.log"
+
+  jq "$jq_filter" "$argus_fixture" >"$broken_fixture"
+  : >"$tmp_dir/gh-calls.log"
+  if PATH="$tmp_dir/bin:$PATH" \
+      GH_RULESET_FIXTURE="$broken_fixture" \
+      GH_CALL_LOG="$tmp_dir/gh-calls.log" \
+      GH_RULESET_LIST_NAME_OVERRIDE="$list_name_override" \
+      tools/github/apply-repo-rulesets.sh \
+        --active --repos Argus --dry-run >"$output_file" 2>&1; then
+    fail "updater accepted invalid baseline identity/scope: $name"
+  fi
+  grep -qF "live ruleset identity or main-only branch scope is invalid" \
+    "$output_file" || {
+      cat "$output_file" >&2
+      fail "$name refusal did not identify invalid identity/scope"
+    }
+  if grep -qF 'DRY-RUN Argus payload:' "$output_file"; then
+    cat "$output_file" >&2
+    fail "$name derived a payload before rejecting identity/scope"
+  fi
+  if grep -Eq -- '(^| )(-X|--method)(=| )(PUT|POST|PATCH|DELETE)( |$)' \
+      "$tmp_dir/gh-calls.log"; then
+    cat "$tmp_dir/gh-calls.log" >&2
+    fail "$name invalid-identity path attempted a mutation"
+  fi
+  echo "PASS: updater rejects $name before payload derivation"
+}
+
+assert_identity_scope_rejected \
+  wildcard-main-scope \
+  '(.rulesets[0].conditions.ref_name.include) = ["refs/heads/*"]'
+assert_identity_scope_rejected \
+  missing-main-branch \
+  'del(.rulesets[0].conditions.ref_name.include)'
+assert_identity_scope_rejected \
+  alternate-main-branch \
+  '(.rulesets[0].conditions.ref_name.include) = ["refs/heads/develop"]'
+assert_identity_scope_rejected \
+  nonempty-branch-exclusions \
+  '(.rulesets[0].conditions.ref_name.exclude) = ["refs/heads/release"]'
+assert_identity_scope_rejected \
+  malformed-ref-scope \
+  '(.rulesets[0].conditions.ref_name) = []'
+assert_identity_scope_rejected \
+  non-branch-target \
+  '(.rulesets[0].target) = "tag"'
+assert_identity_scope_rejected \
+  renamed-fetched-ruleset \
+  '(.rulesets[0].name) = "renamed-main-baseline"' \
+  homeric-main-baseline
+assert_identity_scope_rejected \
+  wrong-repository-owner \
+  '(.rulesets[0].source) = "HomericIntelligence/AnotherRepo"'
+assert_identity_scope_rejected \
+  inherited-organization-ruleset \
+  '(.rulesets[0].source_type) = "Organization"'
+
 jq 'del(.rulesets[] | select(.name == "homeric-main-baseline"))' \
   "$argus_fixture" >"$tmp_dir/no-baseline.json"
 if run_dry_run "$tmp_dir/no-baseline.json" Argus "$tmp_dir/no-baseline.log"; then
@@ -288,12 +351,179 @@ grep -qF "Argus owns a dedicated merge-queue ruleset path" \
   "$tmp_dir/argus-active.log" || fail "Argus refusal did not identify its authority"
 echo "PASS: generic live activation defers Argus to its dedicated ruleset"
 
+seed_ruleset_state() {
+  local fixture=$1
+  local state_file=$2
+  jq '.rulesets[] | select(.name == "homeric-main-baseline")' \
+    "$fixture" >"$state_file"
+}
+
+run_live_update() {
+  local fixture=$1
+  local repos=$2
+  local state_file=$3
+  local snapshot_dir=$4
+  local output_file=$5
+  local put_count_file=$6
+  local get_count_file=$7
+
+  : >"$tmp_dir/gh-calls.log"
+  : >"$put_count_file"
+  : >"$get_count_file"
+  mkdir -p "$snapshot_dir"
+  PATH="$tmp_dir/bin:$PATH" \
+    GH_RULESET_FIXTURE="$fixture" \
+    GH_CALL_LOG="$tmp_dir/gh-calls.log" \
+    GH_ALLOW_MUTATION=true \
+    GH_RULESET_STATE="$state_file" \
+    GH_PUT_COUNT_FILE="$put_count_file" \
+    GH_DETAIL_GET_COUNT_FILE="$get_count_file" \
+    GH_CORRUPT_PUT_AT="${GH_CORRUPT_PUT_AT:-}" \
+    GH_FAIL_PUT_BEFORE_WRITE_AT="${GH_FAIL_PUT_BEFORE_WRITE_AT:-}" \
+    GH_FAIL_PUT_AFTER_WRITE_AT="${GH_FAIL_PUT_AFTER_WRITE_AT:-}" \
+    GH_FAIL_DETAIL_GET_AT="${GH_FAIL_DETAIL_GET_AT:-}" \
+    RULESET_SNAPSHOT_DIR="$snapshot_dir" \
+    tools/github/apply-repo-rulesets.sh --active --repos "$repos" \
+      >"$output_file" 2>&1
+}
+
+assert_durable_snapshot() {
+  local snapshot_dir=$1
+  local expected_file=$2
+  local label=$3
+  local snapshots=()
+  mapfile -t snapshots < <(find "$snapshot_dir" -type f -name '*.json' | sort)
+  [[ ${#snapshots[@]} -eq 1 ]] || \
+    fail "$label expected one durable pre-state snapshot, found ${#snapshots[@]}"
+  jq -e --slurpfile expected "$expected_file" '. == $expected[0]' \
+    "${snapshots[0]}" >/dev/null || fail "$label snapshot is not the exact pre-state"
+}
+
+myrmidons_fixture=tests/fixtures/github/myrmidons-ruleset-contract.json
+
+success_state="$tmp_dir/success-state.json"
+success_pre="$tmp_dir/success-pre.json"
+success_snapshots="$tmp_dir/success-snapshots"
+seed_ruleset_state "$myrmidons_fixture" "$success_state"
+cp "$success_state" "$success_pre"
+if ! run_live_update \
+    "$myrmidons_fixture" Myrmidons "$success_state" "$success_snapshots" \
+    "$tmp_dir/success.log" "$tmp_dir/success-put-count" \
+    "$tmp_dir/success-get-count"; then
+  cat "$tmp_dir/success.log" >&2
+  fail "verified live update scenario failed"
+fi
+assert_durable_snapshot "$success_snapshots" "$success_pre" "verified update"
+[[ $(<"$tmp_dir/success-put-count") -eq 1 ]] || \
+  fail "verified update must issue exactly one PUT"
+[[ $(<"$tmp_dir/success-get-count") -eq 2 ]] || \
+  fail "verified update must read exact post-state after PUT"
+jq -e '
+  .conditions.ref_name == {include: ["refs/heads/main"], exclude: []}
+  and ([.rules[] | select(.type == "merge_queue")] | length) == 1
+' "$success_state" >/dev/null || fail "verified update state does not match the candidate"
+grep -qF "Verified exact postcondition" "$tmp_dir/success.log" || \
+  fail "verified update did not report exact postcondition verification"
+echo "PASS: live update snapshots pre-state and verifies exact post-state"
+
+mismatch_state="$tmp_dir/mismatch-state.json"
+mismatch_pre="$tmp_dir/mismatch-pre.json"
+mismatch_snapshots="$tmp_dir/mismatch-snapshots"
+seed_ruleset_state "$myrmidons_fixture" "$mismatch_state"
+cp "$mismatch_state" "$mismatch_pre"
+if GH_CORRUPT_PUT_AT=1 run_live_update \
+    "$myrmidons_fixture" Myrmidons "$mismatch_state" "$mismatch_snapshots" \
+    "$tmp_dir/mismatch.log" "$tmp_dir/mismatch-put-count" \
+    "$tmp_dir/mismatch-get-count"; then
+  fail "updater accepted a mismatched post-PUT readback"
+fi
+assert_durable_snapshot "$mismatch_snapshots" "$mismatch_pre" "mismatch rollback"
+jq -e --slurpfile expected "$mismatch_pre" '. == $expected[0]' \
+  "$mismatch_state" >/dev/null || fail "mismatched post-state was not rolled back"
+[[ $(<"$tmp_dir/mismatch-put-count") -eq 2 ]] || \
+  fail "mismatched post-state must trigger one rollback PUT"
+[[ $(<"$tmp_dir/mismatch-get-count") -eq 3 ]] || \
+  fail "mismatch rollback must be verified by readback"
+grep -qF "Rollback verified" "$tmp_dir/mismatch.log" || \
+  fail "mismatch rollback was not reported as verified"
+echo "PASS: mismatched postcondition triggers verified rollback"
+
+ambiguous_state="$tmp_dir/ambiguous-state.json"
+ambiguous_pre="$tmp_dir/ambiguous-pre.json"
+ambiguous_snapshots="$tmp_dir/ambiguous-snapshots"
+seed_ruleset_state "$myrmidons_fixture" "$ambiguous_state"
+cp "$ambiguous_state" "$ambiguous_pre"
+if GH_FAIL_PUT_AFTER_WRITE_AT=1 run_live_update \
+    "$myrmidons_fixture" Myrmidons "$ambiguous_state" "$ambiguous_snapshots" \
+    "$tmp_dir/ambiguous.log" "$tmp_dir/ambiguous-put-count" \
+    "$tmp_dir/ambiguous-get-count"; then
+  fail "updater accepted an ambiguous PUT result"
+fi
+assert_durable_snapshot "$ambiguous_snapshots" "$ambiguous_pre" "ambiguous rollback"
+jq -e --slurpfile expected "$ambiguous_pre" '. == $expected[0]' \
+  "$ambiguous_state" >/dev/null || fail "ambiguous PUT was not rolled back"
+[[ $(<"$tmp_dir/ambiguous-put-count") -eq 2 ]] || \
+  fail "ambiguous PUT must trigger one rollback PUT"
+[[ $(<"$tmp_dir/ambiguous-get-count") -eq 2 ]] || \
+  fail "ambiguous PUT rollback must be verified by readback"
+grep -qF "Rollback verified" "$tmp_dir/ambiguous.log" || \
+  fail "ambiguous PUT rollback was not reported as verified"
+echo "PASS: ambiguous PUT failure triggers verified rollback"
+
+readback_state="$tmp_dir/readback-state.json"
+readback_pre="$tmp_dir/readback-pre.json"
+readback_snapshots="$tmp_dir/readback-snapshots"
+seed_ruleset_state "$myrmidons_fixture" "$readback_state"
+cp "$readback_state" "$readback_pre"
+if GH_FAIL_DETAIL_GET_AT=2 run_live_update \
+    "$myrmidons_fixture" Myrmidons "$readback_state" "$readback_snapshots" \
+    "$tmp_dir/readback.log" "$tmp_dir/readback-put-count" \
+    "$tmp_dir/readback-get-count"; then
+  fail "updater accepted a failed post-PUT readback"
+fi
+assert_durable_snapshot "$readback_snapshots" "$readback_pre" "readback rollback"
+jq -e --slurpfile expected "$readback_pre" '. == $expected[0]' \
+  "$readback_state" >/dev/null || fail "failed post-PUT readback was not rolled back"
+[[ $(<"$tmp_dir/readback-put-count") -eq 2 ]] || \
+  fail "failed post-PUT readback must trigger one rollback PUT"
+[[ $(<"$tmp_dir/readback-get-count") -eq 3 ]] || \
+  fail "readback-failure rollback must be verified by another GET"
+echo "PASS: failed post-PUT readback triggers verified rollback"
+
+uncertain_state="$tmp_dir/uncertain-state.json"
+uncertain_snapshots="$tmp_dir/uncertain-snapshots"
+seed_ruleset_state "$myrmidons_fixture" "$uncertain_state"
+if GH_CORRUPT_PUT_AT=1 GH_FAIL_PUT_BEFORE_WRITE_AT=2 run_live_update \
+    "$myrmidons_fixture" Myrmidons,Proteus "$uncertain_state" \
+    "$uncertain_snapshots" "$tmp_dir/uncertain.log" \
+    "$tmp_dir/uncertain-put-count" "$tmp_dir/uncertain-get-count"; then
+  fail "updater accepted an unverified rollback"
+fi
+grep -qF "UNCERTAIN MUTATION" "$tmp_dir/uncertain.log" || {
+  cat "$tmp_dir/uncertain.log" >&2
+  fail "unverified rollback did not report uncertain mutation"
+}
+if grep -qF 'repos/HomericIntelligence/Proteus/rulesets' \
+    "$tmp_dir/gh-calls.log"; then
+  cat "$tmp_dir/gh-calls.log" >&2
+  fail "fleet processing continued after an uncertain mutation"
+fi
+echo "PASS: uncertain rollback aborts fleet processing"
+
 : >"$tmp_dir/gh-calls.log"
+fleet_state="$tmp_dir/fleet-state.json"
+fleet_snapshots="$tmp_dir/fleet-snapshots"
+seed_ruleset_state \
+  tests/fixtures/github/myrmidons-ruleset-contract.json "$fleet_state"
 if ! PATH="$tmp_dir/bin:$PATH" \
     GH_RULESET_FIXTURE=tests/fixtures/github/myrmidons-ruleset-contract.json \
     GH_CALL_LOG="$tmp_dir/gh-calls.log" \
     GH_REPO_LIST=$'Argus\nMyrmidons' \
     GH_ALLOW_MUTATION=true \
+    GH_RULESET_STATE="$fleet_state" \
+    GH_PUT_COUNT_FILE="$tmp_dir/fleet-put-count" \
+    GH_DETAIL_GET_COUNT_FILE="$tmp_dir/fleet-get-count" \
+    RULESET_SNAPSHOT_DIR="$fleet_snapshots" \
     tools/github/apply-repo-rulesets.sh --active --all \
       >"$tmp_dir/all-active.log" 2>&1; then
   cat "$tmp_dir/all-active.log" >&2

--- a/tests/github/merge-queue-readiness.test.sh
+++ b/tests/github/merge-queue-readiness.test.sh
@@ -19,20 +19,6 @@ fail() {
   echo "FAIL: $1" >&2
 }
 
-workflow_prefix() {
-  awk '/^jobs:$/ { exit } { print }' "$1"
-}
-
-job_block() {
-  local workflow=$1
-  local job=$2
-  awk -v job="$job" '
-    $0 == "  " job ":" { in_job = 1 }
-    in_job && $0 ~ /^  [A-Za-z0-9_-]+:$/ && $0 != "  " job ":" { exit }
-    in_job { print }
-  ' "$workflow"
-}
-
 expected_required_workflows=(
   .github/workflows/_required.yml
   .github/workflows/build-images.yml
@@ -68,15 +54,13 @@ for workflow in "${required_workflows[@]}"; do
     fail "$workflow must handle merge_group checks_requested"
   fi
 
-  prefix=$(workflow_prefix "$workflow")
-  if grep -qE '^permissions:$' <<<"$prefix" &&
-     grep -qE '^  contents: read$' <<<"$prefix" &&
-     ! grep -qE '^  (contents|packages): write$' <<<"$prefix"; then
-    pass "$workflow defaults validation to read-only contents"
-  else
-    fail "$workflow must not grant write permission at workflow scope"
-  fi
 done
+
+if python3 tests/github/workflow-permissions.test.py workflow-defaults; then
+  pass "required workflows default validation to parsed contents:read permissions"
+else
+  fail "required workflows must not grant write permission at workflow scope"
+fi
 
 checkout_count=$(grep -hEc 'uses: actions/checkout@' \
   "${required_workflows[@]}" | awk '{ total += $1 } END { print total + 0 }')
@@ -88,40 +72,25 @@ else
   fail "every checkout in a required workflow must disable persisted credentials"
 fi
 
-build_validation=$(job_block .github/workflows/build-images.yml validate)
-if grep -qF "github.event_name == 'pull_request'" <<<"$build_validation" &&
-   grep -qF "github.event_name == 'merge_group'" <<<"$build_validation" &&
-   grep -qF "github.event_name == 'workflow_dispatch'" \
-    <<<"$build_validation" &&
-   ! grep -qE '^[[:space:]]+(contents|packages): write$' \
-    <<<"$build_validation"; then
+if python3 tests/github/workflow-permissions.test.py build-validation; then
   pass "Build Images PR/merge_group/manual validation job is read-only"
 else
   fail "Build Images validation must be read-only for PR/merge_group/manual events"
 fi
 
-build_publish=$(job_block .github/workflows/build-images.yml publish)
-if grep -qF "if: github.event_name == 'push'" \
-    <<<"$build_publish" &&
-   ! grep -qF "workflow_dispatch" <<<"$build_publish" &&
-   grep -qE '^[[:space:]]+packages: write$' <<<"$build_publish" &&
-   grep -qE '^[[:space:]]+contents: read$' <<<"$build_publish"; then
+if python3 tests/github/workflow-permissions.test.py build-publish; then
   pass "Build Images publishing permission is isolated to trusted pushes/tags"
 else
   fail "Build Images publishing must retain packages:write only on trusted pushes/tags"
 fi
 
-release_publish=$(job_block .github/workflows/release.yml publish)
-if grep -qF "startsWith(github.ref, 'refs/tags/')" <<<"$release_publish" &&
-   grep -qE '^[[:space:]]+contents: write$' <<<"$release_publish"; then
+if python3 tests/github/workflow-permissions.test.py release-publish; then
   pass "Release publishing retains contents:write only on trusted tag pushes"
 else
   fail "Release publish job must own the only contents:write grant"
 fi
 
-release_validation=$(job_block .github/workflows/release.yml release)
-if ! grep -qE '^[[:space:]]+(contents|packages): write$' \
-    <<<"$release_validation"; then
+if python3 tests/github/workflow-permissions.test.py release-validation; then
   pass "Release PR/merge_group validation job is read-only"
 else
   fail "Release validation exposes write permission"

--- a/tests/github/merge-queue-readiness.test.sh
+++ b/tests/github/merge-queue-readiness.test.sh
@@ -1,0 +1,222 @@
+#!/usr/bin/env bash
+# Regression contract for Odysseus merge-queue readiness and least privilege.
+set -euo pipefail
+
+REPO_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+cd "$REPO_ROOT"
+
+checks=0
+failures=0
+
+pass() {
+  checks=$((checks + 1))
+  echo "PASS: $1"
+}
+
+fail() {
+  checks=$((checks + 1))
+  failures=$((failures + 1))
+  echo "FAIL: $1" >&2
+}
+
+workflow_prefix() {
+  awk '/^jobs:$/ { exit } { print }' "$1"
+}
+
+job_block() {
+  local workflow=$1
+  local job=$2
+  awk -v job="$job" '
+    $0 == "  " job ":" { in_job = 1 }
+    in_job && $0 ~ /^  [A-Za-z0-9_-]+:$/ && $0 != "  " job ":" { exit }
+    in_job { print }
+  ' "$workflow"
+}
+
+expected_required_workflows=(
+  .github/workflows/_required.yml
+  .github/workflows/build-images.yml
+  .github/workflows/install-test.yml
+  .github/workflows/release.yml
+)
+
+required_context_pattern='^[[:space:]]{4}name: (lint|unit-tests|integration-tests|security/dependency-scan|security/secrets-scan|build|schema-validation|deps/version-sync|test|install|release)$'
+mapfile -t required_workflows < <(
+  grep -lE "$required_context_pattern" .github/workflows/*.yml | sort
+)
+
+if [[ "${required_workflows[*]}" == "${expected_required_workflows[*]}" ]]; then
+  pass "required contexts are supplied by the expected four workflows"
+else
+  fail "required-context workflow inventory has drifted"
+  printf 'Expected: %s\nActual:   %s\n' \
+    "${expected_required_workflows[*]}" "${required_workflows[*]}" >&2
+fi
+
+for workflow in "${required_workflows[@]}"; do
+  on_block=$(awk '
+    /^on:$/ { in_on = 1; next }
+    in_on && /^[^[:space:]#]/ { exit }
+    in_on { print }
+  ' "$workflow")
+
+  if grep -qE '^  merge_group:$' <<<"$on_block" &&
+     grep -A1 -E '^  merge_group:$' <<<"$on_block" |
+       grep -qE '^    types: \[checks_requested\]$'; then
+    pass "$workflow handles merge_group checks_requested"
+  else
+    fail "$workflow must handle merge_group checks_requested"
+  fi
+
+  prefix=$(workflow_prefix "$workflow")
+  if grep -qE '^permissions:$' <<<"$prefix" &&
+     grep -qE '^  contents: read$' <<<"$prefix" &&
+     ! grep -qE '^  (contents|packages): write$' <<<"$prefix"; then
+    pass "$workflow defaults validation to read-only contents"
+  else
+    fail "$workflow must not grant write permission at workflow scope"
+  fi
+done
+
+checkout_count=$(grep -hEc 'uses: actions/checkout@' \
+  "${required_workflows[@]}" | awk '{ total += $1 } END { print total + 0 }')
+nonpersistent_checkout_count=$(grep -hEc 'persist-credentials: false' \
+  "${required_workflows[@]}" | awk '{ total += $1 } END { print total + 0 }')
+if [[ "$checkout_count" -eq "$nonpersistent_checkout_count" ]]; then
+  pass "required workflows do not persist checkout credentials"
+else
+  fail "every checkout in a required workflow must disable persisted credentials"
+fi
+
+build_validation=$(job_block .github/workflows/build-images.yml validate)
+if grep -qF "github.event_name == 'pull_request'" <<<"$build_validation" &&
+   grep -qF "github.event_name == 'merge_group'" <<<"$build_validation" &&
+   grep -qF "github.event_name == 'workflow_dispatch'" \
+    <<<"$build_validation" &&
+   ! grep -qE '^[[:space:]]+(contents|packages): write$' \
+    <<<"$build_validation"; then
+  pass "Build Images PR/merge_group/manual validation job is read-only"
+else
+  fail "Build Images validation must be read-only for PR/merge_group/manual events"
+fi
+
+build_publish=$(job_block .github/workflows/build-images.yml publish)
+if grep -qF "if: github.event_name == 'push'" \
+    <<<"$build_publish" &&
+   ! grep -qF "workflow_dispatch" <<<"$build_publish" &&
+   grep -qE '^[[:space:]]+packages: write$' <<<"$build_publish" &&
+   grep -qE '^[[:space:]]+contents: read$' <<<"$build_publish"; then
+  pass "Build Images publishing permission is isolated to trusted pushes/tags"
+else
+  fail "Build Images publishing must retain packages:write only on trusted pushes/tags"
+fi
+
+release_publish=$(job_block .github/workflows/release.yml publish)
+if grep -qF "startsWith(github.ref, 'refs/tags/')" <<<"$release_publish" &&
+   grep -qE '^[[:space:]]+contents: write$' <<<"$release_publish"; then
+  pass "Release publishing retains contents:write only on trusted tag pushes"
+else
+  fail "Release publish job must own the only contents:write grant"
+fi
+
+release_validation=$(job_block .github/workflows/release.yml release)
+if ! grep -qE '^[[:space:]]+(contents|packages): write$' \
+    <<<"$release_validation"; then
+  pass "Release PR/merge_group validation job is read-only"
+else
+  fail "Release validation exposes write permission"
+fi
+
+if grep -qE "^[[:space:]]+if: github.event_name != 'merge_group'$" \
+    .github/workflows/install-test.yml; then
+  pass "Install test excludes its non-required matrix from merge groups"
+else
+  fail "Install test must exclude its non-required matrix from merge groups"
+fi
+
+expected_contexts='["lint","unit-tests","integration-tests","security/dependency-scan","security/secrets-scan","build","schema-validation","deps/version-sync","test","install","release"]'
+ruleset_files=(
+  configs/github/repo-ruleset.json
+  configs/github/repo-ruleset-active.json
+  configs/github/repo-ruleset-evaluate.json
+)
+
+declare -A expected_enforcement=(
+  [configs/github/repo-ruleset.json]=active
+  [configs/github/repo-ruleset-active.json]=active
+  [configs/github/repo-ruleset-evaluate.json]=evaluate
+)
+
+for ruleset in "${ruleset_files[@]}"; do
+  if jq -e '
+      .target == "branch" and
+      .conditions.ref_name.include == ["refs/heads/main"] and
+      .conditions.ref_name.exclude == []
+    ' "$ruleset" >/dev/null; then
+    pass "$ruleset targets only main"
+  else
+    fail "$ruleset must target only main"
+  fi
+
+  if jq -e --arg expected "${expected_enforcement[$ruleset]}" \
+      '.enforcement == $expected' "$ruleset" >/dev/null; then
+    pass "$ruleset keeps its intended enforcement mode"
+  else
+    fail "$ruleset enforcement mode has drifted"
+  fi
+
+  if jq -e --argjson expected "$expected_contexts" '
+      [.rules[] | select(.type == "required_status_checks")
+        | .parameters.required_status_checks[].context] == $expected
+    ' "$ruleset" >/dev/null; then
+    pass "$ruleset records all 11 Odysseus required checks"
+  else
+    fail "$ruleset does not record the Odysseus required-check contract"
+  fi
+
+  if jq -e '
+      [.rules[] | select(.type == "merge_queue") | .parameters] == [{
+        "check_response_timeout_minutes": 60,
+        "grouping_strategy": "ALLGREEN",
+        "max_entries_to_build": 10,
+        "max_entries_to_merge": 5,
+        "merge_method": "SQUASH",
+        "min_entries_to_merge": 1,
+        "min_entries_to_merge_wait_minutes": 5
+      }]
+    ' "$ruleset" >/dev/null; then
+    pass "$ruleset records the approved merge-queue policy"
+  else
+    fail "$ruleset merge-queue policy is absent or has drifted"
+  fi
+done
+
+if grep -qF 'Live complete repository rulesets are authoritative' \
+    docs/runbooks/branch-protection-rollout.md &&
+   grep -qF 'input and review artifact' docs/runbooks/branch-protection-rollout.md &&
+   grep -qF 'staged' docs/runbooks/branch-protection-rollout.md; then
+  pass "runbook documents live authority, committed artifacts, and staged activation"
+else
+  fail "runbook must distinguish live authority from committed input artifacts"
+fi
+
+if grep -qF "\`allow_merge_commit: true\`" CONTRIBUTING.md &&
+   grep -qF "\`allow_squash_merge: true\`" CONTRIBUTING.md &&
+   grep -qF "\`allow_rebase_merge: false\`" CONTRIBUTING.md; then
+  pass "CONTRIBUTING records current repository merge-method metadata"
+else
+  fail "CONTRIBUTING merge-method facts do not match current metadata"
+fi
+
+if rg -n 'Argus/(pull|issues)/551|Argus #550/#551|PR #551' \
+    CONTRIBUTING.md configs/github docs tests tools justfile \
+    --glob '!tests/github/merge-queue-readiness.test.sh'; then
+  fail "stale Argus replacement PR #551 reference remains"
+else
+  pass "all Argus replacement references use current PR #552"
+fi
+
+echo "Results: $((checks - failures))/$checks checks passed"
+if ((failures > 0)); then
+  exit 1
+fi

--- a/tests/github/merge-queue-readiness.test.sh
+++ b/tests/github/merge-queue-readiness.test.sh
@@ -19,57 +19,16 @@ fail() {
   echo "FAIL: $1" >&2
 }
 
-expected_required_workflows=(
-  .github/workflows/_required.yml
-  .github/workflows/build-images.yml
-  .github/workflows/install-test.yml
-  .github/workflows/release.yml
-)
-
-required_context_pattern='^[[:space:]]{4}name: (lint|unit-tests|integration-tests|security/dependency-scan|security/secrets-scan|build|schema-validation|deps/version-sync|test|install|release)$'
-mapfile -t required_workflows < <(
-  grep -lE "$required_context_pattern" .github/workflows/*.yml | sort
-)
-
-if [[ "${required_workflows[*]}" == "${expected_required_workflows[*]}" ]]; then
-  pass "required contexts are supplied by the expected four workflows"
+if python3 tests/github/workflow-permissions.test.py workflow-structure; then
+  pass "required workflow triggers, contexts, and checkout behavior are structured"
 else
-  fail "required-context workflow inventory has drifted"
-  printf 'Expected: %s\nActual:   %s\n' \
-    "${expected_required_workflows[*]}" "${required_workflows[*]}" >&2
+  fail "required workflow structure has drifted"
 fi
-
-for workflow in "${required_workflows[@]}"; do
-  on_block=$(awk '
-    /^on:$/ { in_on = 1; next }
-    in_on && /^[^[:space:]#]/ { exit }
-    in_on { print }
-  ' "$workflow")
-
-  if grep -qE '^  merge_group:$' <<<"$on_block" &&
-     grep -A1 -E '^  merge_group:$' <<<"$on_block" |
-       grep -qE '^    types: \[checks_requested\]$'; then
-    pass "$workflow handles merge_group checks_requested"
-  else
-    fail "$workflow must handle merge_group checks_requested"
-  fi
-
-done
 
 if python3 tests/github/workflow-permissions.test.py workflow-defaults; then
   pass "required workflows default validation to parsed contents:read permissions"
 else
   fail "required workflows must not grant write permission at workflow scope"
-fi
-
-checkout_count=$(grep -hEc 'uses: actions/checkout@' \
-  "${required_workflows[@]}" | awk '{ total += $1 } END { print total + 0 }')
-nonpersistent_checkout_count=$(grep -hEc 'persist-credentials: false' \
-  "${required_workflows[@]}" | awk '{ total += $1 } END { print total + 0 }')
-if [[ "$checkout_count" -eq "$nonpersistent_checkout_count" ]]; then
-  pass "required workflows do not persist checkout credentials"
-else
-  fail "every checkout in a required workflow must disable persisted credentials"
 fi
 
 if python3 tests/github/workflow-permissions.test.py build-validation; then
@@ -94,13 +53,6 @@ if python3 tests/github/workflow-permissions.test.py release-validation; then
   pass "Release PR/merge_group validation job is read-only"
 else
   fail "Release validation exposes write permission"
-fi
-
-if grep -qE "^[[:space:]]+if: github.event_name != 'merge_group'$" \
-    .github/workflows/install-test.yml; then
-  pass "Install test excludes its non-required matrix from merge groups"
-else
-  fail "Install test must exclude its non-required matrix from merge groups"
 fi
 
 expected_contexts='["lint","unit-tests","integration-tests","security/dependency-scan","security/secrets-scan","build","schema-validation","deps/version-sync","test","install","release"]'
@@ -159,23 +111,6 @@ for ruleset in "${ruleset_files[@]}"; do
     fail "$ruleset merge-queue policy is absent or has drifted"
   fi
 done
-
-if grep -qF 'Live complete repository rulesets are authoritative' \
-    docs/runbooks/branch-protection-rollout.md &&
-   grep -qF 'input and review artifact' docs/runbooks/branch-protection-rollout.md &&
-   grep -qF 'staged' docs/runbooks/branch-protection-rollout.md; then
-  pass "runbook documents live authority, committed artifacts, and staged activation"
-else
-  fail "runbook must distinguish live authority from committed input artifacts"
-fi
-
-if grep -qF "\`allow_merge_commit: true\`" CONTRIBUTING.md &&
-   grep -qF "\`allow_squash_merge: true\`" CONTRIBUTING.md &&
-   grep -qF "\`allow_rebase_merge: false\`" CONTRIBUTING.md; then
-  pass "CONTRIBUTING records current repository merge-method metadata"
-else
-  fail "CONTRIBUTING merge-method facts do not match current metadata"
-fi
 
 if rg -n 'Argus/(pull|issues)/551|Argus #550/#551|PR #551' \
     CONTRIBUTING.md configs/github docs tests tools justfile \

--- a/tests/github/workflow-permissions.test.py
+++ b/tests/github/workflow-permissions.test.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""Behavior assertions for merge-queue workflow permission boundaries."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def load_workflow(path: str) -> dict[str, Any]:
+    """Parse a workflow without YAML 1.1 coercion of keys such as ``on``."""
+    workflow = yaml.load((ROOT / path).read_text(), Loader=yaml.BaseLoader)
+    if not isinstance(workflow, dict):
+        raise AssertionError(f"{path} must contain a YAML mapping")
+    return workflow
+
+
+def job(workflow: dict[str, Any], name: str) -> dict[str, Any]:
+    jobs = workflow.get("jobs")
+    if not isinstance(jobs, dict) or not isinstance(jobs.get(name), dict):
+        raise AssertionError(f"job {name!r} is missing")
+    return jobs[name]
+
+
+def permissions(mapping: dict[str, Any]) -> dict[str, str]:
+    value = mapping.get("permissions", {})
+    if not isinstance(value, dict):
+        raise AssertionError("permissions must be a mapping")
+    return value
+
+
+def assert_workflow_defaults() -> None:
+    for path in (
+        ".github/workflows/_required.yml",
+        ".github/workflows/build-images.yml",
+        ".github/workflows/install-test.yml",
+        ".github/workflows/release.yml",
+    ):
+        actual = permissions(load_workflow(path))
+        assert actual == {"contents": "read"}, (
+            f"{path} workflow permissions must be exactly contents: read; "
+            f"got {actual!r}"
+        )
+
+
+def assert_build_validation() -> None:
+    workflow = load_workflow(".github/workflows/build-images.yml")
+    validate = job(workflow, "validate")
+    condition = validate.get("if", "")
+    for event in ("pull_request", "merge_group", "workflow_dispatch"):
+        assert f"github.event_name == '{event}'" in condition, (
+            f"build validation condition does not include {event}: {condition!r}"
+        )
+    assert all(value != "write" for value in permissions(validate).values()), (
+        "build validation job must not grant write permissions"
+    )
+
+
+def assert_build_publish() -> None:
+    workflow = load_workflow(".github/workflows/build-images.yml")
+    publish = job(workflow, "publish")
+    assert publish.get("if") == "github.event_name == 'push'", (
+        "build publishing must be restricted to push events"
+    )
+    assert permissions(publish) == {"contents": "read", "packages": "write"}, (
+        "build publishing must grant exactly contents:read and packages:write"
+    )
+    writers = {
+        name: permissions(value)
+        for name, value in workflow["jobs"].items()
+        if isinstance(value, dict)
+        and any(permission == "write" for permission in permissions(value).values())
+    }
+    assert writers == {"publish": {"contents": "read", "packages": "write"}}, (
+        f"unexpected Build Images write grants: {writers!r}"
+    )
+
+
+def assert_release_publish() -> None:
+    workflow = load_workflow(".github/workflows/release.yml")
+    publish = job(workflow, "publish")
+    condition = publish.get("if", "")
+    assert "github.event_name == 'push'" in condition
+    assert "startsWith(github.ref, 'refs/tags/')" in condition
+    assert permissions(publish) == {"contents": "write"}, (
+        "release publishing must grant exactly contents:write"
+    )
+    writers = {
+        name: permissions(value)
+        for name, value in workflow["jobs"].items()
+        if isinstance(value, dict)
+        and any(permission == "write" for permission in permissions(value).values())
+    }
+    assert writers == {"publish": {"contents": "write"}}, (
+        f"unexpected Release write grants: {writers!r}"
+    )
+
+
+def assert_release_validation() -> None:
+    workflow = load_workflow(".github/workflows/release.yml")
+    release = job(workflow, "release")
+    assert all(value != "write" for value in permissions(release).values()), (
+        "release validation job must not grant write permissions"
+    )
+
+
+CHECKS = {
+    "workflow-defaults": assert_workflow_defaults,
+    "build-validation": assert_build_validation,
+    "build-publish": assert_build_publish,
+    "release-publish": assert_release_publish,
+    "release-validation": assert_release_validation,
+}
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("check", choices=CHECKS)
+    args = parser.parse_args()
+    CHECKS[args.check]()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/github/workflow-permissions.test.py
+++ b/tests/github/workflow-permissions.test.py
@@ -11,6 +11,25 @@ import yaml
 
 
 ROOT = Path(__file__).resolve().parents[2]
+REQUIRED_CONTEXTS = {
+    "lint",
+    "unit-tests",
+    "integration-tests",
+    "security/dependency-scan",
+    "security/secrets-scan",
+    "build",
+    "schema-validation",
+    "deps/version-sync",
+    "test",
+    "install",
+    "release",
+}
+REQUIRED_WORKFLOWS = (
+    ".github/workflows/_required.yml",
+    ".github/workflows/build-images.yml",
+    ".github/workflows/install-test.yml",
+    ".github/workflows/release.yml",
+)
 
 
 def load_workflow(path: str) -> dict[str, Any]:
@@ -36,17 +55,79 @@ def permissions(mapping: dict[str, Any]) -> dict[str, str]:
 
 
 def assert_workflow_defaults() -> None:
-    for path in (
-        ".github/workflows/_required.yml",
-        ".github/workflows/build-images.yml",
-        ".github/workflows/install-test.yml",
-        ".github/workflows/release.yml",
-    ):
+    for path in REQUIRED_WORKFLOWS:
         actual = permissions(load_workflow(path))
         assert actual == {"contents": "read"}, (
             f"{path} workflow permissions must be exactly contents: read; "
             f"got {actual!r}"
         )
+
+
+def assert_workflow_structure() -> None:
+    suppliers: list[str] = []
+    supplied_contexts: set[str] = set()
+    for path in sorted((ROOT / ".github/workflows").glob("*.yml")):
+        relative_path = str(path.relative_to(ROOT))
+        workflow = load_workflow(relative_path)
+        jobs = workflow.get("jobs", {})
+        if not isinstance(jobs, dict):
+            raise AssertionError(f"{relative_path} jobs must be a mapping")
+        names = {
+            value.get("name")
+            for value in jobs.values()
+            if isinstance(value, dict) and isinstance(value.get("name"), str)
+        }
+        workflow_contexts = names & REQUIRED_CONTEXTS
+        if workflow_contexts:
+            suppliers.append(relative_path)
+            supplied_contexts.update(workflow_contexts)
+
+    assert tuple(suppliers) == REQUIRED_WORKFLOWS, (
+        f"required contexts must be supplied by {REQUIRED_WORKFLOWS!r}; "
+        f"got {tuple(suppliers)!r}"
+    )
+    assert supplied_contexts == REQUIRED_CONTEXTS, (
+        f"required workflow context union changed: got {supplied_contexts!r}"
+    )
+
+    for path in REQUIRED_WORKFLOWS:
+        workflow = load_workflow(path)
+        triggers = workflow.get("on")
+        if not isinstance(triggers, dict):
+            raise AssertionError(f"{path} on must be a mapping")
+        merge_group = triggers.get("merge_group")
+        assert merge_group == {"types": ["checks_requested"]}, (
+            f"{path} must handle only merge_group checks_requested; "
+            f"got {merge_group!r}"
+        )
+
+        jobs = workflow.get("jobs")
+        if not isinstance(jobs, dict):
+            raise AssertionError(f"{path} jobs must be a mapping")
+        checkout_steps = [
+            step
+            for value in jobs.values()
+            if isinstance(value, dict)
+            for step in value.get("steps", [])
+            if isinstance(step, dict)
+            and isinstance(step.get("uses"), str)
+            and step["uses"].startswith("actions/checkout@")
+        ]
+        assert checkout_steps, f"{path} must contain at least one checkout step"
+        for step in checkout_steps:
+            checkout_with = step.get("with")
+            assert isinstance(checkout_with, dict), (
+                f"{path} checkout step must configure with.persist-credentials"
+            )
+            assert checkout_with.get("persist-credentials") == "false", (
+                f"{path} checkout must set persist-credentials: false"
+            )
+
+    install_workflow = load_workflow(".github/workflows/install-test.yml")
+    install_matrix = job(install_workflow, "install-test")
+    assert install_matrix.get("if") == "github.event_name != 'merge_group'", (
+        "install-test matrix must be excluded from merge groups"
+    )
 
 
 def assert_build_validation() -> None:
@@ -111,6 +192,7 @@ def assert_release_validation() -> None:
 
 
 CHECKS = {
+    "workflow-structure": assert_workflow_structure,
     "workflow-defaults": assert_workflow_defaults,
     "build-validation": assert_build_validation,
     "build-publish": assert_build_publish,

--- a/tools/github/apply-repo-rulesets.sh
+++ b/tools/github/apply-repo-rulesets.sh
@@ -2,12 +2,14 @@
 set -euo pipefail
 
 # apply-repo-rulesets.sh [--active|--evaluate] [--repos repo1,repo2,...]
-# Creates or updates the homeric-main-baseline branch ruleset on every repo.
+#                         [--all] [--dry-run]
+# Adds or updates only the merge-queue rule and enforcement mode in an existing
+# homeric-main-baseline ruleset. All other live rules remain repository-owned.
 # Usage:
-#   ./tools/github/apply-repo-rulesets.sh                    # canonical (active) mode, all repos
-#   ./tools/github/apply-repo-rulesets.sh --active           # active (enforcing) mode, all repos
-#   ./tools/github/apply-repo-rulesets.sh --evaluate         # evaluate (shadow) mode, all repos
+#   ./tools/github/apply-repo-rulesets.sh --active --all     # active mode, eligible fleet repos
+#   ./tools/github/apply-repo-rulesets.sh --evaluate --all   # evaluate mode, eligible fleet repos
 #   ./tools/github/apply-repo-rulesets.sh --repos Foo,Bar    # canonical mode, specific repos only
+#   ./tools/github/apply-repo-rulesets.sh --dry-run --repos Foo
 
 ORG="HomericIntelligence"
 RULESET_NAME="homeric-main-baseline"
@@ -16,13 +18,31 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 
 ENFORCEMENT=""
 REPOS_OVERRIDE=""
+DRY_RUN=false
+ALL_REPOS=false
 
 while [[ $# -gt 0 ]]; do
   case "${1:-}" in
     --active)        ENFORCEMENT="active"; shift ;;
     --evaluate)      ENFORCEMENT="evaluate"; shift ;;
-    --repos)         REPOS_OVERRIDE="$2"; shift 2 ;;
-    --repos=*)       REPOS_OVERRIDE="${1#--repos=}"; shift ;;
+    --repos)
+      if [[ $# -lt 2 || -z "${2:-}" ]]; then
+        echo "ERROR: --repos requires a non-empty comma-separated value" >&2
+        exit 2
+      fi
+      REPOS_OVERRIDE="$2"
+      shift 2
+      ;;
+    --repos=*)
+      REPOS_OVERRIDE="${1#--repos=}"
+      if [[ -z "$REPOS_OVERRIDE" ]]; then
+        echo "ERROR: --repos requires a non-empty comma-separated value" >&2
+        exit 2
+      fi
+      shift
+      ;;
+    --dry-run)       DRY_RUN=true; shift ;;
+    --all)           ALL_REPOS=true; shift ;;
     *) echo "Unknown argument: $1" >&2; exit 2 ;;
   esac
 done
@@ -38,17 +58,56 @@ else
   echo "Applying canonical ruleset ($(jq -r .enforcement "$JSON_FILE") mode)"
 fi
 
-if [[ -n "$REPOS_OVERRIDE" ]]; then
+desired_enforcement=$(jq -er '.enforcement' "$JSON_FILE")
+desired_merge_queue=$(jq -ec '
+  [.rules[] | select(.type == "merge_queue")] as $rules
+  | if ($rules | length) != 1
+    then error("canonical ruleset must contain exactly one merge_queue rule")
+    else $rules[0]
+    end
+' "$JSON_FILE")
+
+tmp_dir=$(mktemp -d)
+trap 'rm -rf "$tmp_dir"' EXIT
+
+if [[ -n "$REPOS_OVERRIDE" && "$ALL_REPOS" == true ]]; then
+  echo "ERROR: use either --repos or --all, not both" >&2
+  exit 2
+elif [[ -n "$REPOS_OVERRIDE" ]]; then
   IFS=',' read -ra REPOS <<< "$REPOS_OVERRIDE"
   echo "Targeting ${#REPOS[@]} repo(s) from --repos override: ${REPOS[*]}"
+elif [[ "$ALL_REPOS" == true ]]; then
+  mapfile -t REPOS < <(gh repo list "$ORG" --json name,isFork,isArchived --limit 100 \
+    --jq '[.[] | select(.isFork == false and .isArchived == false) | .name] | sort | .[]')
+  echo "Discovered ${#REPOS[@]} active non-fork repo(s) via gh repo list"
 else
-  mapfile -t REPOS < <(gh repo list "$ORG" --json name,isArchived --limit 100 \
-    --jq '[.[] | select(.isArchived == false) | .name] | sort | .[]')
-  echo "Discovered ${#REPOS[@]} active repo(s) via gh repo list"
+  echo "ERROR: target scope is required; pass --repos <names> or explicit --all" >&2
+  exit 2
 fi
 
 if [[ ${#REPOS[@]} -eq 0 ]]; then
   echo "ERROR: no repos resolved (gh API failure or --repos was empty)" >&2
+  exit 1
+fi
+
+eligible_repos=()
+for repo in "${REPOS[@]}"; do
+  if [[ "$repo" == "Argus" ]]; then
+    if [[ "$ALL_REPOS" == true ]]; then
+      echo "Skipping Argus; dedicated rollout is Argus #550/#552"
+      continue
+    fi
+    if [[ "$DRY_RUN" != true ]]; then
+      echo "ERROR: Argus owns a dedicated merge-queue ruleset path; see Argus #550/#552" >&2
+      exit 1
+    fi
+  fi
+  eligible_repos+=("$repo")
+done
+REPOS=("${eligible_repos[@]}")
+
+if [[ ${#REPOS[@]} -eq 0 ]]; then
+  echo "ERROR: no repos remain after applying dedicated-rollout exclusions" >&2
   exit 1
 fi
 
@@ -59,25 +118,159 @@ for repo in "${REPOS[@]}"; do
   echo ""
   echo "--- $repo ---"
 
-  existing_id=$(gh api "repos/$ORG/$repo/rulesets" --paginate \
-    --jq ".[] | select(.name == \"$RULESET_NAME\") | .id" 2>/dev/null || echo "")
+  ruleset_list="$tmp_dir/$repo-rulesets.json"
+  if ! gh api "repos/$ORG/$repo/rulesets?includes_parents=false" > "$ruleset_list"; then
+    echo "  FAILED: could not list repository rulesets" >&2
+    fail=$((fail + 1))
+    continue
+  fi
+
+  mapfile -t existing_ids < <(
+    jq -r --arg name "$RULESET_NAME" \
+      '.[] | select(.name == $name) | .id' "$ruleset_list"
+  )
+
+  if [[ ${#existing_ids[@]} -gt 1 ]]; then
+    echo "  FAILED: multiple rulesets named '$RULESET_NAME'; refusing ambiguous update" >&2
+    fail=$((fail + 1))
+    continue
+  fi
+
+  existing_id="${existing_ids[0]:-}"
 
   if [[ -z "$existing_id" ]]; then
-    echo "  Creating..."
-    if gh api -X POST "repos/$ORG/$repo/rulesets" --input "$JSON_FILE" > /dev/null 2>&1; then
-      echo "  Created."
-      ok=$((ok + 1))
-    else
-      echo "  FAILED"
-      fail=$((fail + 1))
-    fi
+    echo "  FAILED: '$RULESET_NAME' is absent; bootstrap it from repository-owned policy" >&2
+    fail=$((fail + 1))
   else
-    echo "  Updating (id: $existing_id)..."
-    if gh api -X PUT "repos/$ORG/$repo/rulesets/$existing_id" --input "$JSON_FILE" > /dev/null 2>&1; then
-      echo "  Updated."
+    live_ruleset="$tmp_dir/$repo-$existing_id-live.json"
+    update_payload="$tmp_dir/$repo-$existing_id-update.json"
+
+    if ! gh api "repos/$ORG/$repo/rulesets/$existing_id" > "$live_ruleset"; then
+      echo "  FAILED: could not read live ruleset id $existing_id" >&2
+      fail=$((fail + 1))
+      continue
+    fi
+
+    if ! jq -e \
+        --arg enforcement "$desired_enforcement" \
+        --arg source "$ORG/$repo" \
+        --argjson merge_queue "$desired_merge_queue" '
+      def valid_required_check:
+        type == "object"
+        and has("context")
+        and (.context | type == "string")
+        and (.context | test("\\S"))
+        and has("integration_id")
+        and (
+          .integration_id == null
+          or (
+            (.integration_id | type) == "number"
+            and .integration_id > 0
+            and .integration_id == (.integration_id | floor)
+          )
+        );
+      def complete_required_status_authority:
+        [.rules[] | select(.type == "required_status_checks")] as $status_rules
+        | (.rules | type) == "array"
+        and all(
+          .rules[];
+          type == "object"
+          and has("type")
+          and (.type | type) == "string"
+        )
+        and ($status_rules | length) == 1
+        and ($status_rules[0] | has("parameters"))
+        and ($status_rules[0].parameters | type == "object")
+        and ($status_rules[0].parameters | has("strict_required_status_checks_policy"))
+        and (
+          $status_rules[0].parameters.strict_required_status_checks_policy
+          | type
+        ) == "boolean"
+        and ($status_rules[0].parameters | has("do_not_enforce_on_create"))
+        and (
+          $status_rules[0].parameters.do_not_enforce_on_create
+          | type
+        ) == "boolean"
+        and ($status_rules[0].parameters | has("required_status_checks"))
+        and ($status_rules[0].parameters.required_status_checks | type == "array")
+        and ($status_rules[0].parameters.required_status_checks | length) > 0
+        and all(
+          $status_rules[0].parameters.required_status_checks[];
+          valid_required_check
+        )
+        and (
+          [
+            $status_rules[0].parameters.required_status_checks[]
+            | .context
+          ]
+          | length
+        ) == (
+          [
+            $status_rules[0].parameters.required_status_checks[]
+            | .context
+          ]
+          | unique
+          | length
+        );
+      ([.rules[] | select(.type == "merge_queue")] | length) as $queue_count
+      | if .source_type != "Repository" or .source != $source
+        then error("ruleset is not owned by the target repository")
+        elif (has("name") and has("target") and has("bypass_actors")
+          and has("conditions") and has("rules")) | not
+        then error("live ruleset response is incomplete")
+        elif (complete_required_status_authority | not)
+        then error("required_status_checks authority is incomplete")
+        elif $queue_count > 1
+        then error("live ruleset has multiple merge_queue rules")
+        else {
+          name,
+          target,
+          enforcement: $enforcement,
+          bypass_actors,
+          conditions,
+          rules: (
+            if $queue_count == 1
+            then [.rules[] | if .type == "merge_queue" then $merge_queue else . end]
+            else .rules + [$merge_queue]
+            end
+          )
+        }
+        end
+    ' "$live_ruleset" > "$update_payload"; then
+      echo "  FAILED: could not derive a scoped update from the live ruleset" >&2
+      fail=$((fail + 1))
+      continue
+    fi
+
+    if ! jq -e --slurpfile candidate "$update_payload" '
+      def unrelated:
+        {
+          name,
+          target,
+          bypass_actors,
+          conditions,
+          rules: [.rules[] | select(.type != "merge_queue")]
+        };
+      unrelated == ($candidate[0] | unrelated)
+    ' "$live_ruleset" > /dev/null; then
+      echo "  FAILED: scoped update would change or remove an unrelated live rule" >&2
+      fail=$((fail + 1))
+      continue
+    fi
+
+    if [[ "$DRY_RUN" == true ]]; then
+      echo "DRY-RUN $repo payload: $(jq -c . "$update_payload")"
+      ok=$((ok + 1))
+      continue
+    fi
+
+    echo "  Updating only enforcement and merge_queue (id: $existing_id)..."
+    if gh api -X PUT "repos/$ORG/$repo/rulesets/$existing_id" \
+        --input "$update_payload" > /dev/null; then
+      echo "  Updated; repository-specific contexts and unrelated rules preserved."
       ok=$((ok + 1))
     else
-      echo "  FAILED"
+      echo "  FAILED" >&2
       fail=$((fail + 1))
     fi
   fi
@@ -85,3 +278,6 @@ done
 
 echo ""
 echo "Done: $ok succeeded, $fail failed"
+if ((fail > 0)); then
+  exit 1
+fi

--- a/tools/github/apply-repo-rulesets.sh
+++ b/tools/github/apply-repo-rulesets.sh
@@ -7,7 +7,8 @@ set -euo pipefail
 # homeric-main-baseline ruleset. All other live rules remain repository-owned.
 # Usage:
 #   ./tools/github/apply-repo-rulesets.sh --active --all     # active mode, eligible fleet repos
-#   ./tools/github/apply-repo-rulesets.sh --evaluate --all   # evaluate mode, eligible fleet repos
+#   ./tools/github/apply-repo-rulesets.sh --evaluate --all --dry-run  # no-write fleet preview
+#   ./tools/github/apply-repo-rulesets.sh --evaluate --repos Staged  # already-evaluate only
 #   ./tools/github/apply-repo-rulesets.sh --repos Foo,Bar    # canonical mode, specific repos only
 #   ./tools/github/apply-repo-rulesets.sh --dry-run --repos Foo
 
@@ -138,8 +139,8 @@ rollback_and_abort() {
   local rollback_readback="$tmp_dir/$repo-$existing_id-rollback-readback.json"
   local rollback_put_rc=0
 
+  trap '' HUP INT TERM
   MUTATION_ARMED=false
-  trap '' INT TERM
   echo "  FAILED: $reason; attempting rollback from durable pre-state" >&2
   gh api -X PUT "repos/$ORG/$repo/rulesets/$existing_id" \
     --input "$rollback_payload" > /dev/null || rollback_put_rc=$?
@@ -167,8 +168,10 @@ MUTATION_SNAPSHOT=""
 
 handle_mutation_signal() {
   local signal_name=$1
-  trap - INT TERM
+  local exit_status=$2
+  trap '' HUP INT TERM
   if [[ "$MUTATION_ARMED" == true ]]; then
+    echo "  UNCERTAIN MUTATION: received $signal_name during an armed mutation; live state is ambiguous until rollback verification completes." >&2
     rollback_and_abort \
       "$MUTATION_REPO" \
       "$MUTATION_RULESET_ID" \
@@ -176,11 +179,12 @@ handle_mutation_signal() {
       "received $signal_name during an armed mutation" \
       "$MUTATION_SNAPSHOT"
   fi
-  exit 130
+  exit "$exit_status"
 }
 
-trap 'handle_mutation_signal INT' INT
-trap 'handle_mutation_signal TERM' TERM
+trap 'handle_mutation_signal HUP 129' HUP
+trap 'handle_mutation_signal INT 130' INT
+trap 'handle_mutation_signal TERM 143' TERM
 
 if [[ -n "$REPOS_OVERRIDE" && "$ALL_REPOS" == true ]]; then
   echo "ERROR: use either --repos or --all, not both" >&2
@@ -270,6 +274,22 @@ for repo in "${REPOS[@]}"; do
     # selectors fail closed.
     if ! validate_live_identity_scope "$live_ruleset" "$repo"; then
       echo "  FAILED: live ruleset identity or main-only branch scope is invalid" >&2
+      fail=$((fail + 1))
+      continue
+    fi
+
+    if ! live_enforcement=$(jq -er '
+        .enforcement
+        | select(. == "active" or . == "evaluate" or . == "disabled")
+      ' "$live_ruleset"); then
+      echo "  FAILED: live ruleset enforcement is missing or invalid" >&2
+      fail=$((fail + 1))
+      continue
+    fi
+    if [[ "$live_enforcement" == "active" &&
+          "$desired_enforcement" == "evaluate" &&
+          "$DRY_RUN" != true ]]; then
+      echo "  FAILED: refusing active-to-evaluate downgrade; use --dry-run for a no-write preview" >&2
       fail=$((fail + 1))
       continue
     fi

--- a/tools/github/apply-repo-rulesets.sh
+++ b/tools/github/apply-repo-rulesets.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 # apply-repo-rulesets.sh [--active|--evaluate] [--repos repo1,repo2,...]
-#                         [--all] [--dry-run]
+#                         [--all] [--dry-run] [--snapshot-dir path]
 # Adds or updates only the merge-queue rule and enforcement mode in an existing
 # homeric-main-baseline ruleset. All other live rules remain repository-owned.
 # Usage:
@@ -20,6 +20,7 @@ ENFORCEMENT=""
 REPOS_OVERRIDE=""
 DRY_RUN=false
 ALL_REPOS=false
+SNAPSHOT_DIR_OVERRIDE="${RULESET_SNAPSHOT_DIR:-}"
 
 while [[ $# -gt 0 ]]; do
   case "${1:-}" in
@@ -43,6 +44,22 @@ while [[ $# -gt 0 ]]; do
       ;;
     --dry-run)       DRY_RUN=true; shift ;;
     --all)           ALL_REPOS=true; shift ;;
+    --snapshot-dir)
+      if [[ $# -lt 2 || -z "${2:-}" ]]; then
+        echo "ERROR: --snapshot-dir requires a non-empty path" >&2
+        exit 2
+      fi
+      SNAPSHOT_DIR_OVERRIDE=$2
+      shift 2
+      ;;
+    --snapshot-dir=*)
+      SNAPSHOT_DIR_OVERRIDE="${1#--snapshot-dir=}"
+      if [[ -z "$SNAPSHOT_DIR_OVERRIDE" ]]; then
+        echo "ERROR: --snapshot-dir requires a non-empty path" >&2
+        exit 2
+      fi
+      shift
+      ;;
     *) echo "Unknown argument: $1" >&2; exit 2 ;;
   esac
 done
@@ -69,6 +86,101 @@ desired_merge_queue=$(jq -ec '
 
 tmp_dir=$(mktemp -d)
 trap 'rm -rf "$tmp_dir"' EXIT
+
+if [[ -n "$SNAPSHOT_DIR_OVERRIDE" ]]; then
+  SNAPSHOT_ROOT=$SNAPSHOT_DIR_OVERRIDE
+else
+  operation_id="$(date -u +%Y%m%dT%H%M%SZ)-$$"
+  SNAPSHOT_ROOT="$REPO_ROOT/configs/github/backups/ruleset-mutations/$operation_id"
+fi
+
+validate_live_identity_scope() {
+  local ruleset_file=$1
+  local repo=$2
+  jq -e \
+    --arg name "$RULESET_NAME" \
+    --arg source "$ORG/$repo" '
+      .name == $name
+      and .target == "branch"
+      and .source_type == "Repository"
+      and .source == $source
+      and .conditions == {
+        ref_name: {
+          include: ["refs/heads/main"],
+          exclude: []
+        }
+      }
+    ' "$ruleset_file" > /dev/null
+}
+
+write_mutable_payload() {
+  local ruleset_file=$1
+  local payload_file=$2
+  jq -e '{name, target, enforcement, bypass_actors, conditions, rules}' \
+    "$ruleset_file" >"$payload_file"
+}
+
+exact_mutable_state_matches() {
+  local expected_payload=$1
+  local actual_ruleset=$2
+  jq -e --slurpfile expected "$expected_payload" '
+    {name, target, enforcement, bypass_actors, conditions, rules}
+      == $expected[0]
+  ' "$actual_ruleset" > /dev/null
+}
+
+rollback_and_abort() {
+  local repo=$1
+  local existing_id=$2
+  local rollback_payload=$3
+  local reason=$4
+  local snapshot_file=$5
+  local rollback_readback="$tmp_dir/$repo-$existing_id-rollback-readback.json"
+  local rollback_put_rc=0
+
+  MUTATION_ARMED=false
+  trap '' INT TERM
+  echo "  FAILED: $reason; attempting rollback from durable pre-state" >&2
+  gh api -X PUT "repos/$ORG/$repo/rulesets/$existing_id" \
+    --input "$rollback_payload" > /dev/null || rollback_put_rc=$?
+  if ((rollback_put_rc != 0)); then
+    echo "  WARNING: rollback PUT reported exit $rollback_put_rc; verifying live state" >&2
+  fi
+
+  if gh api "repos/$ORG/$repo/rulesets/$existing_id" >"$rollback_readback" &&
+      validate_live_identity_scope "$rollback_readback" "$repo" &&
+      exact_mutable_state_matches "$rollback_payload" "$rollback_readback"; then
+    echo "  Rollback verified exactly; aborting this operation before any further repository." >&2
+    exit 1
+  fi
+
+  echo "  UNCERTAIN MUTATION: rollback could not be verified exactly for $repo ruleset $existing_id." >&2
+  echo "  Durable recovery snapshot: $snapshot_file" >&2
+  exit 1
+}
+
+MUTATION_ARMED=false
+MUTATION_REPO=""
+MUTATION_RULESET_ID=""
+MUTATION_ROLLBACK_PAYLOAD=""
+MUTATION_SNAPSHOT=""
+
+handle_mutation_signal() {
+  local signal_name=$1
+  trap - INT TERM
+  if [[ "$MUTATION_ARMED" == true ]]; then
+    rollback_and_abort \
+      "$MUTATION_REPO" \
+      "$MUTATION_RULESET_ID" \
+      "$MUTATION_ROLLBACK_PAYLOAD" \
+      "received $signal_name during an armed mutation" \
+      "$MUTATION_SNAPSHOT"
+  fi
+  exit 130
+}
+
+trap 'handle_mutation_signal INT' INT
+trap 'handle_mutation_signal TERM' TERM
 
 if [[ -n "$REPOS_OVERRIDE" && "$ALL_REPOS" == true ]]; then
   echo "ERROR: use either --repos or --all, not both" >&2
@@ -147,6 +259,17 @@ for repo in "${REPOS[@]}"; do
 
     if ! gh api "repos/$ORG/$repo/rulesets/$existing_id" > "$live_ruleset"; then
       echo "  FAILED: could not read live ruleset id $existing_id" >&2
+      fail=$((fail + 1))
+      continue
+    fi
+
+    # Validate the fetched object itself before constructing any PUT payload.
+    # The list endpoint is only discovery data; the detail response must prove
+    # exact identity, repository ownership, and an unambiguous main-only branch
+    # scope. Equality is intentionally strict so wildcards and extra scope
+    # selectors fail closed.
+    if ! validate_live_identity_scope "$live_ruleset" "$repo"; then
+      echo "  FAILED: live ruleset identity or main-only branch scope is invalid" >&2
       fail=$((fail + 1))
       continue
     fi
@@ -264,15 +387,56 @@ for repo in "${REPOS[@]}"; do
       continue
     fi
 
-    echo "  Updating only enforcement and merge_queue (id: $existing_id)..."
-    if gh api -X PUT "repos/$ORG/$repo/rulesets/$existing_id" \
-        --input "$update_payload" > /dev/null; then
-      echo "  Updated; repository-specific contexts and unrelated rules preserved."
-      ok=$((ok + 1))
-    else
-      echo "  FAILED" >&2
+    snapshot_file="$SNAPSHOT_ROOT/$repo-ruleset-$existing_id-pre.json"
+    rollback_payload="$tmp_dir/$repo-$existing_id-rollback.json"
+    post_readback="$tmp_dir/$repo-$existing_id-post-readback.json"
+    if ! mkdir -p "$SNAPSHOT_ROOT" || [[ -e "$snapshot_file" ]]; then
+      echo "  FAILED: durable snapshot path is unavailable or already exists: $snapshot_file" >&2
       fail=$((fail + 1))
+      continue
     fi
+    snapshot_tmp="$snapshot_file.tmp"
+    if ! cp "$live_ruleset" "$snapshot_tmp" ||
+        ! chmod 600 "$snapshot_tmp" ||
+        ! mv "$snapshot_tmp" "$snapshot_file" ||
+        ! sync "$snapshot_file"; then
+      echo "  FAILED: could not persist durable pre-state snapshot" >&2
+      fail=$((fail + 1))
+      continue
+    fi
+    if ! write_mutable_payload "$snapshot_file" "$rollback_payload"; then
+      echo "  FAILED: could not derive rollback payload from durable snapshot" >&2
+      fail=$((fail + 1))
+      continue
+    fi
+    echo "  Durable pre-state snapshot: $snapshot_file"
+
+    echo "  Updating only enforcement and merge_queue (id: $existing_id)..."
+    MUTATION_REPO=$repo
+    MUTATION_RULESET_ID=$existing_id
+    MUTATION_ROLLBACK_PAYLOAD=$rollback_payload
+    MUTATION_SNAPSHOT=$snapshot_file
+    MUTATION_ARMED=true
+    if ! gh api -X PUT "repos/$ORG/$repo/rulesets/$existing_id" \
+        --input "$update_payload" > /dev/null; then
+      rollback_and_abort "$repo" "$existing_id" "$rollback_payload" \
+        "PUT failed or returned an ambiguous result" "$snapshot_file"
+    fi
+
+    if ! gh api "repos/$ORG/$repo/rulesets/$existing_id" >"$post_readback"; then
+      rollback_and_abort "$repo" "$existing_id" "$rollback_payload" \
+        "post-PUT readback failed" "$snapshot_file"
+    fi
+    if ! validate_live_identity_scope "$post_readback" "$repo" ||
+        ! exact_mutable_state_matches "$update_payload" "$post_readback"; then
+      rollback_and_abort "$repo" "$existing_id" "$rollback_payload" \
+        "post-PUT state did not match the exact requested postcondition" \
+        "$snapshot_file"
+    fi
+
+    MUTATION_ARMED=false
+    echo "  Verified exact postcondition; repository-specific contexts and unrelated rules preserved."
+    ok=$((ok + 1))
   fi
 done
 


### PR DESCRIPTION
Refs #386

Implements the HomericIntelligence merge-queue rollout for Odysseus with fail-closed live-ruleset preservation, repository-specific provenance fixtures, read-only merge-group validation permissions, and staged activation guidance. The umbrella issue remains open until all repository activations and queued smoke evidence are complete.

Independent human review of workflow changes remains required before merge; live rulesets are untouched by this PR.