### PR TITLE
ci: fast (<5 min) merge-queue smoke gate

### DIFF
--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -475,4 +475,3 @@ jobs:
 
       - name: Validate version consistency (pixi.toml vs CHANGELOG)
         run: python3 scripts/check_version_consistency.py
-

--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -24,8 +24,10 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
-  merge_group:
-    types: [checks_requested]
+  # merge_group intentionally removed: merge-queue checks are served by the
+  # single fast `merge-queue-smoke` job in merge-queue-smoke.yml. Re-running
+  # the full required matrix per queue entry serialized on runner slots
+  # (70-90 min per merge). PR-side jobs in this workflow are unchanged.
   workflow_dispatch:
 
 permissions:
@@ -473,3 +475,4 @@ jobs:
 
       - name: Validate version consistency (pixi.toml vs CHANGELOG)
         run: python3 scripts/check_version_consistency.py
+

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -20,8 +20,8 @@ name: Build Images
 on:
   pull_request:
     branches: [main]
-  merge_group:
-    types: [checks_requested]
+  # merge_group intentionally removed: merge-queue checks are served by the
+  # single fast `merge-queue-smoke` job in merge-queue-smoke.yml (see that file).
   push:
     branches: [main]
     tags:

--- a/.github/workflows/install-test.yml
+++ b/.github/workflows/install-test.yml
@@ -5,8 +5,8 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
-  merge_group:
-    types: [checks_requested]
+  # merge_group intentionally removed: merge-queue checks are served by the
+  # single fast `merge-queue-smoke` job in merge-queue-smoke.yml (see that file).
   schedule:
     - cron: "0 6 * * 1"  # Every Monday at 06:00 UTC
   workflow_dispatch:

--- a/.github/workflows/merge-queue-smoke.yml
+++ b/.github/workflows/merge-queue-smoke.yml
@@ -1,0 +1,52 @@
+# Fast merge-queue gate. This is the ONLY workflow that runs on merge_group
+# events: _required.yml, build-images.yml, install-test.yml, and release.yml
+# no longer trigger there, so re-running the full required matrix per queue
+# entry (70-90 min of runner-slot starvation) is replaced by this single job.
+# PR-side CI is completely untouched; after the ruleset flip,
+# `merge-queue-smoke` is the only ruleset-required context and is produced
+# exclusively on merge_group events by this job.
+#
+# The steps below are real, fail-fast validations borrowed from the repo's
+# fastest required jobs (lint, install, release). They are NOT decorative: a
+# malformed YAML/JSON config, a broken installer script, or a broken release
+# contract in the merge group fails the queue entry.
+name: Merge Queue Smoke
+
+on:
+  merge_group:
+    types: [checks_requested]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: mq-smoke-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  merge-queue-smoke:
+    name: merge-queue-smoke
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Install yamllint
+        run: pip install yamllint
+
+      - name: Lint YAML (configs/ and .github/workflows/)
+        run: yamllint -d relaxed configs/ .github/workflows/
+
+      - name: Validate all JSON files in configs/
+        run: |
+          set -euo pipefail
+          find configs/ -name "*.json" -print0 | xargs -0 -r -I{} jq . {} > /dev/null
+          echo "All JSON OK"
+
+      - name: Installer script is valid bash
+        run: bash -n install.sh
+
+      - name: Release-contract regression tests (dry-run)
+        run: bash tests/release/release.test.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,8 +7,8 @@ on:
       - 'v[0-9]+.[0-9]+.[0-9]+'
   pull_request:
     branches: [main]
-  merge_group:
-    types: [checks_requested]
+  # merge_group intentionally removed: merge-queue checks are served by the
+  # single fast `merge-queue-smoke` job in merge-queue-smoke.yml (see that file).
   workflow_dispatch:
 
 permissions:

--- a/tests/github/workflow-permissions.test.py
+++ b/tests/github/workflow-permissions.test.py
@@ -90,17 +90,38 @@ def assert_workflow_structure() -> None:
         f"required workflow context union changed: got {supplied_contexts!r}"
     )
 
