### PR TITLE
ci: move idempotent-build and e2e-reliability-t1 to self-hosted runner

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,11 +11,20 @@ on:
   workflow_dispatch:
 jobs:
   idempotent-build:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, self-hosted-aeolus]
+    container:
+      image: ubuntu:24.04
     timeout-minutes: 60
     env:
       SKIP_ODYSSEY_BUILD: "true"
     steps:
+      - name: Bootstrap container toolchain
+        # Runs before checkout: actions/checkout needs `git` on PATH itself to
+        # handle `submodules: recursive`, which a bare ubuntu:24.04 lacks.
+        run: |
+          apt-get update
+          apt-get install -y --no-install-recommends \
+            sudo git curl ca-certificates bash
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           submodules: recursive

--- a/.github/workflows/e2e-reliability.yml
+++ b/.github/workflows/e2e-reliability.yml
@@ -76,9 +76,20 @@ jobs:
   e2e-reliability-t1:
     name: e2e-reliability-t1 (nightly until #391 worker restored)
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, self-hosted-aeolus]
+    container:
+      image: ubuntu:24.04
     timeout-minutes: 30
     steps:
+      - name: Bootstrap container toolchain
+        # Runs before checkout: actions/checkout needs `git` on PATH itself to
+        # handle `submodules: recursive`, which a bare ubuntu:24.04 lacks.
+        run: |
+          apt-get update
+          apt-get install -y --no-install-recommends \
+            sudo git curl ca-certificates bash python3 python3-pip
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           submodules: recursive
@@ -99,7 +110,7 @@ jobs:
           nats-server --version
 
       - name: Install Python NATS client (used by scenario assertions)
-        run: pip install nats-py
+        run: pip install --user nats-py
 
       - name: Build mesh binaries (Agamemnon + myrmidon) from source
         # `just build` produces build/Agamemnon/Agamemnon_server —


### PR DESCRIPTION
Moves the two highest-time-consumption Odysseus jobs (idempotent-build ~41-45min, e2e-reliability-t1 ~33-34min) onto the new self-hosted runner, using an ubuntu:24.04 container for environment parity. Bootstrap installs git before checkout since submodules: recursive needs it.