### PR TITLE
ci(submodules): dependabot-style per-submodule updater + gitsubmodule ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,18 @@ updates:
     labels:
       - dependencies
       - github-actions
+
+  # Git submodules: Dependabot tracks each submodule pin in .gitmodules and
+  # opens one PR per submodule when the pinned SHA falls behind the submodule's
+  # default branch. Those PRs trigger the full required CI matrix
+  # (pull_request on _required.yml), so every submodule bump is tested before
+  # it can merge — no native execution, container CI as everywhere else.
+  - package-ecosystem: gitsubmodule
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 10
+    labels:
+      - dependencies
+      - submodules

--- a/.github/workflows/submodule-update-check.yml
+++ b/.github/workflows/submodule-update-check.yml
@@ -114,8 +114,12 @@ jobs:
 
           # The label is managed here so `gh pr create --label` never fails on
           # a fresh repository.
-          gh label create submodules --force --color 7057ff \
-            --description "Git submodule pin updates" >/dev/null 2>&1 || true
+          if gh label create submodules --force --color 7057ff \
+              --description "Git submodule pin updates" >/dev/null 2>&1; then
+            echo "submodules label ready"
+          else
+            echo "warn: could not ensure the submodules label exists" >&2
+          fi
 
           PR_BODY=$(printf 'Automated PR opened by the Submodule Update Check workflow.\n\n| Submodule | %s |\n|---|---|\n| Pinned SHA | `%s` |\n| Upstream SHA | `%s` |\n\nThe full required CI matrix runs on this PR (pull_request trigger) to test the submodule bump before it can merge. Auto-merge (squash) is enabled — the PR merges only when every required check passes.\n' "$SM" "$OLD_SHA" "$NEW_SHA")
 
@@ -125,4 +129,8 @@ jobs:
             --label submodules)
 
           echo "Opened: $PR_URL"
-          gh pr merge "$PR_URL" --auto --squash 2>&1 | tail -1 || true
+          if gh pr merge "$PR_URL" --auto --squash; then
+            echo "Auto-merge (squash) enabled on $PR_URL"
+          else
+            echo "warn: auto-merge could not be enabled on $PR_URL (mergeable state still computing)" >&2
+          fi

--- a/.github/workflows/submodule-update-check.yml
+++ b/.github/workflows/submodule-update-check.yml
@@ -19,6 +19,7 @@ jobs:
     timeout-minutes: 10
     outputs:
       has_drift: ${{ steps.drift.outputs.has_drift }}
