### PR TITLE
feat(ci): add gated AlexNet mesh smoke workflow (manual dispatch)

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,10 @@
+# actionlint configuration
+# https://github.com/rhysd/actionlint/blob/main/docs/config.md
+#
+# Declares the custom self-hosted runner labels used by this repo's workflows.
+# The `mesh` label is the AlexNet fleet runner registered on epimetheus
+# (see .github/workflows/alexnet-mesh-smoke.yml and
+# docs/runbooks/alexnet-mesh-fleet.md for registration instructions).
+self-hosted-runner:
+  labels:
+    - mesh

--- a/.github/workflows/alexnet-mesh-chaos.yml
+++ b/.github/workflows/alexnet-mesh-chaos.yml
@@ -1,0 +1,103 @@
+# alexnet-mesh-chaos.yml — Crash-test the AlexNet mesh fleet scripts.
+#
+# Runs the self-contained chaos suite (e2e/alexnet-mesh-chaos.sh), which
+# deliberately CRASHES the fleet scripts to prove they fail fast and cleanly:
+#   C1 offline-host teardown (must not hang)   C2 unresolvable-host deploy
+#   C3 missing image (clear diagnostic)        C4 [live] clobber guard
+#   C5 [live] kill-mid-run (gate detects)      C6/C6b smoke-gate semantics
+#   C7 teardown idempotency
+#
+# Manual-dispatch only — same policy as the full mesh smoke: infra-dependent
+# jobs must not auto-gate PRs or main. Default mode (no inputs) runs the FAST
+# suite (C1-C3, C6, C6b, C7 — a minute or two, no training, no fleet writes
+# beyond the bounded offline probes). Live mode (`live: true`) launches and
+# SIGKILLs a REAL training container (C4/C5) and also runs the C6 live smoke,
+# so budget ~15-20 min.
+#
+# ── Runner requirement ──────────────────────────────────────────────────────
+# Must run on a self-hosted runner with the `self-hosted,mesh` labels (rootless
+# podman + tailscale + jq — see the smoke workflow and runbook for one-time
+# registration). GitHub-hosted runners cannot reach the fleet and lack the
+# tailscale CLI the suite requires to resolve fleet hosts.
+#
+# ── Check status notes ───────────────────────────────────────────────────────
+# • Manual-dispatch only: no pull_request/push/schedule triggers, so it never
+#   appears as a PR or main check and can never block a merge. Dispatch it
+#   explicitly when a mesh change needs crash-testing.
+# • While a mesh smoke is running, a dispatched chaos run sits pending in the
+#   shared-concurrency queue until the smoke finishes — that is expected, not
+#   a stuck runner; the suite must never run while training is in flight.
+#
+# ── Safety ──────────────────────────────────────────────────────────────────
+# Serialized against the mesh smoke via a SHARED concurrency group: both use
+# the `alexnet-training` container name on the same runner, and the chaos
+# suite's C6 reseeds/removes that container when it finds one that is not a
+# completed smoke — it must never run concurrently with live training.
+# Static commands only: dispatch inputs pass via env, never interpolated into
+# a run block. Actions pinned to commit SHAs per repo convention.
+
+name: AlexNet mesh chaos
+
+on:
+  workflow_dispatch:
+    inputs:
+      live:
+        description: "Run live cases: C4 clobber guard + C5 kill-mid-run against a real training container"
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+concurrency:
+  # SHARED with alexnet-mesh-smoke.yml — see Safety note above. Never cancel
+  # an in-flight run: the suite under test may be mid-crash.
+  group: alexnet-mesh-fleet
+  cancel-in-progress: false
+
+jobs:
+  mesh-chaos:
+    name: AlexNet mesh chaos (crash-test)
+    runs-on: [self-hosted, mesh]
+    # 40 min: live mode waits up to 11 min for a training container to reach
+    # 'running' (C5) plus up to 10 min for the C6 live smoke to exit — 30 left
+    # only ~7 min of margin on a cold-compile host.
+    timeout-minutes: 40
+    env:
+      INPUT_LIVE: ${{ inputs.live || false }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          submodules: recursive
+
+      - name: Preflight (podman, tailscale, jq)
+        run: |
+          set -euo pipefail
+          command -v podman >/dev/null || { echo "::error::podman missing — register the runner on a host with rootless podman (runbook prerequisites)"; exit 1; }
+          command -v tailscale >/dev/null || { echo "::error::tailscale missing — the runner must be on the tailnet (the suite resolves fleet hosts over it)"; exit 1; }
+          command -v jq >/dev/null || { echo "::error::jq missing (tailscale status parsing)"; exit 1; }
+          podman --version
+          echo "Preflight OK"
+
+      - name: Run chaos suite
+        run: |
+          set -euo pipefail
+          if [[ "$INPUT_LIVE" == "true" ]]; then
+            echo "Live mode: C4 clobber guard + C5 kill-mid-run against a real training container"
+            CHAOS_LIVE=1 bash e2e/alexnet-mesh-chaos.sh | tee "$RUNNER_TEMP/chaos.log"
+          else
+            echo "Default mode: offline-host + gate-semantics crash tests (fast)"
+            bash e2e/alexnet-mesh-chaos.sh | tee "$RUNNER_TEMP/chaos.log"
+          fi
+
+      - name: Upload chaos log
+        # Always upload — a failing run's log is the evidence the suite exists
+        # to produce.
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: alexnet-mesh-chaos-log
+          path: ${{ runner.temp }}/chaos.log
+          if-no-files-found: warn
+          retention-days: 14

--- a/.github/workflows/alexnet-mesh-smoke.yml
+++ b/.github/workflows/alexnet-mesh-smoke.yml
@@ -1,0 +1,183 @@
+# alexnet-mesh-smoke.yml — Run the AlexNet mesh smoke test end-to-end from CI.
+#
+# Repeatable + gated fleet test: build the odyssey:dev image, distribute it to
+# the Tailscale fleet, launch bounded training on every host, wait for all
+# containers to exit, verify per-host completion evidence ("Training complete!"
+# in `podman logs alexnet-training` + non-empty weights dir), then collect
+# results centrally and tear down. The job FAILS if any host lacks completion
+# evidence, so the smoke test is a real gate, not a fire-and-forget launch.
+#
+# ── Runner requirement (ONE-TIME, on epimetheus) ─────────────────────────────
+# This workflow CANNOT run on a GitHub-hosted runner: it needs podman and
+# Tailscale reachability to the fleet. Register a self-hosted runner on
+# epimetheus (the build/distribution hub) with the labels `self-hosted,mesh`:
+#
+#   # epimetheus: create a registration token for this repo, then:
+#   mkdir -p ~/actions-runner && cd ~/actions-runner
+#   curl -fsSL -o runner.tar.gz <latest-runner-linux-x64-url>
+#   tar xzf runner.tar.gz
+#   ./config.sh --url https://github.com/HomericIntelligence/Odysseus \
+#       --token <registration-token> --labels self-hosted,mesh
+#   ./run.sh   (or install as a systemd user service; enable linger)
+#
+# The runner account must satisfy the runbook prerequisites: rootless podman,
+# tailscale up, `jq`, and the Odyssey submodule synced (checkout handles this
+# per-run; the runner user's `podman` must work non-interactively).
+#
+# ── Why NOT a PR gate ────────────────────────────────────────────────────────
+# The full fleet smoke takes ~30-150 min (image build + per-host training) and
+# depends on physical fleet hosts. It is intentionally manual-dispatch only and
+# is not wired into _required.yml — infra flakiness must not block PRs. The
+# fleet e2e PR gate remains e2e-reliability-t1 (host-process mesh on stock
+# runners). See docs/runbooks/alexnet-mesh-fleet.md.
+#
+# ── Security ─────────────────────────────────────────────────────────────────
+# Static commands only: dispatch inputs are passed via env (never interpolated
+# into a run block), avoiding the Actions script-injection class. Actions are
+# pinned to commit SHAs per repo convention.
+
+name: AlexNet mesh smoke
+
+on:
+  workflow_dispatch:
+    inputs:
+      epochs:
+        description: Training epochs per host (10 = fleet smoke, 3 = fast smoke)
+        required: false
+        default: "10"
+      max_batches:
+        description: Cap batches per epoch (3 = smoke, 0 = full dataset)
+        required: false
+        default: "3"
+      fleet:
+        description: Space-separated host list
+        required: false
+        default: "epimetheus apollo aeolus hephaestus"
+      skip_build:
+        description: Reuse the existing odyssey:dev image (skip build + distribute)
+        required: false
+        type: boolean
+        default: false
+      teardown:
+        description: Remove alexnet-training containers on all hosts after collection
+        required: false
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+
+concurrency:
+  # SHARED with alexnet-mesh-chaos.yml: both use the `alexnet-training`
+  # container name on the same runner, and the chaos suite's C6 reseeds/removes
+  # that container — they must never run concurrently. One fleet run at a time.
+  group: alexnet-mesh-fleet
+  cancel-in-progress: false
+
+jobs:
+  mesh-smoke:
+    name: AlexNet mesh smoke (gated)
+    runs-on: [self-hosted, mesh]
+    # 240 min budget: deploy (cold image build + distribution) takes 15-30+ min
+    # on a fresh runner, and the wait+gate step alone can run up to its own
+    # 150-min default. 180 was too tight — the job could be killed mid-poll
+    # before the gate ever ran.
+    timeout-minutes: 240
+    env:
+      INPUT_EPOCHS: ${{ inputs.epochs }}
+      INPUT_MAX_BATCHES: ${{ inputs.max_batches }}
+      INPUT_FLEET: ${{ inputs.fleet }}
+      INPUT_SKIP_BUILD: ${{ inputs.skip_build }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          submodules: recursive
+
+      - name: Preflight (podman, tailscale, jq, submodule)
+        run: |
+          set -euo pipefail
+          command -v podman >/dev/null || { echo "::error::podman missing — register the runner on a host with rootless podman (runbook prerequisites)"; exit 1; }
+          command -v tailscale >/dev/null || { echo "::error::tailscale missing — the runner must be on the tailnet"; exit 1; }
+          command -v jq >/dev/null || { echo "::error::jq missing (deploy/collect scripts use it for tailscale status parsing)"; exit 1; }
+          command -v just >/dev/null || { echo "::error::just missing (teardown step calls the just recipe alexnet-fleet-teardown)"; exit 1; }
+          podman --version
+          # Explicit if-guard (no-silent-failures Bucket B): a failed probe is
+          # reported, and the deploy step still fails hard if hosts are down.
+          if ! tailscale status 2>&1 | sed -n '1,3p'; then
+              echo "WARN: tailscale status unavailable — deploy will fail if fleet hosts are unreachable" >&2
+          fi
+          test -f research/Odyssey/.git || { echo "::error::Odyssey submodule not checked out (submodules: recursive)"; exit 1; }
+          echo "Preflight OK"
+
+      - name: Deploy smoke to fleet (build, distribute, launch)
+        env:
+          WORKSPACE_DIR: ${{ github.workspace }}
+        run: |
+          set -euo pipefail
+          export FLEET="$INPUT_FLEET"
+          export EPOCHS="$INPUT_EPOCHS"
+          export MAX_BATCHES="$INPUT_MAX_BATCHES"
+          if [[ "$INPUT_SKIP_BUILD" == "true" ]]; then
+            export SKIP_BUILD=1
+            echo "SKIP_BUILD=1 — reusing existing odyssey:dev image"
+          fi
+          # WORKSPACE_DIR is inherited by the local alexnet-train.sh launch so
+          # the local host trains against THIS checkout, not a stale ~/Projects
+          # checkout. Remote hosts keep their own default (runbook prerequisites).
+          bash e2e/alexnet-deploy-fleet.sh
+
+      - name: Wait for all hosts + gate on completion evidence
+        run: |
+          set -euo pipefail
+          export FLEET="$INPUT_FLEET"
+          WAIT_ARGS=()
+          # Smoke runs (max_batches>0) intentionally save NO weights
+          # (run_train.mojo #5551): the "Training complete!" marker is the gate.
+          # Smoke runs (max_batches>0) save no weights (run_train.mojo #5551),
+          # so relax the gate to marker-only; full runs stay strict by default.
+          if [[ "$INPUT_MAX_BATCHES" != "0" ]]; then
+            WAIT_ARGS+=(--smoke)
+          fi
+          bash e2e/alexnet-fleet-wait.sh "${WAIT_ARGS[@]}"
+
+      - name: Collect results centrally
+        # Runs even when the gate failed so partial results (weights from hosts
+        # that completed) are preserved for the artifact and forensics.
+        if: always()
+        env:
+          CENTRAL_DIR: ${{ runner.temp }}/alexnet-fleet-results
+        run: |
+          set -euo pipefail
+          export FLEET="$INPUT_FLEET"
+          bash e2e/alexnet-collect-results.sh
+
+      - name: Write run summary
+        if: always()
+        run: |
+          {
+            echo "### AlexNet mesh smoke"
+            echo ""
+            echo "- Epochs: $INPUT_EPOCHS / Max batches: $INPUT_MAX_BATCHES"
+            echo "- Fleet: $INPUT_FLEET"
+            echo ""
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload fleet results
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: alexnet-mesh-smoke-results
+          path: ${{ runner.temp }}/alexnet-fleet-results/
+          if-no-files-found: warn
+          retention-days: 14
+
+      - name: Tear down training containers (unless disabled)
+        if: always() && inputs.teardown
+        env:
+          FLEET: ${{ inputs.fleet }}
+        run: |
+          set -euo pipefail
+          # Teardown is fleet hygiene (orphaned alexnet-training containers
+          # consume RAM on every host) — a failure is real and must surface,
+          # not be swallowed (no-silent-failures Bucket B).
+          FORCE=1 just alexnet-fleet-teardown

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,15 @@ jobs:
     timeout-minutes: 60
     env:
       SKIP_ODYSSEY_BUILD: "true"
+      # The container's /tmp is a RAM-backed tmpfs sized to the runner's
+      # container memory; a full C++ build (Agamemnon test tree, ~178 ninja
+      # targets) exhausts it and g++ dies with "No space left on device"
+      # writing /tmp/cc*.s. Redirect compiler temp files to the disk-backed
+      # workspace mount instead.
+      TMPDIR: /__w/tmp
     steps:
+      - name: Prepare disk-backed tmpdir
+        run: mkdir -p /__w/tmp && chmod 1777 /__w/tmp
       - name: Bootstrap container toolchain
         # Runs before checkout: actions/checkout needs `git` on PATH itself to
         # handle `submodules: recursive`, which a bare ubuntu:24.04 lacks.

--- a/docs/runbooks/alexnet-mesh-fleet.md
+++ b/docs/runbooks/alexnet-mesh-fleet.md
@@ -24,7 +24,7 @@ of "the same workload on different hardware."
 | **apollo** | Training target | i7-8565U (Whiskey Lake) | AVX2+VNNI | HomelabOS host. Docker installed but coexisting Podman works. Python 3.7 is irrelevant — container has Python 3.12+. |
 | **aeolus** | Training target | i7-3820 (Sandy Bridge-E) | **AVX only** | 2012 silicon. Mojo JIT may emit AVX2; script auto-strips via `--target-features -avx2`. |
 | **hephaestus** | Training target | Unknown | Unknown | Run `just install-worker` first; verify SIMD via `/proc/cpuinfo`. |
-| **hermes** | Training target | Intel Core Ultra 7 258V (Lunar Lake) | AVX2 | Modern 2024 silicon. Per the May-2026 cross-CPU survey, runs Mojo cleanly without `--target-features` strip. Preflight investigation flagged 2026-05-12 (see Per-Host Notes). |
+| **hermes** | Training target | Intel Core Ultra 7 258V (Lunar Lake) | AVX2 | Modern 2024 silicon. Per the May-2026 cross-CPU survey, runs Mojo cleanly without `--target-features` strip. Preflight investigation flagged 2026-05-12; host offline since 2026-08-07 (see Per-Host Notes). |
 
 ## Prerequisites (per host)
 
@@ -82,11 +82,31 @@ just doctor --role worker                 # Confirm podman, podman socket, tails
 
 # Smoke test — 3 batches of synthetic data, ~60 seconds
 just alexnet-smoke
+```
 
-# Monitor
+**Smoke-test expectations — `podman logs` is the single source of truth.**
+`alexnet-train.sh` launches the training container **detached** (`podman run -d`), so
+`just alexnet-smoke` returns immediately. All training output — per-batch loss, epoch
+progress, final metrics, and the completion marker — streams to the **container log
+driver**. `training.log` under `~/alexnet-results/<host>/` holds **only the launch
+header** (config summary); the run itself is never written there. Monitor and verify
+via `podman logs`:
+
+```bash
+# Stream live output
 podman logs -f alexnet-training
-tail -f ~/alexnet-results/epimetheus/training.log
-# Expected: "Batch [1/3] - Loss: ..." then "Training complete!"
+
+# Quick peek — prints the lines matching any of these markers
+podman logs alexnet-training 2>/dev/null | grep -E "Batch \[1/3\]|Training complete!|Average Loss|Test Accuracy:"
+# For a strict smoke PASS, verify EACH marker is present + container exited 0:
+#  1. "Batch [1/3] - Loss: ..."   — first batch ran (smoke mode = 3 batches)
+#  2. "Average Loss: ..."         — final loss printed
+#  3. "Test Accuracy: ..."        — evaluation completed
+#  4. "Training complete!"        — the terminal marker
+#  5. container exited 0:
+podman inspect alexnet-training --format '{{.State.Status}} exit={{.State.ExitCode}}'
+#     exited exit=0
+# (e2e/alexnet-fleet-wait.sh enforces all of the above as its gate)
 
 # Full training run (after smoke validation passes)
 podman rm -f alexnet-training             # Clean up smoke container
@@ -108,6 +128,11 @@ DRY_RUN=1 bash e2e/alexnet-deploy-fleet.sh
 EPOCHS=10 MAX_BATCHES=3 bash e2e/alexnet-deploy-fleet.sh
 # Builds image, distributes to apollo/aeolus/hephaestus/hermes over Tailscale, launches
 # 4 training jobs in parallel. ~90s for image transfer, then training runs concurrent.
+#
+# Fleet smoke expectations are per-host and identical to Phase 1: each host's
+# container log is the single source of truth — check every host with
+#   ssh <host> 'podman logs alexnet-training 2>/dev/null | grep -E "Training complete!|Average Loss|Test Accuracy:"'
+# (the wait+gate wrapper, e2e/alexnet-fleet-wait.sh, automates this check)
 
 # Full training run
 EPOCHS=100 bash e2e/alexnet-deploy-fleet.sh
@@ -131,10 +156,15 @@ for h in apollo aeolus hephaestus hermes; do
     ssh "$h" "podman logs -f alexnet-training"
 done
 
-# Check final loss summaries
+# Check final loss summaries — markers live in each host's container log,
+# not in training.log (which only carries the launch header)
 for host in epimetheus apollo aeolus hephaestus hermes; do
     echo "── $host ──"
-    grep -E "Average Loss|Test Accuracy" ~/alexnet-results/$host/training.log | tail -5
+    if [[ "$host" == "$(hostname)" ]]; then
+        podman logs alexnet-training 2>/dev/null | grep -E "Average Loss|Test Accuracy" | tail -5
+    else
+        ssh "$host" "podman logs alexnet-training 2>/dev/null | grep -E 'Average Loss|Test Accuracy' | tail -5"
+    fi
 done
 ```
 
@@ -151,6 +181,78 @@ CENTRAL_DIR=~/alexnet-fleet-results-$(date +%Y%m%d) bash e2e/alexnet-collect-res
 
 The collection script rsyncs each host's `~/alexnet-results/<hostname>/` over Tailscale
 and prints a comparison summary (per-host status, weights count, log excerpts).
+
+### Wait + gate (CI and scripted runs)
+
+`e2e/alexnet-deploy-fleet.sh` launches training **detached** and returns immediately.
+For scripted or CI runs that need to block until the fleet finishes and verify
+completion, use the gate wrapper:
+
+```bash
+# Blocks until every host's alexnet-training container exits (150 min default),
+# then verifies per-host completion evidence ("Training complete!" in podman
+# logs + non-empty weights dir). Exits non-zero if any host fails.
+bash e2e/alexnet-fleet-wait.sh
+
+# Shorter deadline, or wait-only (skip the completion gate)
+bash e2e/alexnet-fleet-wait.sh --timeout-minutes 90
+bash e2e/alexnet-fleet-wait.sh --no-gate
+```
+
+## CI: AlexNet mesh smoke workflow
+
+`.github/workflows/alexnet-mesh-smoke.yml` runs the full smoke pipeline from CI
+as a **manual-dispatch-only, gated** workflow:
+
+1. Checkout (submodules recursive) on a self-hosted runner
+2. Preflight (podman, tailscale, jq, submodule)
+3. `alexnet-deploy-fleet.sh` — build, distribute, launch
+4. `alexnet-fleet-wait.sh` — block until all hosts exit, then **gate** on
+   completion evidence; the job fails if any host lacks it
+5. `alexnet-collect-results.sh` — central collection + uploaded as an artifact
+6. Tear down containers on all hosts (unless `teardown` is unchecked)
+
+Dispatch inputs: `epochs` (default 10), `max_batches` (default 3), `fleet`
+(default `epimetheus apollo aeolus hephaestus` — **hermes is opt-in** until its
+preflight clears: `unprivileged_userns_clone=1` + SSH reachable from epimetheus,
+see Per-Host Notes), `skip_build`, and `teardown`.
+
+**Runner registration (one-time, on aeolus):** the workflow requires a
+self-hosted runner with the `self-hosted,mesh` labels — GitHub-hosted runners
+cannot reach the fleet. Register with:
+
+```bash
+# On aeolus (create a registration token via the repo Settings → Actions →
+# Runners page, or `gh api repos/HomericIntelligence/Odysseus/actions/runners/registration-token`)
+mkdir -p ~/actions-runner && cd ~/actions-runner
+curl -fsSL -o runner.tar.gz <latest-runner-linux-x64-url>
+tar xzf runner.tar.gz
+./config.sh --url https://github.com/HomericIntelligence/Odysseus \
+    --token <registration-token> --labels self-hosted,mesh
+./run.sh   # or install as a systemd user service (enable linger)
+```
+
+The runner account must satisfy the runbook prerequisites (rootless podman,
+tailscale, `jq`). Aeolus confirmed 2026-08-11: podman 4.9.3, tailscale,
+`jq`, `just`, podman.socket active — but **`loginctl enable-linger` must still
+be run** (the user-level systemd service that keeps the runner alive after
+logout requires it). The first fleet host registered a `mesh` runner on
+epimetheus while aeolus was offline — **decommission `epimetheus-mesh` once the
+aeolus runner is up** so job dispatch picks the intended host.
+
+**Chaos suite (`alexnet-mesh-chaos.yml`):** `.github/workflows/alexnet-mesh-chaos.yml`
+runs the crash-test suite `e2e/alexnet-mesh-chaos.sh` **manually via
+`workflow_dispatch` only** — same policy as the mesh smoke: it never auto-gates
+PRs or main. Dispatch it explicitly when a mesh change needs crash-testing.
+Default runs use the fast mode (offline-host tolerance, missing-image
+diagnostic, smoke-gate semantics, teardown idempotency — a minute or two, no
+training). The live cases (C4 clobber guard + C5 kill-mid-run against a real
+training container) are dispatched with `live: true`. Same `self-hosted,mesh`
+runner requirement; the two mesh workflows share a concurrency group so they
+never touch the `alexnet-training` container at the same time.
+
+Locally, the same suite is available as `just alexnet-mesh-chaos` (default mode) and
+`just alexnet-mesh-chaos-live` (live cases).
 
 ## Per-Host Notes
 
@@ -211,28 +313,55 @@ grep -E "model name|flags" /proc/cpuinfo | head -5
 ### hermes (Lunar Lake — new fleet member as of 2026-05-12)
 
 Intel Core Ultra 7 258V (Lunar Lake, late-2024 silicon), **15.4 GB** kernel-reported RAM
-(16 GB physical), 8 cores, 353 GB free disk.Podman 5.8.3 installed (epimetheus currently ships 5.8.1) but
-preflight probes on 2026-05-12 raised two soft concerns that need operator
-investigation before the first fleet smoke:
+(16 GB physical), 8 cores, 353 GB free disk. Podman 5.8.3 installed (epimetheus currently
+ships 5.8.1). Hermes is a **WSL2 host** (Linux 6.6.87.2-microsoft-standard-WSL2, per
+`docs/e2e-walkthrough-report.md`), so it must satisfy both the rootless-Podman chain
+**and** the WSL2 systemd chain (`[boot] systemd=true` in `/etc/wsl.conf` + linger).
 
-| Preflight check | Result | What to investigate |
-|-----------------|--------|---------------------|
-| `/proc/sys/kernel/unprivileged_userns_clone` (user-mode read) | `(unreadable)` | On some kernels the sysctl hides itself from unprivileged users when the value is `0`. Likely same kernel blocker as apollo. Verify with `sudo cat /proc/sys/kernel/unprivileged_userns_clone`. |
-| `podman info` | **FAILED** | Could not verify cgroups / graph driver. Likely same root cause as the sysctl above (rootless user-namespace clone disabled). If confirmed at `0`, deploy Phase 2 (`podman load`) will fail with `cannot clone` — same failure pattern as apollo. |
+**Status (checked 2026-08-11): hermes is OFFLINE on the tailnet** — last seen
+2026-08-07, no ping/SSH response from epimetheus. The 2026-05-12 preflight probes
+could not be re-run live. The pattern evidence below is from **apollo** (the documented
+same-blocker host), confirmed live on 2026-08-11:
+
+```
+$ cat /proc/sys/kernel/unprivileged_userns_clone
+0
+$ podman info
+cannot clone: Operation not permitted
+user namespaces are not enabled in /proc/sys/kernel/unprivileged_userns_clone
+```
+
+| Preflight check | Result (2026-05-12) | What to investigate |
+|-----------------|---------------------|---------------------|
+| `/proc/sys/kernel/unprivileged_userns_clone` (user-mode read) | `(unreadable)` | On some kernels the sysctl hides itself from unprivileged users when the value is `0`. Likely same kernel blocker as apollo (confirmed `0` above). Verify with `sudo cat /proc/sys/kernel/unprivileged_userns_clone`. |
+| `podman info` | **FAILED** | Could not verify cgroups / graph driver. Same root cause as the sysctl above (rootless user-namespace clone disabled). If confirmed at `0`, deploy Phase 2 (`podman load`) will fail with `cannot clone` — identical to apollo. |
+| SSH from epimetheus | **Not configured** (2026-08-11) | Hermes has **no SSH server in WSL2** — not in epimetheus `~/.ssh/config` or `known_hosts`. Fleet deploy uses `ssh <ip> <cmd>` for every remote host, so this is a **second, independent blocker**. Install `openssh-server` in WSL, start sshd, then `ssh-copy-id hermes` from epimetheus. |
 | Podman version | 5.8.3 | OK. |
 | Odyssey workspace (`research/Odyssey`) | Absent before 2026-05-12 onboarding | After meta-repo sync: `git submodule update --init --recursive`. |
 
-**If `kernel.unprivileged_userns_clone=0`**, hermes has the same blocker as apollo
-and the deploy will fail at image load. Two operator options:
+**Remediation (one-shot):** `e2e/hermes-fleet-preflight-fix.sh` — run **on hermes**
+(once it is back online and SSH-reachable):
 
-1. **One-shot workaround**: `sudo sysctl -w kernel.unprivileged_userns_clone=1`
-   (requires sudo + persistence across reboots via `/etc/sysctl.d/99-tailnet.conf`).
+```bash
+ssh hermes 'bash -s' < e2e/hermes-fleet-preflight-fix.sh
+```
+
+It probes and sets `kernel.unprivileged_userns_clone=1` (persisted via
+`/etc/sysctl.d/99-tailnet.conf`), verifies the WSL2 systemd/linger/socket chain,
+re-runs `podman info` (the preflight gate), runs a rootless `alpine` smoke container,
+and prints the ssh prerequisite steps.
+
+**If `kernel.unprivileged_userns_clone=0`**, hermes has the same blocker as apollo
+and the deploy will fail at image load. Operator options:
+
+1. **Run the remediation script above** — `sudo sysctl -w kernel.unprivileged_userns_clone=1`,
+   persisted across reboots via `/etc/sysctl.d/99-tailnet.conf`.
 2. **Skip hermes in the active FLEET** for the smoke run: `FLEET="epimetheus apollo
    aeolus hephaestus" bash e2e/alexnet-deploy-fleet.sh`. Keep hermes in the default
-   for documentation but explicitly exclude for the first run until preflight clears.
+   for documentation but explicitly exclude until both blockers (sysctl + SSH) clear.
 
-**If `kernel.unprivileged_userns_clone=1`**, hermes should work like epimetheus
-with no preflight remediation needed. `e2e/alexnet-train.sh`'s per-host CPU-flag
+**If `kernel.unprivileged_userns_clone=1`** (and SSH is reachable), hermes should work
+like epimetheus with no further remediation. `e2e/alexnet-train.sh`'s per-host CPU-flag
 block has only an `aeolus` exclusion; hermes (Lunar Lake) keeps the default empty
 `MOJO_TARGET_FLAGS`.
 
@@ -240,7 +369,7 @@ block has only an `aeolus` exclusion; hermes (Lunar Lake) keeps the default empt
 
 - [ ] **All hosts**: `just doctor --role worker` passes
 - [ ] **All hosts**: `podman --version` reports a rootless-mode install
-- [ ] **All hosts**: `~/alexnet-results/<hostname>/training.log` ends with "Training complete!"
+- [ ] **All hosts**: `podman logs alexnet-training` shows `Batch [1/3]`, `Average Loss`, `Test Accuracy:`, and ends with `Training complete!`; container `ExitCode=0` (ssh each remote host; `training.log` only carries the launch header — `podman logs` is the single source of truth)
 - [ ] **epimetheus**: Image built via `podman compose build odyssey-dev` (or `podman build` fallback)
 - [ ] **Apollo/aeolus/hephaestus**: Image received via `rsync` and `podman load -i` succeeded
 - [ ] **Apollo/aeolus/hephaestus**: Scripts rsync'd via `~/alexnet-fleet-scripts/` (deployed by Phase 2 of `alexnet-fleet-deploy`)
@@ -277,15 +406,17 @@ The script **does NOT delete** training results — delete those manually with
 
 ## Comparison Metrics to Capture
 
-After the fleet run completes, useful per-host comparisons from the training logs:
+After the fleet run completes, useful per-host comparisons. Training output is
+captured by each host's container log driver, so the metric commands read
+`podman logs` (run the `ssh "$host" "..."` form for remote hosts):
 
 | Metric | Where to find it |
 |--------|-----------------|
-| Epoch time (s) | `grep "Epoch \[" training.log` (parse the wall-clock between epochs) |
-| Final loss | `grep "Average Loss" training.log \| tail -1` |
-| Final test accuracy | `grep "Test Accuracy:" training.log \| tail -1` |
+| Epoch time (s) | `podman logs alexnet-training \| grep "Epoch \["` (parse the wall-clock between epochs) |
+| Final loss | `podman logs alexnet-training \| grep "Average Loss" \| tail -1` |
+| Final test accuracy | `podman logs alexnet-training \| grep "Test Accuracy:" \| tail -1` |
 | Container memory peak | `podman stats --no-stream alexnet-training` while running |
-| Mojo version | `podman exec alexnet-training pixi run mojo --version` |
+| Mojo version | `podman exec alexnet-training mojo --version` |
 | CPU utilization | `grep "model name" /proc/cpuinfo` + `nproc` |
 
 ## Related Skills
@@ -309,9 +440,11 @@ This runbook does NOT cover:
 2. **GPU acceleration** — all training is CPU-only. Adding CUDA/Metal would require
    image build changes plus per-host driver setup (Tailscale works fine for GPU
    hosts; the constraint is container → device passthrough).
-3. **Live result streaming** — training logs are written to disk and rsync'd at the
-   end. A NATS-based streaming path (publish `hi.research.alexnet.<host>.progress`
-   per batch) would enable real-time dashboards via Argus.
+3. **Live result streaming** — training output is captured by each host's
+   container log driver (`podman logs alexnet-training`); only the weights and
+   the launch-header `training.log` are rsync'd back at the end. A NATS-based
+   streaming path (publish `hi.research.alexnet.<host>.progress` per batch)
+   would enable real-time dashboards via Argus.
 4. **Cross-host dataset sync** — CIFAR-10 (~170MB) is downloaded per host if absent.
    Pre-staging to a Tailscale-mounted NAS would skip the per-host download.
 

--- a/e2e/alexnet-collect-results.sh
+++ b/e2e/alexnet-collect-results.sh
@@ -123,6 +123,32 @@ if (( ${#MISSING[@]} > 0 )); then
     done
 fi
 echo ""
+# ── Pull final training markers from a host's container log ──
+# Full training output streams to the container log driver (podman logs), NOT
+# to training.log (which carries only the launch header). Best-effort: the
+# training container may already have been torn down, and rootless podman over
+# a non-interactive ssh may not resolve its runtime dir.
+# Rootless podman over a non-interactive ssh needs the user runtime dir — same
+# preamble as e2e/alexnet-fleet-wait.sh. Single-quoted so `$(id -u)` stays
+# literal here and is evaluated by the REMOTE shell.
+# shellcheck disable=SC2016
+REMOTE_PODMAN_PREFIX='export XDG_RUNTIME_DIR=/run/user/$(id -u) DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/$(id -u)/bus'
+
+extract_podman_markers() {
+    # No `|| true` here (repo no-silent-failures rule): "no markers found" or an
+    # unreachable host is an explicit non-zero exit the caller handles in an
+    # `if` condition. See docs/runbooks/no-silent-failures.md Bucket D.
+    local ip="$1"
+    local pat="Training complete|Average Loss|Test Accuracy"
+    if [[ "$ip" == "localhost" ]]; then
+        podman logs alexnet-training 2>/dev/null | grep -E "$pat" | tail -3
+    else
+        timeout 10 ssh -o ConnectTimeout=5 "$ip" \
+            "$REMOTE_PODMAN_PREFIX; podman logs alexnet-training 2>/dev/null | grep -E '$pat' | tail -3" \
+            2>/dev/null
+    fi
+}
+
 for host_dir in "$CENTRAL_DIR"/*/; do
     [[ -d "$host_dir" ]] || continue
     host=$(basename "$host_dir")
@@ -130,14 +156,23 @@ for host_dir in "$CENTRAL_DIR"/*/; do
 
     echo "── $host ──"
     if [[ -f "$log" ]]; then
-        # Pull out the most informative status line. Explicit if-guard (the
-        # no-silent-failures rule): grep exits 1 when no marker matches, and
-        # the if-condition keeps set -e from aborting on that expected miss.
+        # Launch-header markers (rare; some configs also log the header summary).
+        # Explicit if-guard per no-silent-failures.md Bucket D: a grep with no
+        # matches exits 1, which is the intended "no markers" branch, not a
+        # swallowed failure.
         if status=$(grep -E "Training complete!|Average Loss:|Test Accuracy:|Completed:" "$log" | tail -3); then
             echo "$status" | sed 's/^/  /'
         else
-            echo "  (log present but no completion markers)"
-            tail -3 "$log" | sed 's/^/  /'
+            # training.log holds only the launch header — real markers live in
+            # the container's log driver on the host. Pull them best-effort.
+            if markers=$(extract_podman_markers "$ip"); then
+                echo "$markers" | sed 's/^/  /'
+            elif [[ -d "$host_dir/alexnet_weights" ]]; then
+                echo "  (weights present — run completed; container log no longer available)"
+            else
+                echo "  (no completion markers — training incomplete or container torn down)"
+                tail -3 "$log" | sed 's/^/  /'
+            fi
         fi
         if [[ -d "$host_dir/alexnet_weights" ]]; then
             n=$(ls "$host_dir/alexnet_weights" 2>/dev/null | wc -l)
@@ -151,4 +186,5 @@ done
 
 echo "Per-host results inspection:"
 echo "  ls -la $CENTRAL_DIR/<hostname>/"
-echo "  cat $CENTRAL_DIR/<hostname>/training.log"
+echo "  cat $CENTRAL_DIR/<hostname>/training.log   # launch header / config only"
+echo "  podman logs alexnet-training               # full training output (on each host)"

--- a/e2e/alexnet-deploy-fleet.sh
+++ b/e2e/alexnet-deploy-fleet.sh
@@ -18,6 +18,7 @@
 #   FLEET            — space-separated host list (default: epimetheus apollo aeolus hephaestus)
 #   EPOCHS           — epochs per host (default: 100)
 #   BATCH_SIZE       — batch size per host (default: 128)
+#   MAX_BATCHES      — cap batches per epoch (0 = full dataset). Smoke test: 3.
 #   SKIP_BUILD=1     — use existing odyssey:dev image, don't rebuild or redistribute
 #   SKIP_DISTRIBUTE=1— don't rsync to remote hosts (image already loaded there)
 #   SKIP_LAUNCH=1    — build/distribute only, don't launch training
@@ -32,10 +33,17 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ODYSSEUS_ROOT="$(dirname "$SCRIPT_DIR")"
 LOCAL_HOST=$(hostname)
 
+# Bounded ssh for every remote operation: an offline/unreachable host must not
+# hang distribution or launch. `timeout` caps the whole ssh session and
+# ConnectTimeout fails fast when the host does not answer SYN. Same guard as
+# e2e/alexnet-fleet-wait.sh (SSH_BASE) and e2e/alexnet-fleet-teardown.sh.
+SSH_BASE=(timeout 15 ssh -o ConnectTimeout=5 -o BatchMode=yes)
+
 # ── Configuration ──
 FLEET="${FLEET:-epimetheus apollo aeolus hephaestus hermes}"
 EPOCHS="${EPOCHS:-100}"
 BATCH_SIZE="${BATCH_SIZE:-128}"
+MAX_BATCHES="${MAX_BATCHES:-0}"
 IMAGE_NAME="${IMAGE_NAME:-odyssey:dev}"
 SKIP_BUILD="${SKIP_BUILD:-0}"
 SKIP_DISTRIBUTE="${SKIP_DISTRIBUTE:-0}"
@@ -88,6 +96,7 @@ echo "Fleet:           $FLEET"
 echo "Remote targets:  ${REMOTE_LIST:-(none)}"
 echo "Image:           $IMAGE_NAME"
 echo "Epochs/Batch:    $EPOCHS / $BATCH_SIZE"
+echo "Max batches:     $MAX_BATCHES $([[ $MAX_BATCHES -gt 0 ]] && echo '(smoke)' || echo '(full dataset)')"
 echo ""
 
 # ── Phase 1: Build the Odyssey container image on local ──
@@ -149,7 +158,11 @@ if [[ "$SKIP_DISTRIBUTE" != "1" && -n "$REMOTE_LIST" ]]; then
         for host in $REMOTE_LIST; do
             ip="${REMOTE_HOSTS[$host]}"
             echo "  → $host ($ip): rsync odyssey-dev.tar"
-            rsync -az --info=progress2 /tmp/odyssey-dev.tar "${ip}:~/odyssey-dev.tar" &
+            # --timeout: rsync's own I/O stall guard; -e: ssh ConnectTimeout so
+            # an offline host cannot hang the rsync (bounded like the ssh calls).
+            rsync -az --info=progress2 --timeout=60 \
+                -e 'ssh -o ConnectTimeout=5 -o BatchMode=yes' \
+                /tmp/odyssey-dev.tar "${ip}:~/odyssey-dev.tar" &
         done
         wait
         echo "  image rsync complete."
@@ -160,13 +173,14 @@ if [[ "$SKIP_DISTRIBUTE" != "1" && -n "$REMOTE_LIST" ]]; then
         echo "  rsync launch scripts to ~/alexnet-fleet-scripts/ on each host"
         for host in $REMOTE_LIST; do
             ip="${REMOTE_HOSTS[$host]}"
-            ssh "$ip" "mkdir -p ~/alexnet-fleet-scripts" &
+            "${SSH_BASE[@]}" "$ip" "mkdir -p ~/alexnet-fleet-scripts" &
         done
         wait
         # rsync doesn't support a host list as a dest; do per-host instead.
         for host in $REMOTE_LIST; do
             ip="${REMOTE_HOSTS[$host]}"
-            rsync -az --info=progress2 \
+            rsync -az --info=progress2 --timeout=60 \
+                -e 'ssh -o ConnectTimeout=5 -o BatchMode=yes' \
                 "$SCRIPT_DIR/alexnet-train.sh" \
                 "$SCRIPT_DIR/alexnet-collect-results.sh" \
                 "$SCRIPT_DIR/alexnet-deploy-fleet.sh" \
@@ -175,7 +189,7 @@ if [[ "$SKIP_DISTRIBUTE" != "1" && -n "$REMOTE_LIST" ]]; then
         wait
         for host in $REMOTE_LIST; do
             ip="${REMOTE_HOSTS[$host]}"
-            ssh "$ip" "chmod +x ~/alexnet-fleet-scripts/*.sh && ls -la ~/alexnet-fleet-scripts/" &
+            "${SSH_BASE[@]}" "$ip" "chmod +x ~/alexnet-fleet-scripts/*.sh && ls -la ~/alexnet-fleet-scripts/" &
         done
         wait
         echo "  script rsync + chmod complete."
@@ -184,7 +198,7 @@ if [[ "$SKIP_DISTRIBUTE" != "1" && -n "$REMOTE_LIST" ]]; then
         for host in $REMOTE_LIST; do
             ip="${REMOTE_HOSTS[$host]}"
             echo "  → $host: podman load"
-            ssh "$ip" "podman load -i ~/odyssey-dev.tar && rm ~/odyssey-dev.tar && podman images $IMAGE_NAME --format '{{.Repository}}:{{.Tag}}'" &
+            "${SSH_BASE[@]}" "$ip" "podman load -i ~/odyssey-dev.tar && rm ~/odyssey-dev.tar && podman images $IMAGE_NAME --format '{{.Repository}}:{{.Tag}}'" &
         done
         wait
     fi
@@ -207,10 +221,10 @@ if [[ "$SKIP_LAUNCH" != "1" ]]; then
         echo "  DRY_RUN=1: would launch training on:"
         for host in "${_hosts[@]}"; do
             if [[ "$host" == "$LOCAL_HOST" ]]; then
-                echo "    local:  EPOCHS='$EPOCHS' BATCH_SIZE='$BATCH_SIZE' bash $SCRIPT_DIR/alexnet-train.sh"
+                echo "    local:  EPOCHS='$EPOCHS' BATCH_SIZE='$BATCH_SIZE' MAX_BATCHES='$MAX_BATCHES' bash $SCRIPT_DIR/alexnet-train.sh"
             else
                 ip="${REMOTE_HOSTS[$host]:-<unresolved>}"
-                echo "    ssh $ip:  EPOCHS='$EPOCHS' BATCH_SIZE='$BATCH_SIZE' bash ~/alexnet-fleet-scripts/alexnet-train.sh"
+                echo "    ssh $ip:  EPOCHS='$EPOCHS' BATCH_SIZE='$BATCH_SIZE' MAX_BATCHES='$MAX_BATCHES' bash ~/alexnet-fleet-scripts/alexnet-train.sh"
             fi
         done
     else
@@ -220,7 +234,7 @@ if [[ "$SKIP_LAUNCH" != "1" ]]; then
         for host in "${_hosts[@]}"; do
             echo "  → $host"
             if [[ "$host" == "$LOCAL_HOST" ]]; then
-                EPOCHS="$EPOCHS" BATCH_SIZE="$BATCH_SIZE" \
+                EPOCHS="$EPOCHS" BATCH_SIZE="$BATCH_SIZE" MAX_BATCHES="$MAX_BATCHES" \
                     bash "$SCRIPT_DIR/alexnet-train.sh" &
             else
                 ip="${REMOTE_HOSTS[$host]:-}"
@@ -233,8 +247,8 @@ if [[ "$SKIP_LAUNCH" != "1" ]]; then
                 # double-quoted string interpolates EPOCHS/BATCH_SIZE into the
                 # remote command's prefix. Net effect on remote: clean
                 # `EPOCHS=N BATCH_SIZE=M bash ~/alexnet-fleet-scripts/...`.
-                EPOCHS="$EPOCHS" BATCH_SIZE="$BATCH_SIZE" \
-                    ssh "$ip" "EPOCHS='$EPOCHS' BATCH_SIZE='$BATCH_SIZE' bash ~/alexnet-fleet-scripts/alexnet-train.sh" &
+                EPOCHS="$EPOCHS" BATCH_SIZE="$BATCH_SIZE" MAX_BATCHES="$MAX_BATCHES" \
+                    "${SSH_BASE[@]}" "$ip" "EPOCHS='$EPOCHS' BATCH_SIZE='$BATCH_SIZE' MAX_BATCHES='$MAX_BATCHES' bash ~/alexnet-fleet-scripts/alexnet-train.sh" &
             fi
         done
         wait

--- a/e2e/alexnet-fleet-teardown.sh
+++ b/e2e/alexnet-fleet-teardown.sh
@@ -31,6 +31,12 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 FLEET="${FLEET:-epimetheus apollo aeolus hephaestus hermes}"
 LOCAL_HOST=$(hostname)
 
+# Bounded ssh for every remote probe: an offline/unreachable host (e.g. hermes
+# on the tailnet) must not hang teardown. `timeout` caps the whole ssh session
+# and ConnectTimeout fails fast when the host does not answer SYN.
+# Matches the guard used by e2e/alexnet-fleet-wait.sh (SSH_BASE).
+SSH_BASE=(timeout 15 ssh -o ConnectTimeout=5 -o BatchMode=yes)
+
 # Parse FLEET into a glob-safe bash array. Avoid `for host in $FLEET` which would
 # pathname-expand if FLEET accidentally contained a pattern like 'epimeth*'.
 IFS=' ' read -ra FLEET_ARR <<< "$FLEET"
@@ -94,7 +100,9 @@ for host in "${FLEET_ARR[@]}"; do
     else
         echo "  → $host ($ip)"
         # Idempotent: podman rm -f on a missing container exits 1; tolerate that.
-        ssh "$ip" "podman rm -f alexnet-training 2>/dev/null && echo '[ok] removed' || echo '[skip] no container'" &
+        # Bounded ssh: an unreachable host surfaces as a WARN here instead of a
+        # hang (see SSH_BASE above).
+        "${SSH_BASE[@]}" "$ip" "podman rm -f alexnet-training 2>/dev/null && echo '[ok] removed' || echo '[skip] no container'" &
     fi
 done
 wait
@@ -106,7 +114,7 @@ if [[ "${CLEAN_SCRIPTS:-0}" == "1" ]]; then
     for host in "${FLEET_ARR[@]}"; do
         ip="${HOST_IPS[$host]:-}"
         [[ -z "$ip" || "$ip" == "localhost" ]] && continue
-        ssh "$ip" "rm -rf ~/alexnet-fleet-scripts && echo '[ok] $host: scripts removed'" &
+        "${SSH_BASE[@]}" "$ip" "rm -rf ~/alexnet-fleet-scripts && echo '[ok] $host: scripts removed'" &
     done
     wait
 fi

--- a/e2e/alexnet-fleet-wait.sh
+++ b/e2e/alexnet-fleet-wait.sh
@@ -1,0 +1,263 @@
+#!/usr/bin/env bash
+# e2e/alexnet-fleet-wait.sh — Wait for AlexNet fleet training to finish, then gate
+#
+# e2e/alexnet-deploy-fleet.sh launches training detached on every fleet host and
+# returns immediately. This script is the "gated" counterpart: it polls every
+# host's `alexnet-training` container until all have exited (or a deadline
+# passes), then — unless --no-gate — verifies completion evidence per host:
+#   - `podman logs alexnet-training` contains "Training complete!"
+#   - ~/alexnet-results/<host>/alexnet_weights/ is non-empty
+# and exits non-zero if any host fails, so a CI job calling this fails the gate.
+#
+# Smoke runs (MAX_BATCHES>0) intentionally save NO weights (run_train.mojo
+# #5551) — pass --smoke to relax the weights requirement to a non-fatal note;
+# the completion marker remains the gate. Full 100-epoch runs stay strict.
+#
+# Usage:
+#   bash e2e/alexnet-fleet-wait.sh                # wait 150 min, then gate (strict)
+#   --timeout-minutes 90                          # shorter deadline
+#   --no-gate                                     # wait only, no completion check
+#   --smoke                                       # smoke run: marker-only gate
+#   FLEET="epimetheus apollo" bash e2e/alexnet-fleet-wait.sh
+#
+# Optional env:
+#   FLEET           — space-separated host list (default: same 5 as deploy-fleet)
+#   RESULTS_DIR     — per-host results root for the weights check (default: alexnet-results)
+#   POLL_INTERVAL   — seconds between polls (default: 60)
+#
+# Exit codes:
+#   0 — all hosts exited AND (gate on) all hosts have completion evidence
+#   1 — deadline passed with hosts still running, or gate evidence missing
+#   2 — usage/environment error (bad flag, missing podman, unresolvable host)
+#
+# See docs/runbooks/alexnet-mesh-fleet.md for the full fleet deployment plan.
+
+set -euo pipefail
+
+# ── Configuration ──
+FLEET="${FLEET:-epimetheus apollo aeolus hephaestus hermes}"
+RESULTS_DIR="${RESULTS_DIR:-alexnet-results}"
+POLL_INTERVAL="${POLL_INTERVAL:-60}"
+TIMEOUT_MINUTES=150
+GATE=1
+# Weights are REQUIRED by default (full 100-epoch runs). Smoke runs
+# (MAX_BATCHES>0) intentionally save NO weights (run_train.mojo #5551) — the
+# completion marker is the correct smoke gate, so --smoke relaxes the weights
+# requirement to a non-fatal note.
+REQUIRE_WEIGHTS=1
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --timeout-minutes)
+            TIMEOUT_MINUTES="$2"
+            shift 2
+            ;;
+        --no-gate)
+            GATE=0
+            shift
+            ;;
+        --smoke)
+            REQUIRE_WEIGHTS=0
+            shift
+            ;;
+        *)
+            echo "ERROR: unknown flag '$1' (supported: --timeout-minutes N, --no-gate, --smoke)" >&2
+            exit 2
+            ;;
+    esac
+done
+
+if ! command -v podman >/dev/null 2>&1; then
+    echo "ERROR: podman not found on this host — this script must run on a fleet host." >&2
+    exit 2
+fi
+
+LOCAL_HOST=$(hostname)
+
+# Parse FLEET into a glob-safe array (same pattern as deploy/collect scripts —
+# `for host in $FLEET` would pathname-expand if FLEET ever contained a glob).
+IFS=' ' read -ra _hosts <<< "$FLEET"
+
+# ── Resolve Tailscale IPs (same pattern as deploy/collect scripts) ──
+declare -A HOST_IPS
+for host in "${_hosts[@]}"; do
+    if [[ "$host" == "$LOCAL_HOST" || "$host" == "localhost" ]]; then
+        HOST_IPS[$host]="localhost"
+    else
+        HOST_IPS[$host]=$(tailscale status --json 2>/dev/null \
+            | jq -r --arg h "$host" \
+                '.Peer // {} | to_entries[] | .value | select(.HostName == $h) | .TailscaleIPs[0]' \
+            2>/dev/null || echo "")
+    fi
+done
+
+# ── Remote podman over rootless ssh: same env exports doctor.sh step 8 needs ──
+# Single-quoted literal keeps `$(id -u)` unexpanded here; it is evaluated by
+# the REMOTE shell after ssh (expanded variables are never re-scanned locally).
+# shellcheck disable=SC2016
+REMOTE_PODMAN_PREFIX='export XDG_RUNTIME_DIR=/run/user/$(id -u) DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/$(id -u)/bus'
+
+# SSH_CONNECT_OPTS guards every remote probe so a wedged remote host (e.g. a
+# stuck podman) cannot hang the poll or gate step indefinitely.
+SSH_BASE=(timeout 15 ssh -o ConnectTimeout=5 -o BatchMode=yes)
+
+# ── Per-host helpers ──
+# state <ip> → "exited <code>" | "running" | "created" | "missing" | "ssh-fail"
+state() {
+    local ip="$1"
+    if [[ "$ip" == "localhost" ]]; then
+        podman inspect alexnet-training --format '{{.State.Status}} {{.State.ExitCode}}' 2>/dev/null \
+            || echo "missing"
+    else
+        "${SSH_BASE[@]}" "$ip" "
+            $REMOTE_PODMAN_PREFIX
+            podman inspect alexnet-training --format '{{.State.Status}} {{.State.ExitCode}}' 2>/dev/null || echo missing
+        " 2>/dev/null || echo "ssh-fail"
+    fi
+}
+
+# has_marker <ip> → 0 if container log contains "Training complete!", non-zero otherwise
+# Retries: `podman logs` on an exited rootless container is flaky (observed
+# missing the final lines ~1/10 reads in crash testing) — a single read could
+# false-fail the gate. Retry up to 3x with a 2s pause before declaring absence.
+has_marker() {
+    local ip="$1" attempt=0
+    while [[ "$attempt" -lt 3 ]]; do
+        if [[ "$ip" == "localhost" ]]; then
+            if podman logs alexnet-training 2>/dev/null | grep -q "Training complete!"; then
+                return 0
+            fi
+        else
+            if "${SSH_BASE[@]}" "$ip" "
+                $REMOTE_PODMAN_PREFIX
+                podman logs alexnet-training 2>/dev/null | grep -q 'Training complete!'
+            " 2>/dev/null; then
+                return 0
+            fi
+        fi
+        attempt=$((attempt + 1))
+        [[ "$attempt" -lt 3 ]] && sleep 2
+    done
+    return 1
+}
+
+# weights_count <ip> <host> → number of files in the host's weights dir
+weights_count() {
+    local ip="$1" host="$2"
+    if [[ "$ip" == "localhost" ]]; then
+        # Guard BEFORE find: with a missing weights dir (the normal smoke case),
+        # `find missing-dir | wc -l` fails under pipefail and would abort the
+        # whole gate via the set -e assignment. Report 0 instead.
+        if [[ -d "$HOME/$RESULTS_DIR/$host/alexnet_weights" ]]; then
+            find "$HOME/$RESULTS_DIR/$host/alexnet_weights" -type f 2>/dev/null | wc -l
+        else
+            echo 0
+        fi
+    else
+        "${SSH_BASE[@]}" "$ip" "
+            $REMOTE_PODMAN_PREFIX
+            find ~/$RESULTS_DIR/$host/alexnet_weights -type f 2>/dev/null | wc -l
+        " 2>/dev/null || echo 0
+    fi
+}
+
+# ── Resolve once, fail fast on unresolvable hosts ──
+echo "=== AlexNet fleet wait + gate ==="
+echo "Fleet:       $FLEET"
+echo "Timeout:     ${TIMEOUT_MINUTES} min (poll every ${POLL_INTERVAL}s)"
+if [[ "$GATE" -eq 1 ]]; then
+    echo "Gate:        on — require Training complete! $([[ $REQUIRE_WEIGHTS -eq 1 ]] && echo '+ weights' || echo '(weights relaxed for smoke: --smoke)')  [full run: strict | smoke: --smoke]"
+else
+    echo "Gate:        off — wait only"
+fi
+echo ""
+RESOLVE_FAIL=0
+for host in "${_hosts[@]}"; do
+    if [[ -z "${HOST_IPS[$host]:-}" ]]; then
+        echo "ERROR: cannot resolve Tailscale IP for '$host'" >&2
+        RESOLVE_FAIL=1
+    fi
+done
+if [[ "$RESOLVE_FAIL" -eq 1 ]]; then
+    exit 2
+fi
+
+# ── Poll until all containers exit or deadline ──
+deadline=$(( $(date +%s) + TIMEOUT_MINUTES * 60 ))
+while :; do
+    now=$(date +%s)
+    remaining=$(( deadline - now ))
+    all_done=1
+    line="[$(date -u +%H:%M:%SZ)]"
+    for host in "${_hosts[@]}"; do
+        st=$(state "${HOST_IPS[$host]}")
+        line="$line  $host=$st"
+        if [[ "$st" != "exited"* ]]; then
+            all_done=0
+        fi
+    done
+    echo "$line"
+    if [[ "$all_done" -eq 1 ]]; then
+        echo ""
+        echo "All fleet training containers exited."
+        # Settle: a container that just exited may not have flushed its log to
+        # the on-disk driver yet — probing `podman logs` immediately can miss
+        # the final lines (observed in crash testing). Give the driver a moment
+        # before the gate reads markers/weights.
+        echo "Settling 5s for container log flush before gating..."
+        sleep 5
+        break
+    fi
+    if (( remaining <= 0 )); then
+        echo "" >&2
+        echo "ERROR: deadline (${TIMEOUT_MINUTES} min) passed with hosts still not exited:" >&2
+        for host in "${_hosts[@]}"; do
+            echo "  $host: $(state "${HOST_IPS[$host]}")" >&2
+        done
+        echo "  Inspect per host: podman logs alexnet-training" >&2
+        exit 1
+    fi
+    sleep "$POLL_INTERVAL"
+done
+
+# ── Gate: per-host completion evidence ──
+if [[ "$GATE" -eq 1 ]]; then
+    echo ""
+    echo "=== Gate: verifying completion evidence per host ==="
+    FAILURES=0
+    for host in "${_hosts[@]}"; do
+        ip="${HOST_IPS[$host]}"
+        echo "── $host ──"
+        marker=0 weights=0
+        if has_marker "$ip"; then
+            marker=1
+            echo "  [ok] Training complete! marker found (podman logs)"
+        else
+            echo "  [FAIL] no 'Training complete!' marker in podman logs"
+        fi
+        weights=$(weights_count "$ip" "$host")
+        if [[ "$weights" -gt 0 ]]; then
+            echo "  [ok] weights: $weights files"
+        elif [[ "$REQUIRE_WEIGHTS" -eq 1 ]]; then
+            echo "  [FAIL] weights dir empty or missing (required — add --smoke to relax)"
+        else
+            echo "  [note] no weights — expected for smoke mode (run_train.mojo #5551); marker above is the gate"
+        fi
+        if [[ "$marker" -ne 1 ]]; then
+            FAILURES=$((FAILURES + 1))
+        elif [[ "$REQUIRE_WEIGHTS" -eq 1 && "$weights" -eq 0 ]]; then
+            FAILURES=$((FAILURES + 1))
+        fi
+    done
+    echo ""
+    if [[ "$FAILURES" -gt 0 ]]; then
+        echo "GATE FAILED: $FAILURES host(s) missing completion evidence." >&2
+        echo "  Full output per host: podman logs alexnet-training (ssh for remotes)" >&2
+        exit 1
+    fi
+    if [[ "$REQUIRE_WEIGHTS" -eq 1 ]]; then
+        echo "GATE PASSED: all hosts completed training with weights."
+    else
+        echo "GATE PASSED: all hosts completed training (smoke gate — marker only, --smoke)."
+    fi
+fi

--- a/e2e/alexnet-mesh-chaos.sh
+++ b/e2e/alexnet-mesh-chaos.sh
@@ -1,0 +1,367 @@
+#!/usr/bin/env bash
+# e2e/alexnet-mesh-chaos.sh — Chaos/hardening tests for the AlexNet mesh pipeline
+#
+# Deliberately crashes the fleet scripts (deploy / wait / collect / teardown /
+# train) and asserts they fail FAST + CLEANLY — no hangs, clear diagnostics,
+# correct exit codes — then verifies recovery is possible. The intent is to
+# harden the mesh by breaking it under test, per the repo's chaos convention
+# (e2e/tests/chaos/*), but self-contained: it does NOT depend on the
+# NATS/Agamemnon stack or e2e/lib/common.sh.
+#
+# Cases:
+#   C1 offline-host tolerance: teardown must NOT hang when an offline host
+#      (hermes) is in FLEET — completes within a bounded time.
+#   C2 unresolvable-host tolerance: deploy must warn + skip, never hang.
+#   C3 missing-image: train must fail fast (rc 1) with a clear message.
+#   C4 [CHAOS_LIVE=1] clobber guard: train must REFUSE to clobber a running
+#      container (rc 1) instead of silently destroying an in-flight job.
+#   C5 [CHAOS_LIVE=1] kill-mid-run: gate must detect a killed container
+#      (non-zero exit) and fail with a diagnostic.
+#   C6 smoke-gate: wait+gate --smoke must PASS a completed smoke run (marker
+#      present; smoke mode intentionally saves no weights — run_train.mojo
+#      #5551) and the strict default must FAIL the same run (weights missing).
+#   C7 teardown idempotency: teardown with no container exits 0 (skip).
+#
+# Usage:
+#   bash e2e/alexnet-mesh-chaos.sh              # offline-safety cases only
+#   CHAOS_LIVE=1 bash e2e/alexnet-mesh-chaos.sh # + live container cases
+#   FLEET="epimetheus apollo" bash e2e/alexnet-mesh-chaos.sh  # limit hosts
+#
+# Optional env:
+#   FLEET          — hosts to exercise (default: epimetheus apollo aeolus
+#                    hephaestus hermes — same default as the fleet scripts)
+#   CHAOS_LIVE=1   — enable C4/C5 (launch/kill a real training container)
+#   CHAOS_TIMEOUT  — per-case kill guard in seconds (default: 45)
+#
+# Exit codes:
+#   0 — all enabled cases passed
+#   1 — one or more cases failed (details printed per case)
+#   2 — usage/environment error (missing podman, no image tar, etc.)
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# Per-invocation scratch file: parallel suite runs must not collide.
+CHAOS_OUT="/tmp/mesh-chaos-$$.out"
+trap 'rm -f "$CHAOS_OUT"' EXIT
+FLEET="${FLEET:-epimetheus apollo aeolus hephaestus hermes}"
+LOCAL_HOST=$(hostname)
+CHAOS_TIMEOUT="${CHAOS_TIMEOUT:-45}"
+LIVE=0
+[[ "${CHAOS_LIVE:-0}" == "1" ]] && LIVE=1
+
+# ── Result helpers (self-contained: no e2e/lib dependency) ──
+PASS=0
+FAIL=0
+declare -a FAILED_CASES=()
+
+info()  { printf '\n=== %s ===\n' "$*"; }
+pass()  { PASS=$((PASS + 1)); printf '  [PASS] %s\n' "$*"; }
+fail()  { FAIL=$((FAIL + 1)); FAILED_CASES+=("$*"); printf '  [FAIL] %s\n' "$*" >&2; }
+
+# run_bounded <label> <timeout-s> <cmd...> — run a command under `timeout`;
+# rc 124 proves a hang, rc 0 success, other rc is the command's own exit.
+run_bounded() {
+    # NOTE: never let the wrapped command's non-zero exit abort this suite
+    # under `set -euo pipefail` — capture the rc with `|| rc=$?` instead.
+    local label="$1" to="$2"
+    shift 2
+    local rc=0
+    timeout "$to" "$@" >"$CHAOS_OUT" 2>&1 || rc=$?
+    if [[ "$rc" -eq 124 ]]; then
+        fail "$label: HUNG (killed after ${to}s)"
+    elif [[ "$rc" -eq 0 ]]; then
+        pass "$label: completed cleanly"
+    else
+        pass "$label: failed fast with rc=$rc (expected non-zero)"
+    fi
+    return 0
+}
+
+echo "=== AlexNet Mesh Chaos Suite ==="
+echo "Fleet:            $FLEET"
+echo "Local host:       $LOCAL_HOST"
+echo "CHAOS_LIVE:       $LIVE"
+echo "Per-case timeout: ${CHAOS_TIMEOUT}s"
+echo ""
+
+# ── Prerequisites ──
+if ! command -v podman >/dev/null 2>&1; then
+    echo "ERROR: podman not found — this suite must run on a fleet host." >&2
+    exit 2
+fi
+if ! command -v tailscale >/dev/null 2>&1; then
+    echo "ERROR: tailscale CLI not found — required to resolve fleet IPs." >&2
+    exit 2
+fi
+
+# ── C1: offline-host tolerance (teardown must not hang) ────────────────────
+info "C1: teardown with an offline host in FLEET must not hang"
+# hermes is the documented offline host (runbook); if it is reachable, this
+# case still exercises the bounded-ssh behavior (it will simply run).
+if tailscale status --json 2>/dev/null | python3 -c "
+import json, sys
+d = json.load(sys.stdin)
+hermes = [dev for name, dev in d.get('Peer', {}).items() if dev.get('HostName') == 'hermes']
+print('offline' if hermes and not hermes[0].get('Online') else 'online-or-absent')
+" 2>/dev/null | grep -q offline; then
+    echo "  (hermes offline — this is the real-world crash case)"
+else
+    echo "  (hermes online or absent — exercising normal-path bounded ssh)"
+fi
+run_bounded "C1 teardown FLEET='$LOCAL_HOST hermes'" "$CHAOS_TIMEOUT" \
+    env FLEET="$LOCAL_HOST hermes" FORCE=1 bash "$SCRIPT_DIR/alexnet-fleet-teardown.sh"
+echo "  teardown output (tail):"
+tail -4 "$CHAOS_OUT" | sed 's/^/    /'
+
+# ── C2: unresolvable-host tolerance (deploy must warn + skip, never hang) ──
+info "C2: deploy with an unresolvable host must warn + skip, never hang"
+run_bounded "C2 deploy FLEET='$LOCAL_HOST no-such-host-xyz'" "$CHAOS_TIMEOUT" \
+    env FLEET="$LOCAL_HOST no-such-host-xyz" SKIP_BUILD=1 SKIP_DISTRIBUTE=1 SKIP_LAUNCH=1 \
+    bash "$SCRIPT_DIR/alexnet-deploy-fleet.sh"
+echo "  deploy output (tail):"
+tail -4 "$CHAOS_OUT" | sed 's/^/    /'
+
+# ── C3: missing image must fail fast ───────────────────────────────────────
+info "C3: train with a missing image must fail fast with a clear message"
+run_bounded "C3 train IMAGE_NAME=odyssey:nonexistent" "$CHAOS_TIMEOUT" \
+    env IMAGE_NAME="odyssey:nonexistent" MAX_BATCHES=3 bash "$SCRIPT_DIR/alexnet-train.sh"
+echo "  train output (tail):"
+tail -4 "$CHAOS_OUT" | sed 's/^/    /'
+if grep -q "not loaded" "$CHAOS_OUT"; then
+    pass "C3: clear 'image not loaded' diagnostic present"
+else
+    fail "C3: missing clear 'image not loaded' diagnostic"
+fi
+
+# ── C4 [LIVE]: clobber guard must refuse to destroy a running container ────
+if [[ "$LIVE" -eq 1 ]]; then
+    info "C4 [LIVE]: train must REFUSE to clobber a running container"
+    # Seed a running container with a long sleep so the guard has something
+    # to protect.
+    if podman container exists alexnet-training 2>/dev/null; then
+        echo "  (stale alexnet-training container exists — removing for a clean C4 seed)" >&2
+        rm_rc=0
+        podman rm -f alexnet-training >/dev/null 2>&1 || rm_rc=$?
+        if [[ "$rm_rc" -ne 0 ]]; then
+            echo "  (could not remove stale container — skipping C4)" >&2
+        fi
+    fi
+    if ! podman run -d --name alexnet-training --userns=keep-id \
+        localhost/odyssey:dev sleep 600 >"$CHAOS_OUT" 2>&1; then
+        echo "  (image localhost/odyssey:dev unavailable or seed failed — skipping C4)" >&2
+    else
+        run_bounded "C4 train while container RUNNING" "$CHAOS_TIMEOUT" \
+            env IMAGE_NAME="localhost/odyssey:dev" MAX_BATCHES=3 bash "$SCRIPT_DIR/alexnet-train.sh"
+        echo "  train output (tail):"
+        tail -4 "$CHAOS_OUT" | sed 's/^/    /'
+        if grep -q "currently RUNNING" "$CHAOS_OUT"; then
+            pass "C4: clobber guard message present"
+        else
+            fail "C4: missing clobber-guard message"
+        fi
+        rm_rc=0
+        podman rm -f alexnet-training >/dev/null 2>&1 || rm_rc=$?
+        [[ "$rm_rc" -eq 0 ]] && echo "  (C4 cleanup: seed container removed)" >&2
+    fi
+else
+    info "C4 [LIVE]: skipped (set CHAOS_LIVE=1 to exercise the clobber guard)"
+fi
+
+# ── C5: kill-mid-run (LIVE) — gate must detect a killed container ─────────
+# Crash the gate's failure path: launch a REAL training container, SIGKILL it
+# while it is genuinely running, and assert the gate FAILS fast with a clear
+# diagnostic instead of passing or hanging. A killed container leaves no
+# completion marker and a non-zero exit — the gate must not be fooled.
+info "C5 [LIVE]: kill a real training container mid-run; gate must detect it"
+if [[ "$LIVE" -eq 1 ]]; then
+    rm_rc=0
+    podman rm -f alexnet-training >/dev/null 2>&1 || rm_rc=$?
+    if [[ "$rm_rc" -ne 0 ]]; then
+        echo "  (could not remove stale container — skipping C5)" >&2
+    elif ! podman image exists localhost/odyssey:dev 2>/dev/null; then
+        echo "  (image localhost/odyssey:dev unavailable — skipping C5)" >&2
+    else
+        echo "  launching real training container (MAX_BATCHES=1 EPOCHS=1)..."
+        rc=0
+        timeout 720 env IMAGE_NAME="localhost/odyssey:dev" MAX_BATCHES=1 EPOCHS=1 \
+            bash "$SCRIPT_DIR/alexnet-train.sh" >"$CHAOS_OUT" 2>&1 || rc=$?
+        if [[ "$rc" -ne 0 ]]; then
+            echo "  launch failed (rc=$rc):" >&2
+            tail -5 "$CHAOS_OUT" >&2
+            info "C5: SKIP (could not launch training container)"
+        else
+            # Mojo compile dominates the first minutes; wait (bounded) until the
+            # container is genuinely RUNNING before killing it. Break early if
+            # it exits on its own (a crash is still a valid incomplete case).
+            st=created
+            for _i in $(seq 1 66); do
+                st=$(podman inspect alexnet-training --format '{{.State.Status}}' 2>/dev/null || echo missing)
+                [[ "$st" == running ]] && break
+                [[ "$st" == exited* ]] && break
+                sleep 10
+            done
+            echo "  container state before kill: $st"
+            kill_rc=0
+            podman kill alexnet-training >/dev/null 2>&1 || kill_rc=$?
+            echo "  kill rc: $kill_rc (0 = SIGKILL delivered)"
+            state_after=$(podman inspect alexnet-training --format '{{.State.Status}} exit={{.State.ExitCode}}' 2>/dev/null || echo missing)
+            echo "  state after kill: $state_after"
+            # The gate must DETECT the kill: non-zero rc with a clear marker FAIL.
+            rc=0
+            FLEET="$LOCAL_HOST" POLL_INTERVAL=5 bash "$SCRIPT_DIR/alexnet-fleet-wait.sh" \
+                --timeout-minutes 1 --smoke >"$CHAOS_OUT" 2>&1 || rc=$?
+            echo "  gate rc: $rc (expect non-zero — killed container must NOT pass)"
+            tail -8 "$CHAOS_OUT" | sed 's/^/    /'
+            if [[ "$rc" -ne 0 ]] && grep -q "no 'Training complete!' marker" "$CHAOS_OUT"; then
+                pass "C5: gate detected the incomplete container (rc=$rc, marker FAIL)"
+            else
+                fail "C5: gate rc=$rc — killed container was NOT detected as incomplete"
+            fi
+            rm_rc=0
+            podman rm -f alexnet-training >/dev/null 2>&1 || rm_rc=$?
+            [[ "$rm_rc" -eq 0 ]] && echo "  (C5 cleanup: killed container removed)" >&2
+        fi
+    fi
+else
+    info "C5 [LIVE]: skipped (set CHAOS_LIVE=1 to kill a real training container mid-run)"
+fi
+
+# ── C6: smoke gate must pass with --smoke, strict default must fail ────────
+# Smoke mode (MAX_BATCHES>0) intentionally saves NO weights (run_train.mojo
+# #5551). --smoke relaxes the gate to marker-only; the strict default keeps
+# weights required for full runs. C6b asserts the strict default FAILS this
+# same smoke container (weights missing) — proving the default didn't regress.
+info "C6: gate semantics — --smoke passes a smoke run, strict default fails it"
+if podman container exists alexnet-training 2>/dev/null; then
+    st=$(podman inspect alexnet-training --format '{{.State.Status}} {{.State.ExitCode}}' 2>/dev/null || echo unknown)
+    echo "  existing alexnet-training: $st"
+    if [[ "$st" != exited*0 ]] || ! podman logs alexnet-training 2>/dev/null | grep -q "Training complete!"; then
+        echo "  (container not a completed smoke — removing and seeding a synthetic fixture)" >&2
+        rm_rc=0
+        podman rm -f alexnet-training >/dev/null 2>&1 || rm_rc=$?
+        if [[ "$rm_rc" -ne 0 ]]; then
+            echo "  (could not remove container — SKIPPING C6)" >&2
+            info "C6: SKIP (could not seed gate fixture)"
+        else
+            st=missing
+        fi
+    fi
+fi
+# Seed a synthetic completed-smoke fixture: an exited(0) container whose log
+# holds the completion marker but NO weights dir — exactly the state smoke mode
+# produces (run_train.mojo #5551). Clearly a fixture: it exists only to exercise
+# the gate logic deterministically in every mode; it is not presented as real
+# training evidence. Reused only when a REAL completed smoke container is
+# already present (checked above).
+if ! podman container exists alexnet-training 2>/dev/null; then
+    echo "  seeding synthetic smoke fixture (exited container + marker, no weights)" >&2
+    if podman image exists localhost/odyssey:dev 2>/dev/null; then
+        podman run -d --name alexnet-training --userns=keep-id \
+            localhost/odyssey:dev bash -c 'sleep 2; echo "Training complete!"' >/dev/null 2>&1
+    else
+        podman run -d --name alexnet-training \
+            docker.io/library/alpine:3.20 sh -c 'sleep 2; echo "Training complete!"' >/dev/null 2>&1
+    fi
+    for _i in $(seq 1 15); do
+        st=$(podman inspect alexnet-training --format '{{.State.Status}}' 2>/dev/null || echo missing)
+        [[ "$st" == exited ]] && break
+        sleep 2
+    done
+    echo "  fixture state: $(podman inspect alexnet-training --format '{{.State.Status}} exit={{.State.ExitCode}}' 2>/dev/null || echo missing)" >&2
+    echo "  fixture marker: $(podman logs alexnet-training 2>/dev/null | grep -c 'Training complete!')" >&2
+fi
+if podman container exists alexnet-training 2>/dev/null; then
+    st=$(podman inspect alexnet-training --format '{{.State.Status}} {{.State.ExitCode}}' 2>/dev/null || echo unknown)
+    if [[ "$st" == exited*0 ]] && podman logs alexnet-training 2>/dev/null | grep -q "Training complete!"; then
+        echo "  (reusing completed smoke container for the gate check)"
+        rc=0
+        FLEET="$LOCAL_HOST" POLL_INTERVAL=5 bash "$SCRIPT_DIR/alexnet-fleet-wait.sh" \
+            --timeout-minutes 1 --smoke >"$CHAOS_OUT" 2>&1 || rc=$?
+        echo "  gate rc (--smoke): $rc"
+        tail -6 "$CHAOS_OUT" | sed 's/^/    /'
+        if [[ "$rc" -eq 0 ]]; then
+            pass "C6: smoke gate (--smoke) PASSED"
+        else
+            fail "C6: smoke gate failed (rc=$rc) — smoke mode saves no weights (see run_train.mojo #5551)"
+        fi
+        # C6b: the STRICT default (no --smoke) must FAIL this same container —
+        # proves weights stay required for full runs (reviewer: strict-by-default).
+        rc=0
+        FLEET="$LOCAL_HOST" POLL_INTERVAL=5 bash "$SCRIPT_DIR/alexnet-fleet-wait.sh" \
+            --timeout-minutes 1 >"$CHAOS_OUT" 2>&1 || rc=$?
+        echo "  gate rc (strict default): $rc"
+        if [[ "$rc" -eq 1 ]]; then
+            pass "C6b: strict default correctly FAILED smoke run (weights required)"
+        else
+            fail "C6b: strict default gate rc=$rc — expected 1 (weights must be required for full runs)"
+        fi
+    else
+        echo "  (no completed smoke container available — launching a live smoke next)"
+    fi
+fi
+if ! podman container exists alexnet-training 2>/dev/null || [[ $(podman inspect alexnet-training --format '{{.State.ExitCode}}' 2>/dev/null) != 0 ]]; then
+    if [[ "$LIVE" -eq 1 ]]; then
+        echo "  launching live smoke (MAX_BATCHES=1 EPOCHS=1)..."
+        rc=0
+        timeout 720 env IMAGE_NAME="localhost/odyssey:dev" MAX_BATCHES=1 EPOCHS=1 \
+            bash "$SCRIPT_DIR/alexnet-train.sh" >"$CHAOS_OUT" 2>&1 || rc=$?
+        if [[ "$rc" -eq 124 ]]; then
+            echo "  smoke launch HUNG (killed after 720s):" >&2
+            tail -5 "$CHAOS_OUT" >&2
+            fail "C6: smoke launch hung"
+        elif [[ "$rc" -ne 0 ]]; then
+            echo "  smoke launch failed (rc=$rc):" >&2
+            tail -5 "$CHAOS_OUT" >&2
+            fail "C6: smoke launch failed"
+        else
+            # Wait for the container to exit (bounded), then gate it.
+            echo "  waiting for smoke container to exit..."
+            if timeout 600 bash -c 'while podman inspect alexnet-training --format "{{.State.Status}}" 2>/dev/null | grep -q running; do sleep 10; done'; then
+                rc=0
+                FLEET="$LOCAL_HOST" POLL_INTERVAL=5 bash "$SCRIPT_DIR/alexnet-fleet-wait.sh" \
+                    --timeout-minutes 1 --smoke >"$CHAOS_OUT" 2>&1 || rc=$?
+                echo "  gate rc (--smoke): $rc"
+                tail -6 "$CHAOS_OUT" | sed 's/^/    /'
+                if [[ "$rc" -eq 0 ]]; then
+                    pass "C6: smoke gate (--smoke) PASSED"
+                else
+                    fail "C6: smoke gate failed (rc=$rc) — smoke mode saves no weights (see run_train.mojo #5551)"
+                fi
+                # C6b: strict default must FAIL this smoke container.
+                rc=0
+                FLEET="$LOCAL_HOST" POLL_INTERVAL=5 bash "$SCRIPT_DIR/alexnet-fleet-wait.sh" \
+                    --timeout-minutes 1 >"$CHAOS_OUT" 2>&1 || rc=$?
+                echo "  gate rc (strict default): $rc"
+                if [[ "$rc" -eq 1 ]]; then
+                    pass "C6b: strict default correctly FAILED smoke run (weights required)"
+                else
+                    fail "C6b: strict default gate rc=$rc — expected 1 (weights must be required for full runs)"
+                fi
+            else
+                fail "C6: smoke container did not exit within 600s"
+            fi
+        fi
+    else
+        info "C6: no completed smoke container and CHAOS_LIVE unset — SKIP (gate logic covered by CHAOS_LIVE=1 / post-smoke runs)"
+    fi
+fi
+
+# ── C7: teardown idempotency (no container -> rc 0) ────────────────────────
+info "C7: teardown with no container must exit 0 (idempotent)"
+run_bounded "C7 teardown FLEET='$LOCAL_HOST'" "$CHAOS_TIMEOUT" \
+    env FLEET="$LOCAL_HOST" FORCE=1 bash "$SCRIPT_DIR/alexnet-fleet-teardown.sh"
+echo "  teardown output (tail):"
+tail -4 "$CHAOS_OUT" | sed 's/^/    /'
+
+# ── Summary ──
+echo ""
+echo "=== Chaos Suite Summary ==="
+echo "PASS: $PASS  FAIL: $FAIL"
+if [[ "$FAIL" -gt 0 ]]; then
+    echo "Failed cases:"
+    for c in "${FAILED_CASES[@]}"; do
+        echo "  - $c"
+    done
+    exit 1
+fi
+echo "All enabled cases passed."

--- a/e2e/alexnet-train.sh
+++ b/e2e/alexnet-train.sh
@@ -69,6 +69,19 @@ if ! command -v podman >/dev/null 2>&1; then
     exit 1
 fi
 
+# ── cgroup CPU controller availability ──
+# Rootless podman only applies --cpus when the cpu controller is delegated to
+# the user slice (cgroup v2). On hosts where systemd delegates only memory+pids
+# (e.g. default Debian user@.service), --cpus makes crun fail with
+# "controller `cpu` is not available under .../cgroup.controllers".
+# Detect delegation and drop the CPU limit if the controller is missing.
+CPU_CTRL_AVAILABLE=1
+USER_CGROUP_CONTROLLERS=/sys/fs/cgroup/user.slice/user-$(id -u).slice/user@$(id -u).service/cgroup.controllers
+if [[ -f "$USER_CGROUP_CONTROLLERS" ]] && ! grep -qw "cpu" "$USER_CGROUP_CONTROLLERS" 2>/dev/null; then
+    echo "NOTE: cpu controller not delegated to user slice — skipping --cpus limit" >&2
+    CPU_CTRL_AVAILABLE=0
+fi
+
 # podman-compose build (and rootless podman save+load) tag the resulting image
 # as `localhost/$IMAGE_NAME` rather than `$IMAGE_NAME`. Accept both forms so the
 # preflight doesn't spuriously fail when the image was built here and rsynced
@@ -112,7 +125,7 @@ if [[ "$MAX_BATCHES" -eq 0 ]]; then
             -v "$WORKSPACE_DIR/research/Odyssey:/workspace:Z" \
             -w /workspace \
             "$IMAGE_NAME" \
-            pixi run python examples/alexnet_cifar10/download_cifar10.py
+            python examples/alexnet_cifar10/download_cifar10.py
     fi
 fi
 
@@ -132,6 +145,10 @@ LOG="$RESULTS_DIR/training.log"
         echo "CPU:      $(grep -m1 "model name" /proc/cpuinfo | sed 's/^model name\s*:\s*//')"
     fi
     echo ""
+    echo "NOTE: Full training output streams to the container log driver."
+    echo "      View it with:  podman logs -f alexnet-training"
+    echo "      This file holds only the launch header (config) above."
+    echo ""
 } | tee -a "$LOG"
 
 # Single training entry point. Fleet ships run_train.mojo on every host.
@@ -144,12 +161,17 @@ LOG="$RESULTS_DIR/training.log"
 # -v workspace:Z: SELinux relabel for workspace bind-mount (Fedora/RHEL)
 # -v results:Z: SELinux relabel for results bind-mount
 echo "Launching training container..."
+# --cpus is only passed when the cpu cgroup controller is delegated (see above)
+CPUS_ARGS=()
+if [[ "$CPU_CTRL_AVAILABLE" == "1" ]]; then
+    CPUS_ARGS=(--cpus "$CPU_LIMIT")
+fi
 podman run -d \
     --name alexnet-training \
     --network=host \
     --userns=keep-id \
-    --mem-limit="$MEM_LIMIT" \
-    --cpus="$CPU_LIMIT" \
+    --memory="$MEM_LIMIT" \
+    "${CPUS_ARGS[@]}" \
     --shm-size="$SHM_SIZE" \
     -v "$WORKSPACE_DIR/research/Odyssey:/workspace:Z" \
     -v "$RESULTS_DIR:/results:Z" \
@@ -164,7 +186,7 @@ podman run -d \
     "$IMAGE_NAME" \
     bash -c '
         set -euo pipefail
-        echo "[$(date -u +%H:%M:%S)] Container started. Image: $(pixi run mojo --version 2>&1 | head -1)"
+        echo "[$(date -u +%H:%M:%S)] Container started. Image: $(mojo --version 2>&1 | head -1)"
 
         # Smoke mode: when MAX_BATCHES > 0, pass --smoke and --max-batches
         # unconditionally. Hosts whose run_train.mojo lacks those flags will
@@ -174,7 +196,8 @@ podman run -d \
             EXTRA_ARGS=(--smoke --max-batches "$MAX_BATCHES")
         fi
 
-        pixi run mojo run $MOJO_TARGET_FLAGS -I . \
+        # odyssey package lives under src/ (CI convention: -I src -I .)
+        mojo run $MOJO_TARGET_FLAGS -I src -I . \
             examples/alexnet_cifar10/run_train.mojo \
             --epochs "$EPOCHS" \
             --batch-size "$BATCH_SIZE" \
@@ -187,9 +210,11 @@ podman run -d \
 
 echo ""
 echo "Training launched on $HOST_NAME."
-echo "Monitor with:"
+echo "Monitor with (full output — loss, accuracy, 'Training complete!'):"
 echo "  podman logs -f alexnet-training"
-echo "  tail -f $RESULTS_DIR/training.log"
+echo ""
+echo "  $RESULTS_DIR/training.log holds only the launch header (config);"
+echo "  the training run itself is NOT written there — it streams to podman logs."
 echo ""
 echo "To collect results centrally on epimetheus:"
 echo "  bash $SCRIPT_DIR/alexnet-collect-results.sh"

--- a/e2e/hermes-fleet-preflight-fix.sh
+++ b/e2e/hermes-fleet-preflight-fix.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# hermes-fleet-preflight-fix.sh
+# Resolves the 2026-05-12 hermes blocker (rootless podman on WSL2 Lunar Lake)
+# so hermes can join the AlexNet mesh fleet. Run ON hermes (the WSL2 host),
+# e.g.:  ssh hermes 'bash -s' < e2e/hermes-fleet-preflight-fix.sh
+#
+# Preflight blocker (docs/runbooks/alexnet-mesh-fleet.md "hermes" section):
+#   - /proc/sys/kernel/unprivileged_userns_clone  -> (unreadable) / likely 0
+#   - podman info                                 -> FAILED (cannot clone userns)
+# Pattern confirmed live on apollo 2026-08-11:
+#   unprivileged_userns_clone=0 -> "cannot clone: Operation not permitted"
+set -euo pipefail
+
+echo "=== [1/6] unprivileged_userns_clone probe ==="
+if [[ -r /proc/sys/kernel/unprivileged_userns_clone ]]; then
+    US="$(cat /proc/sys/kernel/unprivileged_userns_clone)"
+    echo "kernel.unprivileged_userns_clone = $US"
+else
+    US="unreadable"
+    echo "kernel.unprivileged_userns_clone = (unreadable as user — probe with sudo next)"
+fi
+
+echo
+echo "=== [2/6] enable + persist unprivileged_userns_clone=1 ==="
+if [[ "$US" != "1" ]]; then
+    sudo sysctl -w kernel.unprivileged_userns_clone=1
+    if [[ -d /etc/sysctl.d ]]; then
+        echo "kernel.unprivileged_userns_clone=1" | sudo tee /etc/sysctl.d/99-tailnet.conf >/dev/null
+        echo "persisted via /etc/sysctl.d/99-tailnet.conf"
+    else
+        echo "WARN: no /etc/sysctl.d — persistence skipped (WSL2: verify /etc/wsl.conf [boot] command)" >&2
+    fi
+    if [[ -r /proc/sys/kernel/unprivileged_userns_clone ]]; then
+        echo "now: kernel.unprivileged_userns_clone = $(cat /proc/sys/kernel/unprivileged_userns_clone)"
+    else
+        echo "note: sysctl value still unreadable to this user (log out/in if unsure)" >&2
+    fi
+else
+    echo "already 1 — nothing to do"
+fi
+
+echo
+echo "=== [3/6] WSL2 rootless prerequisites (systemd + linger + socket) ==="
+echo "WSL interop kernel: $(uname -r)"
+if ! systemd_running="$(ps -p 1 -o comm= 2>/dev/null)"; then
+    systemd_running=""
+fi
+echo "pid1: $systemd_running"
+if [[ "$systemd_running" != "systemd" ]]; then
+    echo "WARN: systemd not PID 1 (WSL2 legacy init). Rootless podman services need" >&2
+    echo "      '[boot] systemd=true' in /etc/wsl.conf + 'wsl --shutdown' on Windows." >&2
+fi
+if command -v loginctl >/dev/null 2>&1; then
+    if ! loginctl show-user "$USER" 2>/dev/null | grep -q 'Linger=yes'; then
+        if ! sudo loginctl enable-linger "$USER"; then
+            echo "WARN: could not enable linger (systemd may not be PID 1 on WSL2 legacy init) — continue" >&2
+        else
+            echo "linger enabled for $USER"
+        fi
+    else
+        echo "linger already enabled"
+    fi
+else
+    echo "WARN: loginctl unavailable" >&2
+fi
+
+export XDG_RUNTIME_DIR="${XDG_RUNTIME_DIR:-/run/user/$(id -u)}"
+export DBUS_SESSION_BUS_ADDRESS="${DBUS_SESSION_BUS_ADDRESS:-unix:path=${XDG_RUNTIME_DIR}/bus}"
+if [[ ! -d "$XDG_RUNTIME_DIR" ]]; then
+    echo "WARN: $XDG_RUNTIME_DIR does not exist — attempting to create (root-owned on legacy-init WSL2; may fail)" >&2
+    if mkdir -p "$XDG_RUNTIME_DIR" 2>/dev/null; then
+        chmod 700 "$XDG_RUNTIME_DIR"
+    else
+        echo "WARN: cannot create $XDG_RUNTIME_DIR as user — podman.socket may fail below; this is the WSL2 systemd fix" >&2
+    fi
+fi
+if ! systemctl --user enable --now podman.socket 2>&1 | tail -2; then
+    echo "WARN: podman.socket enable/start reported failure (see output above)" >&2
+fi
+
+echo
+echo "=== [4/6] podman info ==="
+if ! podman version --format 'podman {{.Version}}' 2>&1; then
+    echo "ERROR: podman not found or version query failed — install podman first (see runbook prerequisites)" >&2
+    exit 1
+fi
+if podman info >/tmp/hermes-podman-info.log 2>&1; then
+    echo "podman info: PASS"
+    if ! grep -E 'os:|kernel:|cgroupManager|eventLogger|graphDriverName|rootless' /tmp/hermes-podman-info.log | head -8; then
+        echo "  (info schema keys not matched — not an error; podman info already PASSED)"
+    fi
+else
+    echo "podman info: FAILED — log tail:" >&2
+    tail -8 /tmp/hermes-podman-info.log >&2
+    exit 1
+fi
+
+echo
+echo "=== [5/6] rootless run smoke test ==="
+if podman run --rm --userns=keep-id docker.io/library/alpine:3.20 echo "hermes rootless podman OK" >/tmp/hermes-smoke.log 2>&1; then
+    cat /tmp/hermes-smoke.log
+    echo "rootless container run: PASS"
+else
+    echo "rootless container run: FAILED — log tail:" >&2
+    tail -8 /tmp/hermes-smoke.log >&2
+    exit 1
+fi
+
+echo
+echo "=== [6/6] fleet deploy prerequisite (ssh from epimetheus) ==="
+echo "Fleet deploy uses 'ssh <ip> <cmd>' (see e2e/alexnet-deploy-fleet.sh)."
+echo "WSL2 hermes has NO ssh server configured (verified 2026-08-11: not in"
+echo "epimetheus ~/.ssh/config or known_hosts). From epimetheus:"
+echo "  ssh-copy-id hermes   # install openssh-server inside WSL, start sshd first"
+echo "  ssh hermes 'podman --version'  # must return without password/prompt"
+
+echo
+echo "=== hermes preflight RESOLVED ==="
+echo "Next, from epimetheus:"
+echo "  just doctor --role worker --install   # on hermes"
+echo "  FLEET='epimetheus apollo aeolus hephaestus hermes' bash e2e/alexnet-deploy-fleet.sh"

--- a/justfile
+++ b/justfile
@@ -726,6 +726,22 @@ alexnet-fleet-teardown:
 alexnet-smoke:
     MAX_BATCHES=3 bash e2e/alexnet-train.sh
 
+# Crash-test the mesh fleet scripts (self-contained chaos suite): asserts the
+# scripts fail FAST and cleanly — offline-host teardown/deploy must not hang,
+# missing image gives a clear diagnostic, smoke-gate semantics hold, teardown
+# is idempotent. Fast (a minute or two, no training) — safe on any fleet host.
+# CHAOS_TIMEOUT=<s> overrides the per-case kill guard (default 45).
+alexnet-mesh-chaos:
+    bash e2e/alexnet-mesh-chaos.sh
+
+# Same suite PLUS the live cases: C4 clobber guard (train must REFUSE to
+# overwrite a running container) and C5 kill-mid-run (launch a REAL training
+# container, SIGKILL it, gate must detect it). Takes minutes and needs the
+# odyssey:dev image loaded on this host. Do not run while a fleet training or
+# smoke is in progress — both use the shared alexnet-training container name.
+alexnet-mesh-chaos-live:
+    CHAOS_LIVE=1 bash e2e/alexnet-mesh-chaos.sh
+
 # ===========================================================================
 # Python Package Installation
 # ===========================================================================


### PR DESCRIPTION
## Summary
Wires the AlexNet mesh smoke test into CI as a **manual-dispatch, gated** workflow so the fleet test is repeatable and blocked on real completion evidence. Also fixes two bugs found while running the smoke test end-to-end: the deploy script silently ran **full** training in "smoke" mode (MAX_BATCHES was never forwarded), and the runbook/scripts claimed training output landed in `training.log` when it actually streams to `podman logs`.

## Changes
- `.github/workflows/alexnet-mesh-smoke.yml` (new) — `workflow_dispatch`-only job on a `[self-hosted, mesh]` runner: checkout → preflight → deploy → wait+gate → collect → artifact → teardown. Inputs: `epochs`/`max_batches`/`fleet`/`skip_build`/`teardown` (default 4-host smoke; hermes opt-in until its preflight clears). Fails the job if any host lacks `Training complete!` in `podman logs` or a non-empty weights dir. Dispatch inputs passed via env (no `${{ }}` in run blocks); actions SHA-pinned.
- `e2e/alexnet-fleet-wait.sh` (new) — polls every fleet host's `alexnet-training` container until exited (deadline-guarded, 150 min default), then gates on per-host completion evidence over rootless ssh (`timeout`-guarded, `XDG_RUNTIME_DIR` exports).
- `e2e/alexnet-deploy-fleet.sh` — **bug fix**: forward `MAX_BATCHES` to local + remote train launches (config, header, DRY_RUN, and both launch paths).
- `e2e/alexnet-train.sh` — smoke-run fixes validated by a completed training run: `--mem-limit`→`--memory` (podman), conditional `--cpus` when the cpu cgroup controller isn't delegated, uv-era `mojo` invocation (no `pixi run`), `-I src` include path; monitor hint now points at `podman logs` (`training.log` = launch header only).
- `e2e/alexnet-collect-results.sh` — honest summary: weights dir as completion evidence + best-effort `podman logs` marker pull per host.
- `.github/actionlint.yaml` (new) — declare the `mesh` self-hosted runner label (actionlint gate).
- `docs/runbooks/alexnet-mesh-fleet.md` — monitoring sections aligned to `podman logs`; new CI section with runner registration steps and wait+gate usage.

## Checklist
- [x] Runbooks updated if operational procedure changed
- [x] Config changes documented in comments
- [ ] Submodule pins updated if needed (`just update-submodules`) — not needed
- [ ] `just ci` passes locally — workflow actionlint/yamllint/shellcheck validated locally; full suite runs in CI

## Related Issues
N/A — runner registration + first dispatch are follow-ups (documented in the runbook).
