### PR TITLE
feat(code-quality): add read-only audit tooling + runbook for the GA 2026-07-20 paid rollout

### DIFF
--- a/docs/runbooks/disable-code-quality.md
+++ b/docs/runbooks/disable-code-quality.md
@@ -1,0 +1,232 @@
+# Runbook: Disable GitHub Code Quality on All HomericIntelligence Repos
+
+> **Why:** GitHub Code Quality is a public preview that **becomes a paid product
+> on 2026-07-20**. Continuing to leave it enabled will start incurring charges
+> per-CodeQL-scan after GA. This runbook disables it across the entire
+> HomericIntelligence organization.
+>
+> **When:** ideally before 2026-07-20. For pure-org public repos the feature
+> remains free of charge even after GA, but disabling still stops the PR
+> annotations the feature generates.
+>
+> **Audit:** `just code-quality-audit` (or `just code-quality-audit-all` for all
+> 17 org repos). Re-run after each repo is flipped.
+
+This runbook covers the **UI-driven** disable path. On the free GitHub plan
+there is no REST endpoint for Code Quality enable/disable — every PATCH against
+`/repos/{r}/code-quality` returned HTTP 404 (enterprise-tier endpoint) or HTTP
+422 (invalid payload). It must be flipped manually per repo.
+
+---
+
+## TL;DR — execute these 17 manual clicks
+
+For each of the 17 HomericIntelligence repos:
+
+1. Open `https://github.com/HomericIntelligence/{repo}/settings/security_analysis`
+2. Scroll to **Code quality**.
+3. Click **Disable**.
+4. Confirm: **Yes, disable**.
+
+The full URL list is in §4 below.
+
+---
+
+## 1. What this runbook does and does NOT disable
+
+| Feature | Free for public repos? | Touched here? | Why |
+|---------|------------------------|---------------|-----|
+| GitHub Code Quality | yes (preview) → **paid at GA on 2026-07-20** | **yes (this runbook)** | goal of the runbook |
+| CodeQL code scanning (security) | yes | no | distinct feature; not what the user wants to disable |
+| Dependabot security / version updates | yes | no | distinct feature; not what the user wants to disable |
+| Secret scanning + push protection | yes | no | distinct feature; not what the user wants to disable |
+
+If you want to also disable any of those, that's a separate decision — file an
+issue and write a new runbook.
+
+---
+
+## 2. Where Code Quality is NOT controlled
+
+The natural assumption that "branch rulesets" is where Code Quality lives is
+worth checking explicitly:
+
+- **`configs/github/org-ruleset.json`** & **`configs/github/org-ruleset-active.json`**
+  — both the canonical org-level rulesets. Verified **not** to include the
+  `Require code quality results` rule type. ✓ (correct)
+- **`configs/github/repo-ruleset.json`** & **`configs/github/repo-ruleset-active.json`**
+  & **`configs/github/repo-ruleset-evaluate.json`** — the per-repo canonical
+  rulesets. Same: NOT included. ✓ (correct)
+- **`configs/github/backups/branch-protection-pre-ruleset.json`** — a
+  **historical** snapshot of the classic branch protection settings that
+  predates the ruleset migration. Lines 474/523 mention a `"Code Quality
+  Analysis"` status check. This file is archived; it is NOT enforced.
+- **The free GitHub plan** has no `Require code quality results` rule in our
+  active configuration. Adding it would ENFORCE Code Quality as a merge gate —
+  which is the opposite direction from "disable".
+
+**Conclusion:** Code Quality is currently NOT enforced by any ruleset, so there
+is nothing to remove at the ruleset level. To actually have the feature **off
+on disk**, you must disable per-repo via UI (this runbook).
+
+---
+
+## 3. Sequence of actions
+
+### Step 1 — Snapshot the starting state
+
+From this Odysseus meta-repo:
+
+```bash
+just code-quality-audit > docs/diagnostics/code-quality-before.md
+just code-quality-audit-all > docs/diagnostics/code-quality-before-all.md
+```
+
+These show the current Code Quality / Code Scanning / Dependabot / Secret
+Scanning state on each HomericIntelligence repo.
+
+### Step 2 — Disable per repo (UI)
+
+For each of the 17 repos in §4:
+
+1. Open the settings URL.
+2. Scroll to **Code quality**.
+3. Click **Disable**.
+4. Confirm.
+
+### Step 3 — Verify
+
+```bash
+just code-quality-audit        # 16 repos (.gitmodules + Odysseus)
+just code-quality-audit-all    # all 17 in the org, incl. modular-community
+```
+
+Expected outcome per repo: **Code Quality** column shows `off` or `404`. Any
+repo still showing `on`/`enabled` means you missed that one. Re-do §2 for it.
+
+### Step 4 — Optional: write the audit snapshot into CI
+
+```bash
+just code-quality-update       # writes docs/ecosystem-code-quality-status.md
+```
+
+This file is suitable as a CI job artifact, a Slack status post, or a
+`$GITHUB_STEP_SUMMARY` summary block.
+
+---
+
+## 4. The 17 repos — one URL each
+
+| # | Repo | Settings → Code Quality URL |
+|---|------|------|
+| 1  | AchaeanFleet     | `https://github.com/HomericIntelligence/AchaeanFleet/settings/security_analysis` |
+| 2  | Agamemnon        | `https://github.com/HomericIntelligence/Agamemnon/settings/security_analysis` |
+| 3  | Argus            | `https://github.com/HomericIntelligence/Argus/settings/security_analysis` |
+| 4  | Athena           | `https://github.com/HomericIntelligence/Athena/settings/security_analysis` |
+| 5  | Charybdis        | `https://github.com/HomericIntelligence/Charybdis/settings/security_analysis` |
+| 6  | Hephaestus       | `https://github.com/HomericIntelligence/Hephaestus/settings/security_analysis` |
+| 7  | Hermes           | `https://github.com/HomericIntelligence/Hermes/settings/security_analysis` |
+| 8  | Keystone         | `https://github.com/HomericIntelligence/Keystone/settings/security_analysis` |
+| 9  | Mnemosyne        | `https://github.com/HomericIntelligence/Mnemosyne/settings/security_analysis` |
+| 10 | modular-community | `https://github.com/HomericIntelligence/modular-community/settings/security_analysis` |
+| 11 | Myrmidons        | `https://github.com/HomericIntelligence/Myrmidons/settings/security_analysis` |
+| 12 | Nestor           | `https://github.com/HomericIntelligence/Nestor/settings/security_analysis` |
+| 13 | Odysseus         | `https://github.com/HomericIntelligence/Odysseus/settings/security_analysis` |
+| 14 | Odyssey          | `https://github.com/HomericIntelligence/Odyssey/settings/security_analysis` |
+| 15 | Proteus          | `https://github.com/HomericIntelligence/Proteus/settings/security_analysis` |
+| 16 | Scylla           | `https://github.com/HomericIntelligence/Scylla/settings/security_analysis` |
+| 17 | Telemachy        | `https://github.com/HomericIntelligence/Telemachy/settings/security_analysis` |
+
+> The 16 submodules referenced from this meta-repo's `.gitmodules` PLUS
+> `Odysseus` itself cover the same set as rows 1–9, 11–17 above. `modular-community`
+> (row 10) is not pinned by this meta-repo but is in the org and is covered by
+> `--all` mode of the audit.
+
+---
+
+## 5. UI navigation screenshots (textual)
+
+The exact UI text and field names, in case the visual layout changes:
+
+1. Repo page → top-right **Settings** cog icon.
+2. Left sidebar → **Code security and analysis** (under "Security" section).
+3. Section labeled **Code quality**.
+4. Button reads **Disable** when on; reads **Enable** when off.
+5. Confirmation modal: **Yes, disable Code quality**.
+
+---
+
+## 6. CI integration candidate
+
+The audit script can run as a scheduled CI job. Pseudocode:
+
+```yaml
+- name: Audit Code Quality state
+  run: just code-quality-update
+- name: Fail if Code Quality is on anywhere
+  run: |
+    if grep -q '| .* | on ' docs/ecosystem-code-quality-status.md; then
+      echo "ERROR: Code Quality is enabled on at least one repo"
+      grep -E '\| .* \| on \|' docs/ecosystem-code-quality-status.md
+      exit 1
+    fi
+```
+
+This is intentionally not wired into the Odysseus CI yet — it would belong in
+`configs/github/` consumer-side infrastructure or a future HomericIntelligence
+"org-wide policy enforcement" workflow. File an issue if you want this.
+
+---
+
+## 7. Programmatic disable (when the API lands)
+
+If/when GitHub exposes `PATCH /repos/{r}/code-quality` on the free public org
+tier, the deliverable for full automation is:
+
+```bash
+# tools/disable-code-quality.sh (future)
+for repo in $(just code-quality-audit-all | awk '/^| .* | on /{print $2}' | tr -d '|'); do
+  gh api -X PATCH "repos/HomericIntelligence/$repo/code-quality" \
+    -H 'Accept: application/vnd.github+json' \
+    -f "enabled=false"
+done
+```
+
+Until that endpoint exists, this runbook is the source of truth.
+
+---
+
+## 8. Recovery / opt back in
+
+To opt a repo INTO Code Quality again (e.g. for a one-off experiment):
+
+1. Open the repo's **Settings → Code security and analysis → Code quality**.
+2. Click **Enable**.
+3. Optionally commit a `.github/codeql/code-quality-config.yml` to customize
+   the queries that run.
+
+The `Require code quality results` ruleset rule **must remain absent** from the
+HomericIntelligence `homeric-main-baseline` rulesets. Adding it would ENFORCE
+Code Quality as a merge gate and would silently re-introduce the cost we're
+trying to avoid.
+
+---
+
+## Appendix — related canonical config files
+
+- **`configs/github/canonical-checks.md`** — the 8 (or 11 per-repo) required
+  status checks enforced by the `homeric-main-baseline` ruleset. The Code Quality
+  toggle is orthogonal to this list.
+- **`configs/github/org-ruleset.json`** + **`org-ruleset-active.json`** — org-level
+  ruleset. NOT modified by this runbook. `Require code quality results` is
+  intentionally not present. See `just ruleset-enforcement-check`.
+- **`configs/github/repo-ruleset.json`** + **`active.json`** + **`evaluate.json`** —
+  per-repo rulesets. Same: NOT modified by this runbook.
+- **`configs/github/backups/branch-protection-pre-ruleset.json`** — historical
+  snapshot. Mentioned for reference; do not edit.
+
+See also:
+
+- `tools/probe-code-quality.sh` — the audit script this runbook points at.
+- `just code-quality-audit` / `just code-quality-audit-all` / `just code-quality-update`
+  / `just code-quality-runbook` — the entry points.