+      drifted: ${{ steps.drifted.outputs.drifted }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
@@ -28,6 +29,13 @@ jobs:
         id: drift
         run: bash scripts/check-submodule-drift.sh --ci
 
+      # Emit the JSON list of drifted submodule paths for the per-submodule
+      # PR matrix (dependabot-style granularity).
+      - name: Emit drifted submodule list
+        id: drifted
+        run: |
+          echo "drifted=$(jq -c '[.submodules[] | select(.status == "behind") | .submodule]' drift-report.json)" >> "$GITHUB_OUTPUT"
+
       - name: Upload drift report
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
@@ -36,51 +44,85 @@ jobs:
           path: drift-report.json
           retention-days: 30
 
-  create-update-pr:
-    name: open draft submodule-bump PR
+  create-update-prs:
+    name: open submodule-bump PR (${{ matrix.submodule }})
     needs: check-drift
     if: needs.check-drift.outputs.has_drift == 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 20
     permissions:
       contents: write
       pull-requests: write
+    strategy:
+      fail-fast: false
+      matrix:
+        submodule: ${{ fromJson(needs.check-drift.outputs.drifted) }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           submodules: true
 
-      - name: Bump stale submodule pins
+      # Dedupe: skip submodules that already have an open bump PR (opened by
+      # this workflow on a previous run, or by Dependabot gitsubmodule).
+      - name: Skip if a bump PR already exists
+        id: dedupe
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          set -uo pipefail
-          BRANCH="chore/submodule-updates-$(date +%Y-%m-%d)"
-          # Skip if a branch for today's run already exists (idempotency).
-          if git ls-remote --exit-code --heads origin "$BRANCH" >/dev/null 2>&1; then
-            echo "Branch $BRANCH already exists — skipping."
-            echo "skip=true" >> "$GITHUB_ENV"
-            exit 0
+          SM="${{ matrix.submodule }}"
+          EXISTING=$(gh pr list --repo "$GITHUB_REPOSITORY" --state open --json title \
+            --jq '[.[] | select(.title | contains("'"$SM"'"))] | length' 2>/dev/null || echo 0)
+          echo "existing_open_prs=$EXISTING"
+          if [ "$EXISTING" -gt 0 ]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
           fi
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git checkout -b "$BRANCH"
-          git submodule update --remote
-          echo "branch=$BRANCH" >> "$GITHUB_ENV"
 
-      - name: Open draft PR
-        if: env.skip != 'true'
+      - name: Bump pin and open CI-tested PR
+        if: steps.dedupe.outputs.skip != 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -uo pipefail
-          if git diff --quiet; then
-            echo "No submodule pin changes after update --remote — nothing to PR."
+          SM="${{ matrix.submodule }}"
+          SAFE_NAME="${SM//\//-}"
+          BRANCH="chore/submodule-${SAFE_NAME}-$(date +%Y-%m-%d)"
+
+          # Idempotency: skip if a branch for this submodule already exists.
+          if git ls-remote --exit-code --heads origin "$BRANCH" >/dev/null 2>&1; then
+            echo "Branch $BRANCH already exists — skipping."
             exit 0
           fi
-          DATESTR="$(date +%Y-%m-%d)"
-          git add -A
-          git commit -m "chore(submodules): bump stale submodule pins (${DATESTR})"
-          git push -u origin "$branch"
-          gh pr create \
-            --draft \
-            --title "chore(submodules): bump stale submodule pins (${DATESTR})" \
-            --body "Automated draft PR opened by the Submodule Update Check workflow. One or more submodule pins were behind their upstream default branch. Review the changes and the attached drift report before merging. This PR is **not** auto-merged."
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$BRANCH"
+
+          git submodule update --remote "$SM"
+          if git diff --quiet; then
+            echo "No pin change for $SM — nothing to PR."
+            exit 0
+          fi
+
+          OLD_SHA=$(git diff HEAD -- "$SM" | awk '/^-Subproject/{print $3}' | cut -c1-8)
+          NEW_SHA=$(git -C "$SM" rev-parse HEAD | cut -c1-8)
+
+          git add "$SM"
+          git commit -m "chore(submodules): bump $SM to $NEW_SHA"
+          git push -u origin "$BRANCH"
+
+          # The label is managed here so `gh pr create --label` never fails on
+          # a fresh repository.
+          gh label create submodules --force --color 7057ff \
+            --description "Git submodule pin updates" >/dev/null 2>&1 || true
+
+          PR_BODY=$(printf 'Automated PR opened by the Submodule Update Check workflow.\n\n| Submodule | %s |\n|---|---|\n| Pinned SHA | `%s` |\n| Upstream SHA | `%s` |\n\nThe full required CI matrix runs on this PR (pull_request trigger) to test the submodule bump before it can merge. Auto-merge (squash) is enabled — the PR merges only when every required check passes.\n' "$SM" "$OLD_SHA" "$NEW_SHA")
+
+          PR_URL=$(gh pr create \
+            --title "chore(submodules): bump $SM to $NEW_SHA" \
+            --body "$PR_BODY" \
+            --label submodules)
+
+          echo "Opened: $PR_URL"
+          gh pr merge "$PR_URL" --auto --squash 2>&1 | tail -1 || true


### PR DESCRIPTION
## Summary

Upgrade submodule update automation to dependabot-style granularity so every submodule bump is automatically **opened and CI-tested** before it can merge.

## Changes

**`.github/dependabot.yml`** — add the `gitsubmodule` package-ecosystem. Dependabot natively tracks the 15 submodule pins in `.gitmodules` and opens one PR per submodule whose pin falls behind upstream default branch.

**`.github/workflows/submodule-update-check.yml`** — replaced the single aggregate draft PR with a **per-submodule matrix**: one PR per drifted submodule (dependabot-style), each triggering the full required CI matrix via the `pull_request` trigger, so every bump is validated by container CI before merge.

## Behavior

- Weekly Monday 09:00 UTC + manual dispatch.
- Drift check (scripts/check-submodule-drift.sh) emits the drifted submodule list + `drift-report.json` artifact.
- One branch/PR per submodule: `chore/submodule-<name>-<date>`, labeled `submodules`.
- Dedupe step skips submodules that already have an open bump PR (this workflow or dependabot).
- Auto-merge (squash) enabled on each PR — merges only when every required check passes.
- Commits signed.