+    # Merge-queue checks are served solely by the single fast
+    # `merge-queue-smoke` job in merge-queue-smoke.yml. The context-supplying
+    # workflows must NOT run for merge groups any more: re-running the full
+    # required matrix per queue entry serialized on runner slots (70-90 min
+    # per merge). PR-side CI is untouched.
+    for path in sorted((ROOT / ".github/workflows").glob("*.yml")):
+        relative_path = str(path.relative_to(ROOT))
+        triggers = load_workflow(relative_path).get("on")
+        if not isinstance(triggers, dict):
+            raise AssertionError(f"{relative_path} on must be a mapping")
+        if relative_path == ".github/workflows/merge-queue-smoke.yml":
+            assert triggers.get("merge_group") == {"types": ["checks_requested"]}, (
+                "merge-queue-smoke.yml must handle merge_group checks_requested"
+            )
+        else:
+            assert "merge_group" not in triggers, (
+                f"{relative_path} must not run for merge groups; the queue is "
+                "served solely by merge-queue-smoke.yml"
+            )
+
+    smoke = load_workflow(".github/workflows/merge-queue-smoke.yml")
+    smoke_jobs = smoke.get("jobs")
+    assert isinstance(smoke_jobs, dict) and list(smoke_jobs) == ["merge-queue-smoke"], (
+        "merge-queue-smoke.yml must define exactly one job: merge-queue-smoke"
+    )
+    assert smoke_jobs["merge-queue-smoke"].get("name") == "merge-queue-smoke"
+    assert permissions(smoke) == {"contents": "read"}, (
+        "merge-queue-smoke.yml workflow permissions must be exactly contents: read"
+    )
+
     for path in REQUIRED_WORKFLOWS:
         workflow = load_workflow(path)
-        triggers = workflow.get("on")
-        if not isinstance(triggers, dict):
-            raise AssertionError(f"{path} on must be a mapping")
-        merge_group = triggers.get("merge_group")
-        assert merge_group == {"types": ["checks_requested"]}, (
-            f"{path} must handle only merge_group checks_requested; "
-            f"got {merge_group!r}"
-        )
-
         jobs = workflow.get("jobs")
         if not isinstance(jobs, dict):
             raise AssertionError(f"{path} jobs must be a mapping")


### PR DESCRIPTION
Closes #423

## Diagnosis

Merge-group runs re-executed the full required matrix across four workflows (`_required.yml`, `build-images.yml`, `install-test.yml`, `release.yml`). Each job waited 8-16+ minutes for a runner slot, so a single queue entry took **70-90 minutes** to merge and serialized the whole queue on runner-slot starvation.

## Design

- The four workflows above no longer trigger on `merge_group`. Their `pull_request`/`push`/`schedule`/`workflow_dispatch` triggers and every existing job are unchanged — **PR-side CI is completely untouched** (no new jobs in existing workflows).
- New `.github/workflows/merge-queue-smoke.yml`: the ONLY workflow triggering on `merge_group` (`checks_requested`). Single job named `merge-queue-smoke`, `timeout-minutes: 5`, one runner slot, real fail-fast validations borrowed from the fastest required jobs: `yamllint -d relaxed configs/ .github/workflows/`, `jq` validation of all `configs/` JSON, `bash -n install.sh`, and `tests/release/release.test.sh`. No `continue-on-error`, no `|| true`.
- `tests/github/workflow-permissions.test.py` (run by `just test-merge-queue-readiness`) updated minimally for the new topology: no workflow other than `merge-queue-smoke.yml` may declare `merge_group`, and that workflow must define exactly one read-only `merge-queue-smoke` job.
- All action SHAs reuse the pins already present in this repo.

## Post-merge ruleset rollout (operator step — NOT part of this PR)

After merge, replace ALL `required_status_checks` contexts (in every ruleset) with the single context `merge-queue-smoke` and set `min_entries_to_merge_wait_minutes` to 0; PR-side checks keep running but become non-blocking; the queue must not be used between merge and flip. `configs/github/repo-ruleset*.json` still mirror the current 11-context ruleset and must be updated together with the live flip (along with the context list in `tests/github/merge-queue-readiness.test.sh`).

## Validation

- `bash tests/github/merge-queue-readiness.test.sh` — 19/19 checks passed
- All six `workflow-permissions.test.py` checks pass individually
- `bash tests/release/release.test.sh` — 13/13; `bash -n install.sh` OK
- `yamllint -d relaxed configs/ .github/workflows/` — exit 0
- `check-jsonschema --builtin-schema vendor.github-workflows .github/workflows/*.yml` — ok
- `_required.yml` diff vs base is a trigger-comment-only change; all jobs byte-identical

🤖 Generated with [Claude Code](https://claude.com/claude-code)