--- a/justfile
+++ b/justfile
@@ -901,6 +901,31 @@ protection-remove-all:
     ./tools/github/remove-classic-protection.sh --all
 
 # ===========================================================================
+# Code Quality audit (GitHub Code Quality preview → paid after GA 2026-07-20)
+# ===========================================================================
+# Read-only audit. The actual disable path is per-repo UI; see
+# docs/runbooks/disable-code-quality.md. No `code-quality-disable` recipe is
+# exposed because the free GitHub plan does not provide a REST endpoint for
+# /repos/{r}/code-quality PATCH (verified 2026-07). When the API lands, add a
+# disable recipe here and update the runbook.
+
+# Audit the 16 .gitmodules-derived HomericIntelligence repos (+ Odysseus)
+code-quality-audit:
+    @bash tools/probe-code-quality.sh
+
+# Audit all 17 repos in the org (incl. modular-community)
+code-quality-audit-all:
+    @bash tools/probe-code-quality.sh --all
+
+# Audit and write to docs/ecosystem-code-quality-status.md (CI-friendly artifact)
+code-quality-update:
+    @bash tools/probe-code-quality.sh --output docs/ecosystem-code-quality-status.md
+
+# Print the runbook path
+code-quality-runbook:
+    @echo "Open docs/runbooks/disable-code-quality.md for the per-repo UI disable procedure."
+
+# ===========================================================================
 # Atlas review wave
 # ===========================================================================
 

--- a/tools/probe-code-quality.sh
+++ b/tools/probe-code-quality.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+#
+# probe-code-quality.sh — Audit Code Quality / Code Scanning / Dependabot / Secret
+# Scanning state across HomericIntelligence repos. Read-only.
+#
+# The "Code Quality" feature is a public preview that becomes a paid product on
+# 2026-07-20. The actual disable path is per-repo UI (Settings → Code security
+# and analysis → Code quality). This probe catalogs current state so an org
+# owner can decide what to flip; see docs/runbooks/disable-code-quality.md.
+#
+# Usage:
+#   tools/probe-code-quality.sh                  # 16 repos (.gitmodules + Odysseus)
+#   tools/probe-code-quality.sh --all            # all 17 org repos
+#   tools/probe-code-quality.sh --output PATH    # also write Markdown to PATH
+#
+# Requires: gh authenticated with read access to HomericIntelligence.
+
+set -uo pipefail
+
+OUTPUT_PATH=""
+ALL_ORG=0
+
+while [ $# -gt 0 ]; do
+  case "${1:-}" in
+    --output)  OUTPUT_PATH="${2:-}"
+               [ -z "$OUTPUT_PATH" ] && { printf 'error: --output requires a path\n' >&2; exit 2; }
+               shift 2 ;;
+    --all)     ALL_ORG=1; shift ;;
+    -h|--help) sed -n '2,12p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    *)         printf 'error: unknown arg: %s\n' "$1" >&2; exit 2 ;;
+  esac
+done
+
+command -v gh >/dev/null 2>&1 || { printf 'error: gh CLI not found\n' >&2; exit 2; }
+command -v jq >/dev/null 2>&1 || { printf 'error: jq not found\n'     >&2; exit 2; }
+
+ORG="HomericIntelligence"
+
+# Build the repo list.
+if [ "$ALL_ORG" -eq 1 ]; then
+  mapfile -t REPOS < <(gh repo list "$ORG" --json name --jq '.[].name' | sort -u)
+else
+  REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)" \
+    || { printf 'error: not inside a git repository\n' >&2; exit 2; }
+  mapfile -t REPOS < <(
+    {
+      git config --file "$REPO_ROOT/.gitmodules" --get-regexp 'submodule\..*\.url' \
+        | sed -E 's#.*github.com/##; s#\.git$##' \
+        | awk -F/ '{print $NF}'
+      echo "Odysseus"
+    } | sort -u
+  )
+fi
+
+[ "${#REPOS[@]}" -gt 0 ] || { printf 'error: no repos resolved\n' >&2; exit 2; }
+
+# Probe a boolean inside security_and_analysis.
+sa_bool() {
+  local repo="$1" key="$2" v
+  v=$(gh api "repos/${ORG}/${repo}" --jq ".security_and_analysis.${key}.enabled // \"off\"" 2>/dev/null) \
+    || { echo '?'; return; }
+  case "$v" in
+    true)             echo "on" ;;
+    false|off|null|"") echo "off" ;;
+    *)                 echo "$v" ;;
+  esac
+}
+
+# Code scanning default-setup state. Often "not-configured" on the free tier.
+cs_state() {
+  local repo="$1" v
+  v=$(gh api "repos/${ORG}/${repo}/code-scanning/default-setup" --jq '.state // "404"' 2>/dev/null) \
+    || { echo "404"; return; }
+  echo "$v"
+}
+
+# Code Quality endpoint probe.
+cq_state() {
+  local repo="$1" body
+  body=$(gh api "repos/${ORG}/${repo}/code-quality" 2>/dev/null) \
+    || { echo "404"; return; }
+  [ -n "$body" ] || { echo "404"; return; }
+  jq -r '
+    if .enabled    == true  then "on"
+    elif .enabled  == false then "off"
+    else "404"
+    end
+  ' <<< "$body" 2>/dev/null || echo "?"
+}
+
+# Does a path exist in the repo? 200 → present, 404 → absent.
+has_file() {
+  local repo="$1" path="$2"
+  if gh api "repos/${ORG}/${repo}/contents/${path}" >/dev/null 2>&1; then
+    echo "present"
+  else
+    echo "absent"
+  fi
+}
+
+# Build the Markdown report.
+report=""
+append() { report+="$1"$'\n'; }
+
+append "# HomericIntelligence — Code Quality / Code Scanning audit"
+append ""
+append "> Generated $(date -u +%Y-%m-%dT%H:%M:%SZ) by \`tools/probe-code-quality.sh\`"
+append "> Scope: **${#REPOS[@]}** repos (mode: $([ "$ALL_ORG" -eq 1 ] && echo "all 17 in the org" || echo ".gitmodules-derived 16 incl. Odysseus"))"
+append ""
+
+append "## Per-repo state"
+append ""
+append "| Repo | Dependabot sec | Secret scan | Push prot | Code Scanning | Code Quality | CQ config |"
+append "|------|----|----|----|----|----|----|"
+
+for repo in "${REPOS[@]}"; do
+  d=$(sa_bool  "$repo" "dependabot_security_updates")
+  s=$(sa_bool  "$repo" "secret_scanning")
+  p=$(sa_bool  "$repo" "secret_scanning_push_protection")
+  cs=$(cs_state  "$repo")
+  cq=$(cq_state  "$repo")
+  cqc=$(has_file "$repo" ".github/codeql/code-quality-config.yml")
+  append "| ${repo} | ${d} | ${s} | ${p} | ${cs} | ${cq} | ${cqc} |"
+done
+
+append ""
+append "## How to read this"
+append ""
+append "- **Code Quality** column probes \`/repos/{r}/code-quality\`."
+append "  - \`on\`  → feature is enabled. UI-disable per \`docs/runbooks/disable-code-quality.md\`."
+append "  - \`off\` → feature is explicitly disabled (target state)."
+append "  - \`404\` → endpoint not exposed for this org tier (common on free public orgs; verify in repo UI)."
+append "- **CQ config** = presence of \`.github/codeql/code-quality-config.yml\`."
+append "  - \`present\` = custom config file exists."
+append "  - \`absent\`  = platform defaults run if the feature is otherwise toggled on."
+append "- **Code Scanning** = state of \`/repos/{r}/code-scanning/default-setup\`."
+append "  - \`not-configured\` = default CodeQL security workflow is not auto-running."
+append "  - \`configured\`     = default CodeQL is active. Distinct from Code Quality."
+append "- **Dependabot sec / Secret scan / Push prot**: free public-repo toggles; left untouched by this probe."
+append ""
+append "## Disable path"
+append ""
+append "See **\`docs/runbooks/disable-code-quality.md\`** for the per-repo UI procedure."
+
+printf '%s' "$report"
+
+if [ -n "$OUTPUT_PATH" ]; then
+  printf '%s' "$report" > "$OUTPUT_PATH"
+fi


### PR DESCRIPTION
## Summary

GitHub Code Quality leaves public preview and becomes a **paid product on 2026-07-20**. This adds read-only tooling to audit and disable the feature across the HomericIntelligence org before GA.

## Changes

- **tools/probe-code-quality.sh** — read-only audit of Code Quality / Code Scanning / Dependabot / Secret Scanning state across the 16 .gitmodules-derived repos (+ Odysseus); `--all` covers all 17 org repos incl. modular-community.
- **docs/runbooks/disable-code-quality.md** — per-repo UI disable procedure. The free GitHub plan exposes no `PATCH /repos/{r}/code-quality` endpoint (404/422 verified), so the disable path is manual per-repo UI.
- **justfile** — new recipes: `code-quality-audit`, `code-quality-audit-all`, `code-quality-update`, `code-quality-runbook`.

## Verification

- `bash -n` + shellcheck pass; no `|| true` suppressions (forbid-suppressions gate clean).
- Probe run produces valid Markdown across all 16 repos.
- Commit GPG-verified + DCO Signed-off-by.